### PR TITLE
Allow delete requests

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,6 +5,6 @@ origins_array = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins origins_array
-    resource '*', headers: :any, methods: %i[get post patch put]
+    resource '*', headers: :any, methods: %i[get post patch put delete]
   end
 end


### PR DESCRIPTION
Allow delete requests to be made in cross origins middleware.

This is needed to allow deleting projects from the UI.