### PR TITLE
API Endpoint for creating components

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -3,16 +3,15 @@
 module Api
   class ProjectsController < ApiController
     require 'phrase_identifier'
-
     before_action :require_oauth_user, only: %i[update]
+    before_action :load_project
+    load_and_authorize_resource
 
     def show
-      @project = Project.find_by!(identifier: params[:id])
       render :show, formats: [:json]
     end
 
     def update
-      @project = Project.find_by!(identifier: params[:id])
       authorize! :update, @project
 
       components = project_params[:components]
@@ -24,6 +23,10 @@ module Api
     end
 
     private
+
+    def load_project
+      @project = Project.find_by!(identifier: params[:id])
+    end
 
     def project_params
       params.require(:project)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,6 +4,8 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    can :read, Project
+
     return if user.blank?
 
     can :update, Project, user_id: user

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -2,4 +2,7 @@
 
 class Component < ApplicationRecord
   belongs_to :project
+  validates :name, presence: true
+  validates :extension, presence: true
+  validates :index, uniqueness: { scope: :project_id }
 end

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -4,4 +4,4 @@ json.call(@project, :identifier, :project_type, :name, :user_id)
 
 json.parent(@project.parent, :name, :identifier) if @project.parent
 
-json.components @project.components, :id, :name, :extension, :content
+json.components @project.components, :id, :name, :extension, :content, :index

--- a/db/migrate/20220307144811_allow_nil_content_on_components.rb
+++ b/db/migrate/20220307144811_allow_nil_content_on_components.rb
@@ -1,0 +1,9 @@
+class AllowNilContentOnComponents < ActiveRecord::Migration[7.0]
+  def up
+    change_column :components, :content, :string, null: true
+  end
+
+  def down
+    change_column :components, :content, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_28_094815) do
+ActiveRecord::Schema.define(version: 2022_03_07_144811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2022_02_28_094815) do
     t.uuid "project_id"
     t.string "name", null: false
     t.string "extension", null: false
-    t.text "content", null: false
+    t.string "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "index"

--- a/spec/factories/component.rb
+++ b/spec/factories/component.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :component do
     name { Faker::Lorem.word }
     extension { 'py' }
-    content { Faker::Lorem.paragraph(sentence_count: 2) }
+    sequence (:index) { |n| n }
   end
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Component, type: :model do
+  subject { build(:component) }
   it { is_expected.to belong_to(:project) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:extension) }
+  it { is_expected.to validate_uniqueness_of(:index).scoped_to(:project_id) }
+
 end


### PR DESCRIPTION
Add an endpoint to allow creation of components. 
The front end can call this endpoint with a name and extension and the backend will add an index if needed.

- Add validations for component
- Use cancancan load_and_authorize_resource in projects controller.