### PR TITLE
Do not compile assets in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX


### PR DESCRIPTION
We're seeing the following warning in deployments like [this one][1]:

    You set your `config.assets.compile = true` in production.
    This can negatively impact the performance of your application.

    For more information can be found in this article:
      https://devcenter.heroku.com/articles/rails-asset-pipeline#compile-set-to-true-in-production

Heroku is automatically running `rake assets:precompile` and `rake assets:clean` (which just removes old versions of assets) as part of the build step and the build will fail if either of these tasks fails. So we should be able to rely on precompiled assets being present and thus we should be able to set `config.assets.compile` in the Rails production environment.

[1]: https://dashboard.heroku.com/apps/editor-api-staging/activity/builds/f9360560-9d26-487b-8258-cf84906055bf