### PR TITLE
Fix bundle script in readme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -303,4 +302,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.3.7
+   2.3.26


### PR DESCRIPTION
- Updates `with_builder` to be `with-builder` to match script name