### PR TITLE
Remove whitespace from Introduction path projects

### DIFF
--- a/lib/tasks/project_components/dont-collide-starter/main.py
+++ b/lib/tasks/project_components/dont-collide-starter/main.py
@@ -13,6 +13,6 @@ def setup():
 def draw():
     # Put code to run every frame here
 
-  
+
 # Keep this to run your code
 run()

--- a/lib/tasks/project_components/hello_world_starter/main.py
+++ b/lib/tasks/project_components/hello_world_starter/main.py
@@ -6,27 +6,13 @@ world = '🌍🌎🌏'
 python = 'Python 🐍'
 fire = '🔥'
 
-# Emojis to copy and paste into your code 
+# Emojis to copy and paste into your code
 # 📅🕒🎨🎮🔬🎉🕶️🎲🦄🚀💯⭐💛
 # 😃😜❤️📚⚽🎾👟♻️🌳✨🥺🌈
 
 # Useful characters :',()*_/.#
 
-# Function definitions        
-  
+# Function definitions
+
 # Put code to run under here
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/lib/tasks/project_components/powerful_patterns_starter/main.py
+++ b/lib/tasks/project_components/powerful_patterns_starter/main.py
@@ -11,9 +11,9 @@ def setup():
 
 def draw():
     # Put code to run every frame here
-    fill(255, 0, 255) 
-    rect(50, 50, 120, 100) 
+    fill(255, 0, 255)
+    rect(50, 50, 120, 100)
 
-  
+
 # Keep this to run your code
 run(frame_rate = 5)

--- a/lib/tasks/project_components/rocket_launch_starter/main.py
+++ b/lib/tasks/project_components/rocket_launch_starter/main.py
@@ -17,12 +17,12 @@ from random import randint
 
 def setup():
   # Setup your animation here
-  
+
 
 
 def draw():
   # Things to do in every frame
-    
+
 
 
 run()

--- a/lib/tasks/project_components/rocket_launch_starter/main.py
+++ b/lib/tasks/project_components/rocket_launch_starter/main.py
@@ -16,12 +16,12 @@ from random import randint
 
 
 def setup():
-  # Setup your animation here
+    # Setup your animation here
 
 
 
 def draw():
-  # Things to do in every frame
+    # Things to do in every frame
 
 
 

--- a/lib/tasks/project_components/target_practice_starter/main.py
+++ b/lib/tasks/project_components/target_practice_starter/main.py
@@ -3,7 +3,7 @@ from p5 import *
 from random import randint
 
 # The mouse_pressed function goes here
-    
+
 # The shoot_arrow function goes here
 
 def setup():
@@ -13,7 +13,7 @@ def setup():
 def draw():
 # Things to do in every frame
     fill('cyan')  # Set the fill color for the sky to cyan
-    rect(0, 0, 400, 250)  # Draw a rectangle for the sky with these values for x, y, width, height    
-  
+    rect(0, 0, 400, 250)  # Draw a rectangle for the sky with these values for x, y, width, height
+
 # Keep this to run your code
 run(frame_rate=2)


### PR DESCRIPTION
Indentation can be tricky for people starting with Python so it is best not to have unnecessary whitespace in the starter projects.

This PR removes extra whitespace specifically from the 'Introduction to Python: Variables, functions, and loops' path projects.