### PR TITLE
Fix user model organisation_ids array

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User
   end
 
   def organisation_ids
-    organisations.keys
+    organisations&.keys || []
   end
 
   def role?(organisation_id:, role:)


### PR DESCRIPTION
Currently `organisations` doesn't exist in profile so it's currently mocked. Slight tweak to future proof `organisation_ids` to ensure an array is returned 