### PR TITLE
update school validations to return list of errors for frontend use

### DIFF
--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -15,13 +15,14 @@ module Api
     end
 
     def create
-      result = School::Create.call(school_params:)
+      @school = School.new(school_params)
 
-      if result.success?
-        @school = result[:school]
+      if @school.save
         render :show, formats: [:json], status: :created
       else
-        render json: { error: result[:error] }, status: :unprocessable_entity
+        render json: {
+          errors: @school.errors
+        }, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -15,14 +15,13 @@ module Api
     end
 
     def create
-      @school = School.new(school_params)
+      result = School::Create.call(school_params:)
 
-      if @school.save
+      if result.success?
+        @school = result[:school]
         render :show, formats: [:json], status: :created
       else
-        render json: {
-          errors: @school.errors
-        }, status: :unprocessable_entity
+        render json: { error: result[:error] }, status: :unprocessable_entity
       end
     end
 

--- a/lib/concepts/school/operations/create.rb
+++ b/lib/concepts/school/operations/create.rb
@@ -10,8 +10,7 @@ class School
         response
       rescue StandardError => e
         Sentry.capture_exception(e)
-        errors = response[:school].errors.full_messages.join(',')
-        response[:error] = "Error creating school: #{errors}"
+        response[:error] = response[:school].errors
         response
       end
 

--- a/spec/concepts/school/create_spec.rb
+++ b/spec/concepts/school/create_spec.rb
@@ -55,9 +55,14 @@ RSpec.describe School::Create, type: :unit do
       expect(response.failure?).to be(true)
     end
 
-    it 'returns the error message in the operation response' do
+    it 'returns the correct number of objects in the operation response' do
       response = described_class.call(school_params:)
-      expect(response[:error]).to match(/Error creating school/)
+      expect(response[:error].count).to eq(6)
+    end
+
+    it 'returns the correct type of object in the operation response' do
+      response = described_class.call(school_params:)
+      expect(response[:error].first).to be_a(ActiveModel::Error)
     end
 
     it 'sent the exception to Sentry' do


### PR DESCRIPTION
### Issue
Related to https://github.com/RaspberryPiFoundation/editor-standalone/issues/28


### What changed
When a school is trying to be created, but validations fail, we now get this response:
```
{
  "errors": {
    "website":["can't be blank"],
    "address_line_1":["can't be blank"],
    "municipality":["can't be blank"],
    "country_code":["can't be blank","is not included in the list"]
  }
}
```

This is useful, as the FE application can now iterate on the keys, and selectively update each input field to show the error message.


Before this change we got:
```
{"error":"Error creating school: Website can't be blank,Address line 1 can't be blank,Municipality can't be blank,Country code can't be blank,Country code is not included in the list"}
```

which isn't useful, as we can't associate errors to fields