### PR TITLE
Fallback to "Referer" header (vs "Origin" header) for `Project#remix_origin`

### DIFF
--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -15,7 +15,7 @@ module Api
         result = Project::CreateRemix.call(params: remix_params,
                                            user_id: current_user&.id,
                                            original_project: project,
-                                           remix_origin: request.origin)
+                                           remix_origin:)
 
         if result.success?
           @project = result[:project]
@@ -37,6 +37,15 @@ module Api
                       :identifier,
                       :locale,
                       components: %i[id name extension content index])
+      end
+
+      def remix_origin
+        request.origin || referer
+      end
+
+      def referer
+        referer = request.headers['Referer']
+        referer && URI(referer).origin
       end
     end
   end


### PR DESCRIPTION
When running Cypress E2E specs (which run in the Electron browser by default), there is no "Origin" header on the requests and so the "validation" for `Project#remix_origin` in [`Project::CreateRemix#validate_params`][1] fails, making it impossible to remix a project.

The Electron browser does seem to provide a "Referer" header on the requests, so I've changed the code to fallback to use that. I've used `URI#origin` to format `Project#remix_origin` consistently, because unlike the "Origin" header, the "Referer" header can include a path, a query string & a fragment.

I notice that when `Project#remix_origin` was added in #223, the format of the origin was a bit inconsistent in whether or not it included the URL scheme (see [this code](https://github.com/RaspberryPiFoundation/editor-api/blob/1bb7e7f74b8021418503bcf3af201844c130aa9a/db/migrate/20231106151705_default_remixed_project_origin.rb#L3-L9)):
* "http://localhost:3010"
* "staging-editor.raspberrypi.org"
* "editor.raspberrypi.org"

I've chosen to use [the standard format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) for an origin which *does* include the scheme. I realise this might mean that the values end up being inconsistent; however, it should still be possible to distinguish them OK and normalise them later.

[1]: https://github.com/RaspberryPiFoundation/editor-api/blob/1bb7e7f74b8021418503bcf3af201844c130aa9a/lib/concepts/project/operations/create_remix.rb#L22-L25