### PR TITLE
WIP: Model roles in editor-api instead of profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User
   end
 
   def org_roles(organisation_id:)
+    return [] unless organisations
+
     organisations[organisation_id.to_s]&.to_s&.split(',')&.map(&:strip) || []
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,9 +70,6 @@ class User
       info = info.stringify_keys
       args = info.slice(*ATTRIBUTES)
 
-      # TODO: remove once the UserInfoApi returns the 'organisations' key.
-      temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
       new(args)
     end
   end
@@ -89,9 +86,6 @@ class User
     args = auth.extra.raw_info.to_h.slice(*ATTRIBUTES)
     args['id'] = auth.uid
 
-    # TODO: remove once the OmniAuth info returns the 'organisations' key.
-    temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
     new(args)
   end
 
@@ -107,16 +101,6 @@ class User
     args['id'] ||= auth['sub']
     args['token'] = token
 
-    # TODO: remove once the HydraPublicApi returns the 'organisations' key.
-    temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
     new(args)
-  end
-
-  def self.temporarily_add_organisations_until_the_profile_app_is_updated(hash)
-    return hash if hash.key?('organisations')
-
-    # Use the same organisation ID as the one from users.json for now.
-    hash.merge!('organisations' => { '12345678-1234-1234-1234-123456789abc' => hash['roles'] })
   end
 end

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :school do
-    id { '12345678-1234-1234-1234-123456789abc' }
     sequence(:name) { |n| "School #{n}" }
     website { 'http://www.example.com' }
     address_line_1 { 'Address Line 1' }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     organisations { {} }
 
     factory :admin_user do
-      organisations { { '12345678-1234-1234-1234-123456789abc' => 'editor-admin' } }
+      organisations { {} }
     end
 
     skip_create

--- a/spec/fixtures/users.json
+++ b/spec/fixtures/users.json
@@ -16,10 +16,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-owner",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-owner"
-      }
+      "roles": "school-owner"
     },
     {
       "id": "11111111-1111-1111-1111-111111111111",
@@ -37,10 +34,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-teacher",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-teacher"
-      }
+      "roles": "school-teacher"
     },
     {
       "id": "22222222-2222-2222-2222-222222222222",
@@ -58,10 +52,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-student",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-student"
-      }
+      "roles": "school-student"
     },
     {
       "id": "33333333-3333-3333-3333-333333333333",


### PR DESCRIPTION
We're currently using fake data in editor-api to fill in organisation/role data that we assume will be available from the profile API later. We've decided instead to model organisations (i.e. schools) solely in the editor-api for now (see #281) which means that we now need to model roles too. 

@chrisroos - I haven't started implementing anything here yet, I mostly wanted to see how the current system works, and start removing code that stubs/fakes out the data to more closely reflect the current reality and see what breaks. There seems to be really good test coverage around the API so these test failures might be able to guide us in how to replace the faked functionality with a real implementation. 

## TODO/IDEAS

Change the implementation of `User#school_owner?`, `User#school_teacher?` etc to look up this data in a join table. I *think* a User could `have_many` Schools through `role` or something similar where we have a join table that has

| user_id | school_id | role |
| 123 | 456 | school-owner |

and then change the implementation of methods on User to use that instead. We'd need to make sure that the `school_owner` role was set when a School is created/verified. And we might want to replace the current `School#user_id` with that (and/or model the idea of `requesting` a school separately from `owning` a school). 

The existing tests - many of which are failing in this PR could be fixed by changing the factories/stubs to use this new join table I think. 

I'm not yet worked out how to sequence that into commits that keep the tests passing, so this PR just has a bunch of failing tests for now and should be considered disposable! 


