### PR TITLE
Consistently respond to errors in all environments

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,12 +5,10 @@ class ApiController < ActionController::API
 
   include Identifiable
 
-  unless Rails.application.config.consider_all_requests_local
-    rescue_from ActionController::ParameterMissing, with: -> { bad_request }
-    rescue_from ActiveRecord::RecordNotFound, with: -> { not_found }
-    rescue_from CanCan::AccessDenied, with: -> { denied }
-    rescue_from ParameterError, with: -> { unprocessable }
-  end
+  rescue_from ActionController::ParameterMissing, with: -> { bad_request }
+  rescue_from ActiveRecord::RecordNotFound, with: -> { not_found }
+  rescue_from CanCan::AccessDenied, with: -> { denied }
+  rescue_from ParameterError, with: -> { unprocessable }
 
   private
 


### PR DESCRIPTION
The check for `consider_all_requests_local` (true in development, false in test and production) meant that we were responding with a 500 for these 4 exceptions in development, and with 400, 404, 403 and 422 respectively in test and production. This made is tricky to develop clients of this API because they'd get different responses in development than they would in production.

The commits below have all touched this block of code but none of them explain why the behaviour is as it is, so I'm going to assume it's OK to change as I have here:

- 632f55d5
- c93169b9
- d597bd93
- 86414675