### PR TITLE
Editor API should be canonical source of Organisations

### DIFF
--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     def create
-      result = School::Create.call(school_params:, user_id: current_user.id, token: current_user&.token)
+      result = School::Create.call(school_params:, user_id: current_user.id)
 
       if result.success?
         @school = result[:school]

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -18,12 +18,6 @@ class School < ApplicationRecord
 
   before_validation :normalize_reference
 
-  # TODO: To be removed once we move to a separate organisation_id
-  def valid_except_for_id?
-    validate
-    errors.attribute_names.all? { |name| name == :id }
-  end
-
   def user
     User.from_userinfo(ids: user_id).first
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -7,8 +7,6 @@ class School < ApplicationRecord
 
   VALID_URL_REGEX = %r{\A(?:https?://)?(?:www.)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,6}(/.*)?\z}ix
 
-  # TODO: To be removed once we move to a separate organisation_id
-  validates :id, presence: false, uniqueness: { case_sensitive: false }
   validates :name, presence: true
   validates :website, presence: true, format: { with: VALID_URL_REGEX, message: I18n.t('validations.school.website') }
   validates :address_line_1, presence: true

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -9,8 +9,7 @@ class SchoolVerificationService
   def verify
     School.transaction do
       school = School.find(@school_id)
-      result = ProfileApiClient.create_organisation(token: @current_user.token)
-      school.update(verified_at: Time.zone.now, rejected_at: nil, organisation_id: result&.fetch(:id))
+      school.update(verified_at: Time.zone.now, rejected_at: nil)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)
@@ -22,6 +21,6 @@ class SchoolVerificationService
 
   def reject
     school = School.find(@school_id)
-    school.update(verified_at: nil, rejected_at: Time.zone.now, organisation_id: nil)
+    school.update(verified_at: nil, rejected_at: Time.zone.now)
   end
 end

--- a/db/migrate/20240507162837_remove_organisation_id_from_schools.rb
+++ b/db/migrate/20240507162837_remove_organisation_id_from_schools.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationIdFromSchools < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :schools, :organisation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_19_102922) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_07_162837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -196,7 +196,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_102922) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "rejected_at"
-    t.uuid "organisation_id"
     t.uuid "user_id"
     t.string "website", null: false
     t.index ["reference"], name: "index_schools_on_reference", unique: true

--- a/lib/concepts/school/operations/create.rb
+++ b/lib/concepts/school/operations/create.rb
@@ -3,9 +3,9 @@
 class School
   class Create
     class << self
-      def call(school_params:, user_id:, token:)
+      def call(school_params:, user_id:)
         response = OperationResponse.new
-        response[:school] = build_school(school_params.merge!(user_id:), token)
+        response[:school] = build_school(school_params.merge!(user_id:))
         response[:school].save!
         response
       rescue StandardError => e
@@ -16,16 +16,8 @@ class School
 
       private
 
-      def build_school(school_params, token)
-        school = School.new(school_params)
-
-        # TODO: To be removed once we move to a separate organisation_id
-        if school.valid_except_for_id?
-          response = ProfileApiClient.create_organisation(token:)
-          school.id = response&.fetch(:id)
-        end
-
-        school
+      def build_school(school_params)
+        School.new(school_params)
       end
     end
   end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -5,22 +5,6 @@ class ProfileApiClient
     # TODO: Replace with HTTP requests once the profile API has been built.
 
     # The API should enforce these constraints:
-    # - The user should have an email address
-    # - The user should not be under 13
-    # - The user must have a verified email
-    #
-    # The API should respond:
-    # - 422 Unprocessable if the constraints are not met
-    def create_organisation(token:)
-      return nil if token.blank?
-
-      # TODO: We should make Faraday raise a Ruby error for a non-2xx status
-      # code so that School::Create propagates the error in the response.
-      response = { 'id' => '12345678-1234-1234-1234-123456789abc' }
-      response.deep_symbolize_keys
-    end
-
-    # The API should enforce these constraints:
     # - The token has the school-owner or school-teacher role for the given organisation ID
     # - The token user or given user should not be under 13
     # - The email must be verified

--- a/spec/concepts/school/create_spec.rb
+++ b/spec/concepts/school/create_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe School::Create, type: :unit do
 
   before do
     stub_user_info_api
-    stub_profile_api_create_organisation
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school/create_spec.rb
+++ b/spec/concepts/school/create_spec.rb
@@ -22,26 +22,26 @@ RSpec.describe School::Create, type: :unit do
   end
 
   it 'returns a successful operation response' do
-    response = described_class.call(school_params:, user_id:, token:)
+    response = described_class.call(school_params:, user_id:)
     expect(response.success?).to be(true)
   end
 
   it 'creates a school' do
-    expect { described_class.call(school_params:, user_id:, token:) }.to change(School, :count).by(1)
+    expect { described_class.call(school_params:, user_id:) }.to change(School, :count).by(1)
   end
 
   it 'returns the school in the operation response' do
-    response = described_class.call(school_params:, user_id:, token:)
+    response = described_class.call(school_params:, user_id:)
     expect(response[:school]).to be_a(School)
   end
 
   it 'assigns the name' do
-    response = described_class.call(school_params:, user_id:, token:)
+    response = described_class.call(school_params:, user_id:)
     expect(response[:school].name).to eq('Test School')
   end
 
   it 'assigns the user_id' do
-    response = described_class.call(school_params:, user_id:, token:)
+    response = described_class.call(school_params:, user_id:)
     expect(response[:school].user_id).to eq(user_id)
   end
 
@@ -53,26 +53,26 @@ RSpec.describe School::Create, type: :unit do
     end
 
     it 'does not create a school' do
-      expect { described_class.call(school_params:, user_id:, token:) }.not_to change(School, :count)
+      expect { described_class.call(school_params:, user_id:) }.not_to change(School, :count)
     end
 
     it 'returns a failed operation response' do
-      response = described_class.call(school_params:, user_id:, token:)
+      response = described_class.call(school_params:, user_id:)
       expect(response.failure?).to be(true)
     end
 
     it 'returns the correct number of objects in the operation response' do
-      response = described_class.call(school_params:, user_id:, token:)
+      response = described_class.call(school_params:, user_id:)
       expect(response[:error].count).to eq(7)
     end
 
     it 'returns the correct type of object in the operation response' do
-      response = described_class.call(school_params:, user_id:, token:)
+      response = described_class.call(school_params:, user_id:)
       expect(response[:error].first).to be_a(ActiveModel::Error)
     end
 
     it 'sent the exception to Sentry' do
-      described_class.call(school_params:, user_id:, token:)
+      described_class.call(school_params:, user_id:)
       expect(Sentry).to have_received(:capture_exception).with(kind_of(StandardError))
     end
   end

--- a/spec/features/school/creating_a_school_spec.rb
+++ b/spec/features/school/creating_a_school_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a school', type: :request do
   before do
     stub_hydra_public_api
-    stub_profile_api_create_organisation
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe SchoolVerificationService do
       school.reload
     end
 
-    it 'sets organisation_id to the expected uuid' do
-      expect(school.organisation_id).to eq(organisation_id)
-    end
-
     it 'sets verified_at to a date' do
       expect(school.verified_at).to be_a(ActiveSupport::TimeWithZone)
     end
@@ -31,10 +27,6 @@ RSpec.describe SchoolVerificationService do
     before do
       service.reject
       school.reload
-    end
-
-    it 'sets organisation_id to nil' do
-      expect(school.organisation_id).to be_nil
     end
 
     it 'sets verified_at to nil' do
@@ -51,10 +43,6 @@ RSpec.describe SchoolVerificationService do
       service.verify
       service.reject
       school.reload
-    end
-
-    it 'sets organisation_id to nil' do
-      expect(school.organisation_id).to be_nil
     end
 
     it 'sets verified_at to nil' do

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe SchoolVerificationService do
   let(:service) { described_class.new(school.id, user) }
   let(:organisation_id) { SecureRandom.uuid }
 
-  before do
-    allow(ProfileApiClient).to receive(:create_organisation).and_return({ id: organisation_id })
-  end
-
   describe '#verify' do
     before do
       service.verify

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -5,10 +5,6 @@ module ProfileApiMock
 
   # TODO: Replace with WebMock HTTP stubs once the profile API has been built.
 
-  def stub_profile_api_create_organisation(organisation_id: ORGANISATION_ID)
-    allow(ProfileApiClient).to receive(:create_organisation).and_return(id: organisation_id)
-  end
-
   def stub_profile_api_list_school_owners(user_id:)
     allow(ProfileApiClient).to receive(:list_school_owners).and_return(ids: [user_id])
   end


### PR DESCRIPTION
GitHub issue #273 

Following a discussion with @DanielBrierton, @sra405, @grega, @floehopper, @chrislo and me, we've agreed not to store Schools/Organisations in Profile for now. Editor API is going to be the canonical source of Schools in the short term and we'll only look to store them in Profile if a user need requires us to.

This change allows us to use Editor Standalone to create multiple Schools in this API, because we're no longer assigning the [same ID to every School created](https://github.com/RaspberryPiFoundation/editor-api/blob/6b5575e43dc3b4b689c319d0952eb9140db15418/lib/profile_api_client.rb#L19).

The individual commit notes describe the changes in more detail.