### PR TITLE
Tweaks to allow using another database in local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
     ports:
-      - "5433:5432"
+      - "5434:5432"
 
   api:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,14 @@ services:
     stdin_open: true # For docker run --interactive, i.e. keep STDIN open even if not attached
     tty: true # For docker run --tty, i.e. allocate a pseudo-TTY. Important to allow interactive byebug sessions
     environment:
-      - POSTGRES_HOST=db
+      - POSTGRES_HOST
       - POSTGRES_DB
       - POSTGRES_PASSWORD
       - POSTGRES_USER
   smee:
     image: deltaprojects/smee-client
     command: -u $SMEE_TUNNEL -t http://api:3009/github_webhooks
+
+networks:
+  default:
+    name: shared-development


### PR DESCRIPTION
Three changes here:

* import `POSTGRES_HOST` from the environment (`.env` file) rather than presetting it in docker-compose; this makes it easier to use another database without editing version-controlled files). This also brings editor-api into consistency with how projects-admin does it
* move postgres database exposed port to 5434, to avoid a clash with projects-admin
* add the shared development network so editor-api can see postgres/nginx in core-dev-services for those who choose to use it