### PR TITLE
Fix order of `schools.reference` in `schema.rb`

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_19_151721) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_19_102922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -186,6 +186,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_151721) do
 
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
+    t.string "reference"
     t.string "address_line_1", null: false
     t.string "address_line_2"
     t.string "municipality", null: false
@@ -195,7 +196,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_151721) do
     t.datetime "verified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "reference"
     t.datetime "rejected_at"
     t.uuid "organisation_id"
     t.uuid "user_id"


### PR DESCRIPTION
In #267, this column was removed and then re-added. However, [the squashed merge commit][1] only included a single migration that did not add/remove the column was included, i.e. there was no net effect on `schools.reference`, but the `reference` column was still moved from near the top to near the bottom of the table in `schema.rb`.

Ideally `schema.rb` should reflect the state of the production database and so I've moved `reference` column back to where it was. This also means that other developers won't see unexpected differences in their `schema.rb` when they run the migrations locally.

[1]: https://github.com/RaspberryPiFoundation/editor-api/commit/f3248986273f62017a8d0bef58bdabc6282c6d78