### PR TITLE
Dev-container-tweaks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,13 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
 {
-  "name": "editor-api",
+  "name": "editor-api (dev-container)",
 
   // Update the 'dockerComposeFile' list if you have more compose files or use different names.
   // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
   "dockerComposeFile": [
-    "../docker-compose.yml"
+    "../docker-compose.yml",
+    "docker-compose.yml"
   ],
 
   // The 'service' property is the name of the service for the container that VS Code should
@@ -34,7 +35,7 @@
   // "runServices": [],
 
   // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
-  "shutdownAction": "stopCompose",
+  "shutdownAction": "none",
 
   // Uncomment the next line to run commands after the container is created.
   // "postCreateCommand": "",
@@ -64,17 +65,14 @@
         "christian-kohler.path-intellisense",
         "esbenp.prettier-vscode",
         "syler.sass-indented",
-        "codezombiech.gitignore"
+        "codezombiech.gitignore",
+        "shopify.ruby-lsp"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }
-  },
-
-  "mounts": [
-    "source=vscode_extensions,target=/root/.vscode-server/extensions,type=volume"
-  ]
+  }
 
   // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "devcontainer"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  api:
+    build:
+      context: .
+      target: dev-container
+    command: bash bin/dev-container-entrypoint.sh
+    volumes:
+      # - ${HOME}/.bashrc:/root/.bashrc:ro # Map a ~/.bashrc in your home directory for customising bash
+      - ${HOME}/.ssh:/root/.ssh:ro # To share any ssh keys with the container
+      - /var/run/docker.sock:/var/run/docker.sock
+      - node_modules:/app/node_modules
+
+volumes:
+  node_modules: null
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "ruby_lsp",
+      "name": "Debug script",
+      "request": "launch",
+      "program": "ruby ${file}"
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Debug test",
+      "request": "launch",
+      "program": "ruby -Itest ${relativeFile}"
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Attach debugger",
+      "request": "attach"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN gem install bundler \
   && apt-get update \
   && apt-get install --yes --no-install-recommends postgresql-client-15 \
   && rm -rf /var/lib/apt/lists/* /var/lib/apt/archives/*.deb
-RUN apt-get update && apt-get install -y sudo curl wget vim git zsh docker.io
-RUN sh -c "$(wget https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"
 ENV TZ='Europe/London'
 ENV RUBYOPT='-W:no-deprecated -W:no-experimental'
 
@@ -26,6 +24,18 @@ RUN apt-get update \
 COPY Gemfile Gemfile.lock /app/
 RUN bundle install --jobs 4 \
   && bundle binstubs --all --path /usr/local/bundle/bin
+
+# Dev container image
+FROM builder AS dev-container
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends sudo git vim zsh ssh curl less
+RUN sh -c "$(curl -L https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
+    -t robbyrussell \
+    -p git -p docker-compose -p yarn \
+    -p https://github.com/zsh-users/zsh-autosuggestions \
+    # -p https://github.com/marlonrichert/zsh-autocomplete \
+    -p https://github.com/unixorn/fzf-zsh-plugin
+RUN chsh -s $(which zsh) ${USER}
 
 # Slim application image without development dependencies
 FROM base AS app

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,7 +8,7 @@ class School < ApplicationRecord
   VALID_URL_REGEX = %r{\A(?:https?://)?(?:www.)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,6}(/.*)?\z}ix
 
   # TODO: To be removed once we move to a separate organisation_id
-  validates :id, presence: true, uniqueness: { case_sensitive: false }
+  validates :id, presence: false, uniqueness: { case_sensitive: false }
   validates :name, presence: true
   validates :website, presence: true, format: { with: VALID_URL_REGEX, message: I18n.t('validations.school.website') }
   validates :address_line_1, presence: true

--- a/bin/dev-container-entrypoint.sh
+++ b/bin/dev-container-entrypoint.sh
@@ -1,0 +1,3 @@
+rails db:prepare --trace
+rails projects:create_all
+rdbg -n --open -c -- bin/rails s -p 3009 -b '0.0.0.0'

--- a/spec/concepts/school/create_spec.rb
+++ b/spec/concepts/school/create_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe School::Create, type: :unit do
 
     it 'returns the correct number of objects in the operation response' do
       response = described_class.call(school_params:, user_id:, token:)
-      expect(response[:error].count).to eq(8)
+      expect(response[:error].count).to eq(7)
     end
 
     it 'returns the correct type of object in the operation response' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,6 +103,12 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
+  config.before(:suite) do
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first
+    puts "Running tests in environment: #{Rails.env}"
+    puts "Running tests against the database: #{db_config.database}"
+  end
+
   config.before(:each, js: true, type: :system) do
     # We need to allow net connect at this stage to allow WebDrivers to update
     # or Capybara to talk to selenium etc.


### PR DESCRIPTION
- adds output at start of test run to show current env_type and database (to aid debugging)
- dev-containers now use their own image, dev specific packages have been removed from the api container
- dev-containers now use their own docker-compose to manage containers
- add a launch.json to debug using ruby LSP