### PR TITLE
Add middleware to intercept add CORP headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-ALLOWED_ORIGINS=localhost:3002,localhost:3010,editor.rpfdev.com
+ALLOWED_ORIGINS=localhost:3002,localhost:3010,editor.rpfdev.com,localhost:3009
 
 AWS_ACCESS_KEY_ID=changeme
 AWS_S3_ACTIVE_STORAGE_BUCKET=changeme

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ require 'action_text/engine'
 require 'action_view/railtie'
 require 'action_cable/engine'
 # require "rails/test_unit/railtie"
+require_relative '../lib/corp_middleware'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -49,5 +50,7 @@ module App
     config.active_job.queue_adapter = :good_job
 
     config.api_only = false
+
+    config.middleware.insert_before 0, CORPMiddleware
   end
 end

--- a/lib/corp_middleware.rb
+++ b/lib/corp_middleware.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CORPMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    request_origin = env['HTTP_HOST']
+    allowed_origins = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
+
+    if env['PATH_INFO'].start_with?('/rails/active_storage') && allowed_origins.include?(request_origin)
+      headers['Cross-Origin-Resource-Policy'] = 'cross-origin'
+    end
+
+    [status, headers, response]
+  end
+end

--- a/spec/lib/corp_middleware_spec.rb
+++ b/spec/lib/corp_middleware_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CORPMiddleware do
+  let(:app) { double('App') } # rubocop:disable RSpec/VerifiedDoubles  let(:middleware) { described_class.new(app) }
+  let(:env) { { 'HTTP_HOST' => 'test.com', 'PATH_INFO' => '/rails/active_storage' } }
+
+  before do
+    allow(app).to receive(:call).and_return([200, {}, ['OK']])
+    allow(ENV).to receive(:[]).with('ALLOWED_ORIGINS').and_return('test.com')
+  end
+
+  it 'sets the Cross-Origin-Resource-Policy header for allowed origins' do
+    _status, headers, _response = middleware.call(env)
+
+    expect(headers['Cross-Origin-Resource-Policy']).to eq('cross-origin')
+  end
+
+  it 'does not set the Cross-Origin-Resource-Policy header for disallowed origins' do
+    allow(ENV).to receive(:[]).with('ALLOWED_ORIGINS').and_return('other.com')
+
+    _status, headers, _response = middleware.call(env)
+
+    expect(headers).not_to have_key('Cross-Origin-Resource-Policy')
+  end
+end

--- a/spec/lib/corp_middleware_spec.rb
+++ b/spec/lib/corp_middleware_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe CORPMiddleware do
-  let(:app) { double('App') } # rubocop:disable RSpec/VerifiedDoubles  let(:middleware) { described_class.new(app) }
+  let(:app) { double('App') } # rubocop:disable RSpec/VerifiedDoubles
+  let(:middleware) { described_class.new(app) }
   let(:env) { { 'HTTP_HOST' => 'test.com', 'PATH_INFO' => '/rails/active_storage' } }
 
   before do


### PR DESCRIPTION
Intercepts active storage requests and adds the required headers needed to allow images to be utilised in the app.