### PR TITLE
Ensure sample words exist for phrase generator

### DIFF
--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
     end
   end
 
-  context 'when authenticated and project exists' do
+  context 'when authenticated and project exists', :sample_words do
     let(:current_user_id) { project.user_id }
     let(:returned_gid) { result.dig('data', 'remixProject', 'project', 'id') }
     let(:remixed_project) { GlobalID.find(returned_gid) }

--- a/spec/lib/project_loader_spec.rb
+++ b/spec/lib/project_loader_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'project_loader'
 
-RSpec.describe ProjectLoader do
+RSpec.describe ProjectLoader, :sample_words do
   let(:identifier) { PhraseIdentifier.generate }
   let(:preferred_locales) { %w[locale1 locale2] }
   let(:loaded_project) do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Project do
-  describe 'associations' do
+  describe 'associations', :sample_words do
     it { is_expected.to have_many(:components) }
     it { is_expected.to have_many(:remixes).dependent(:nullify) }
     it { is_expected.to have_many(:project_errors).dependent(:nullify) }
@@ -58,7 +58,7 @@ RSpec.describe Project do
     end
   end
 
-  describe 'check_unique_not_null' do
+  describe 'check_unique_not_null', :sample_words do
     let(:saved_project) { create(:project) }
 
     it 'generates an identifier if nil' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,6 +89,10 @@ RSpec.configure do |config|
     config.before { Bullet.start_request }
     config.after  { Bullet.end_request }
   end
+
+  config.before do |example|
+    create_list(:word, 10) if example.metadata[:sample_words]
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Fixes #192 

## Description

With the default setup some of the RSpec tests fail with

```
  1) ProjectLoader when no project with identifier returns nil
     Failure/Error: raise PhraseIdentifier::Error, 'Unable to generate a random phrase identifier' if phrase.blank?
     
     PhraseIdentifier::Error:
       Unable to generate a random phrase identifier
     # ./lib/phrase_identifier.rb:12:in `block in generate'
     # ./lib/phrase_identifier.rb:8:in `times'
     # ./lib/phrase_identifier.rb:8:in `generate'
     # ./spec/lib/project_loader_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/lib/project_loader_spec.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/lib/project_loader_spec.rb:54:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

This is because the `words` database is empty.

## Solution

An option `sample_words` is created for example groups that will create 10 sample words.