### PR TITLE
Set active storage to deliver images via proxy

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy


### PR DESCRIPTION
With active storage's normal delivery method requests to images are forwarded to the s3 url.
P5js does not follow the redirects and the images are not loaded.