### PR TITLE
WIP: Remove hardcoded user ids from factories

### DIFF
--- a/spec/concepts/class_member/create_spec.rb
+++ b/spec/concepts/class_member/create_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe ClassMember::Create, type: :unit do
   before do
     stub_user_info_api
+    stub_user_info_api_for_student(student_id, school.id)
   end
 
   let!(:school_class) { create(:school_class) }

--- a/spec/concepts/school_class/create_spec.rb
+++ b/spec/concepts/school_class/create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SchoolClass::Create, type: :unit do
   end
 
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher(teacher_id, school.id)
   end
 
   it 'returns a successful operation response' do

--- a/spec/factories/class_member.rb
+++ b/spec/factories/class_member.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :class_member do
     school_class
-    student_id { '22222222-2222-2222-2222-222222222222' } # Matches users.json.
+    student_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/lesson.rb
+++ b/spec/factories/lesson.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :lesson do
-    user_id { '11111111-1111-1111-1111-111111111111' } # Matches users.json.
+    user_id { SecureRandom.uuid }
     sequence(:name) { |n| "Lesson #{n}" }
     visibility { 'private' }
   end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :project do
-    user_id { '22222222-2222-2222-2222-222222222222' } # Matches users.json.
+    user_id { SecureRandom.uuid }
     name { Faker::Book.title }
     identifier { "#{Faker::Verb.base}-#{Faker::Verb.base}-#{Faker::Verb.base}" }
     project_type { 'python' }

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :school do
-    id { '12345678-1234-1234-1234-123456789abc' }
+    # id { '12345678-1234-1234-1234-123456789abc' }
     sequence(:name) { |n| "School #{n}" }
     website { 'http://www.example.com' }
     address_line_1 { 'Address Line 1' }

--- a/spec/factories/school_class.rb
+++ b/spec/factories/school_class.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :school_class do
     school
-    teacher_id { '11111111-1111-1111-1111-111111111111' } # Matches users.json.
+    teacher_id { SecureRandom.uuid }
     sequence(:name) { |n| "Class #{n}" }
   end
 end

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds 201 Created when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:created)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   end
 
   it 'responds 204 No Content when the user is the class teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:no_content)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -24,10 +24,12 @@ RSpec.describe 'Listing class members', type: :request do
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data.first[:student_id]).to eq(student_id)
+    expect(data.first[:student_id]).to eq(class_member.student_id)
   end
 
   it 'responds with the students JSON' do
+    stub_user_info_api_for_class_member(class_member)
+
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Creating a lesson', type: :request do
           name: 'Test Lesson',
           school_id: school.id,
           school_class_id: school_class.id,
-          user_id: teacher_id
+          user_id: school_class.teacher_id
         }
       }
     end

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Listing lessons', type: :request do
   end
 
   it 'responds with the user JSON' do
+    stub_user_info_api_for_lesson(lesson)
+
     get('/api/lessons', headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe 'Listing lessons', type: :request do
     end
 
     it "includes the lesson when the user is a school-student within the lesson's class" do
-      authenticate_as_school_student
-      create(:class_member, school_class:)
+      member = create(:class_member, school_class:)
+      authenticate_as_school_student(member)
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe 'Listing lessons', type: :request do
 
   context "when the lesson's visibility is 'students'" do
     let(:school_class) { create(:school_class) }
-    let!(:lesson) { create(:lesson, school_class:, name: 'Test Lesson', visibility: 'students') }
+    let!(:lesson) { create(:lesson, school_class:, user_id: school_class.teacher_id, name: 'Test Lesson', visibility: 'students') }
     let(:teacher_index) { user_index_by_role('school-teacher') }
     let(:teacher_id) { user_id_by_index(teacher_index) }
 
     it 'includes the lesson when the user owns the lesson' do
-      authenticate_as_school_teacher
-      lesson.update!(user_id: teacher_id)
+      authenticate_as_school_teacher # (teacher_id: school_class.teacher_id)
+      # lesson.update!(user_id: school_class.teacher_id)
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -103,13 +103,13 @@ RSpec.describe 'Showing a lesson', type: :request do
 
   context "when the lesson's visibility is 'students'" do
     let(:school_class) { create(:school_class) }
-    let!(:lesson) { create(:lesson, school_class:, name: 'Test Lesson', visibility: 'students') }
+    let!(:lesson) { create(:lesson, school_class:, user_id: school_class.teacher_id, name: 'Test Lesson', visibility: 'students') }
     let(:teacher_index) { user_index_by_role('school-teacher') }
     let(:teacher_id) { user_id_by_index(teacher_index) }
 
     it 'responds 200 OK when the user owns the lesson' do
-      authenticate_as_school_teacher
-      lesson.update!(user_id: teacher_id)
+      authenticate_as_school_teacher # (teacher_id: school_class.teacher_id)
+      # lesson.update!(user_id: school_class.teacher_id)
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:ok)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Showing a lesson', type: :request do
   end
 
   it 'responds with the user JSON' do
+    stub_user_info_api_for_lesson(lesson)
+
     get("/api/lessons/#{lesson.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe 'Showing a lesson', type: :request do
     end
 
     it "responds 200 OK when the user is a school-student within the lesson's class" do
-      authenticate_as_school_student
-      create(:class_member, school_class:)
+      member = create(:class_member, school_class:)
+      authenticate_as_school_student(member)
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:ok)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Updating a lesson', type: :request do
     end
 
     it 'responds 200 OK when assigning the lesson to a school class' do
-      school_class = create(:school_class, school:)
+      school_class = create(:school_class, school:, teacher_id: lesson.user_id)
 
       new_params = { lesson: params[:lesson].merge(school_class_id: school_class.id) }
       put("/api/lessons/#{lesson.id}", headers:, params: new_params)
@@ -100,7 +100,7 @@ RSpec.describe 'Updating a lesson', type: :request do
 
   context 'when the lesson is associated with a school class' do
     let(:school_class) { create(:school_class) }
-    let!(:lesson) { create(:lesson, school_class:, name: 'Test Lesson', visibility: 'students') }
+    let!(:lesson) { create(:lesson, school_class:, user_id: school_class.teacher_id, name: 'Test Lesson', visibility: 'students') }
 
     it 'responds 200 OK when the user is a school-owner' do
       put("/api/lessons/#{lesson.id}", headers:, params:)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Creating a project', type: :request do
           components: [],
           school_id: school.id,
           lesson_id: lesson.id,
-          user_id: teacher_id
+          user_id: lesson.user_id
         }
       }
     end

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   end
 
   it 'responds 204 No Content when the user is the class teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:no_content)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe 'Listing school classes', type: :request do
   before do
     authenticate_as_school_owner
     stub_user_info_api
-
-    create(:class_member, school_class:)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let!(:school_class) { create(:school_class, name: 'Test School Class') }
   let(:school) { school_class.school }
+  let!(:member) { create(:class_member, school_class:) }
 
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}/classes", headers:)
@@ -53,7 +52,8 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it "does not include school classes that the school-student isn't a member of" do
-    authenticate_as_school_student
+    authenticate_as_school_student(member)
+
     create(:school_class, school:, teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes", headers:)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it 'responds with the teachers JSON' do
+    stub_user_info_api_for_school_class(school_class)
+
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
@@ -42,7 +44,7 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it "does not include school classes that the school-teacher doesn't teach" do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
     create(:school_class, school:, teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes", headers:)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is the class teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:ok)
@@ -40,6 +40,8 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds with the teacher JSON' do
+    stub_user_info_api_for_school_class(school_class)
+
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is a student in the class' do
-    authenticate_as_school_student
-    create(:class_member, school_class:)
+    member = create(:class_member, school_class:)
+    authenticate_as_school_student(member)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:ok)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is the school-teacher for the class' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(teacher_id: school_class.teacher_id)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:ok)
@@ -42,6 +42,8 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds with the teacher JSON' do
+    stub_user_info_api_for_school_class(school_class)
+
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe ClassMember do
 
   describe '.students' do
     it 'returns User instances for the current scope' do
-      create(:class_member)
+      member = create(:class_member)
+      stub_user_info_api_for_class_member(member)
 
       student = described_class.all.students.first
       expect(student.name).to eq('School Student')

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe Lesson do
 
   describe '.users' do
     it 'returns User instances for the current scope' do
-      create(:lesson)
+      lesson = create(:lesson)
+      stub_user_info_api_for_lesson(lesson)
 
       user = described_class.all.users.first
       expect(user.name).to eq('School Teacher')

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Lesson do
     it 'optionally belongs to a school class' do
       school_class = create(:school_class)
 
-      lesson = create(:lesson, school_class:, school: school_class.school)
+      lesson = create(:lesson, school_class:, school: school_class.school, user_id: school_class.teacher_id)
       expect(lesson.school_class).to be_a(SchoolClass)
     end
 
@@ -78,7 +78,8 @@ RSpec.describe Lesson do
 
     context 'when the lesson has a school_class' do
       before do
-        lesson.update!(school_class: create(:school_class))
+        school_class = create(:school_class)
+        lesson.update!(school_class:, user_id: school_class.teacher_id)
       end
 
       it 'requires that the user that is the school-teacher for the school_class' do
@@ -131,7 +132,8 @@ RSpec.describe Lesson do
 
   describe '#school' do
     it 'is set from the school_class' do
-      lesson = create(:lesson, school_class: build(:school_class))
+      school_class = build(:school_class)
+      lesson = create(:lesson, school_class:, user_id: school_class.teacher_id)
       expect(lesson.school).to eq(lesson.school_class.school)
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Project do
 
   describe '.users' do
     it 'returns User instances for the current scope' do
-      create(:project)
+      project = create(:project)
+      stub_user_info_api_for_project(project)
 
       user = described_class.all.users.first
       expect(user.name).to eq('School Student')

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -19,12 +19,18 @@ RSpec.describe SchoolClass do
     end
 
     it 'has many lessons' do
-      school_class = create(:school_class, lessons: [build(:lesson)])
+      school_class = create(:school_class)
+      create(:lesson, school_class:, user_id: school_class.teacher_id)
+
       expect(school_class.lessons.size).to eq(1)
     end
 
     context 'when a school_class is destroyed' do
-      let!(:school_class) { create(:school_class, members: [build(:class_member)], lessons: [build(:lesson)]) }
+      let!(:school_class) { create(:school_class, members: [build(:class_member)]) }
+
+      before do
+        create(:lesson, school_class:, user_id: school_class.teacher_id)
+      end
 
       it 'also destroys class members to avoid making them invalid' do
         expect { school_class.destroy! }.to change(ClassMember, :count).by(-1)
@@ -80,7 +86,9 @@ RSpec.describe SchoolClass do
 
   describe '.teachers' do
     it 'returns User instances for the current scope' do
-      create(:school_class)
+      school_class = create(:school_class)
+
+      stub_user_info_api_for_school_class(school_class)
 
       teacher = described_class.all.teachers.first
       expect(teacher.name).to eq('School Teacher')

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe School do
     end
 
     context 'when a school is destroyed' do
-      let(:lesson_1) { build(:lesson) }
-      let(:lesson_2) { build(:lesson) }
+      let!(:school) { create(:school, classes: [school_class], projects: [project]) }
+      let!(:school_class) { build(:school_class, members: [build(:class_member)]) }
+      let!(:lesson_1) { create(:lesson, school_class:, user_id: school_class.teacher_id) }
+      let!(:lesson_2) { create(:lesson, school:) }
       let(:project) { build(:project) }
-
-      let!(:school_class) { build(:school_class, members: [build(:class_member)], lessons: [lesson_1]) }
-      let!(:school) { create(:school, classes: [school_class], lessons: [lesson_2], projects: [project]) }
 
       it 'also destroys school classes to avoid making them invalid' do
         expect { school.destroy! }.to change(SchoolClass, :count).by(-1)

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -17,6 +17,16 @@ module UserProfileMock
       end
   end
 
+  def stub_user_info_api_for_class_member(class_member)
+    index = user_index_by_role('school-student')
+    attrs = user_attributes_by_index(index)
+    attrs[:id] = class_member.student_id
+
+    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
+      .to_return({ body: { users: [attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+  end
+
   def authenticate_as_school_owner
     stub_hydra_public_api(user_index: 0)
   end
@@ -25,8 +35,12 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 1)
   end
 
-  def authenticate_as_school_student
-    stub_hydra_public_api(user_index: 2)
+  def authenticate_as_school_student(member = nil)
+    if member
+      stub_hydra_public_api_for_class_member(member)
+    else
+      stub_hydra_public_api(user_index: 2)
+    end
   end
 
   def authenticate_as_school_student_without_organisations
@@ -35,6 +49,22 @@ module UserProfileMock
 
   def unauthenticated_user
     stub_hydra_public_api(user_index: nil)
+  end
+
+  def stub_hydra_public_api_for_class_member(class_member, token: TOKEN)
+    index = user_index_by_role('school-student')
+    attrs = user_attributes_by_index(index)
+    attrs[:id] = class_member.student_id
+
+    body = attrs.to_json
+
+    stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")
+      .with(headers: { Authorization: "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        headers: { content_type: 'application/json' },
+        body:
+      )
   end
 
   def stubbed_user

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module UserProfileMock
   USERS = File.read('spec/fixtures/users.json')
   TOKEN = 'fake-user-access-token'
@@ -21,6 +22,16 @@ module UserProfileMock
     index = user_index_by_role('school-student')
     attrs = user_attributes_by_index(index)
     attrs[:id] = class_member.student_id
+
+    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
+      .to_return({ body: { users: [attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+  end
+
+  def stub_user_info_api_for_project(project)
+    index = user_index_by_role('school-student')
+    attrs = user_attributes_by_index(index)
+    attrs[:id] = project.user_id
 
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
       .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
@@ -125,3 +136,4 @@ module UserProfileMock
       )
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -37,6 +37,16 @@ module UserProfileMock
       .to_return({ body: { users: [attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
   end
 
+  def stub_user_info_api_for_lesson(lesson)
+    index = user_index_by_role('school-teacher')
+    attrs = user_attributes_by_index(index)
+    attrs[:id] = lesson.user_id
+
+    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
+      .to_return({ body: { users: [attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+  end
+
   def authenticate_as_school_owner
     stub_hydra_public_api(user_index: 0)
   end


### PR DESCRIPTION
@chrisroos - I've extracted those three methods we talked about and made a start on removing the hard-coded user id in the school_class factory. 

[4ed8e79](https://github.com/RaspberryPiFoundation/editor-api/pull/289/commits/4ed8e797abd223059f52699d86d2abab694640b2) still has some failing tests for us to continue working on tomorrow. 