### PR TITLE
Avoid caching words used in `PhraseIdentifier` in the database

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Word < ApplicationRecord
-end

--- a/db/migrate/20240514163045_drop_words.rb
+++ b/db/migrate/20240514163045_drop_words.rb
@@ -1,0 +1,5 @@
+class DropWords < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :words
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_07_162837) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_14_163045) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -199,11 +200,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_07_162837) do
     t.uuid "user_id"
     t.string "website", null: false
     t.index ["reference"], name: "index_schools_on_reference", unique: true
-  end
-
-  create_table "words", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "word"
-    t.index ["word"], name: "index_words_on_word"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,3 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-PhraseIdentifier.seed!

--- a/lib/phrase_identifier.rb
+++ b/lib/phrase_identifier.rb
@@ -4,15 +4,9 @@ class PhraseIdentifier
   class Error < RuntimeError
   end
 
-  def self.seed!
-    words = File.readlines('words.txt', chomp: true)
-    Word.delete_all
-    words.each { |word| Word.create!(word:) }
-  end
-
   def self.generate
     10.times do
-      phrase = Word.order(Arel.sql('RANDOM()')).take(3).pluck(:word).join('-')
+      phrase = words.shuffle.take(3).join('-')
 
       # Uh-oh, no words found?
       raise PhraseIdentifier::Error, 'Unable to generate a random phrase identifier' if phrase.blank?
@@ -26,5 +20,9 @@ class PhraseIdentifier
 
   def self.unique?(phrase)
     phrase.present? && Project.where(identifier: phrase).none?
+  end
+
+  def self.words
+    @words ||= File.readlines('words.txt', chomp: true)
   end
 end

--- a/spec/factories/word.rb
+++ b/spec/factories/word.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :word do
-    word { Faker::Verb.base }
-  end
-end

--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
     end
   end
 
-  context 'when authenticated and project exists', :sample_words do
+  context 'when authenticated and project exists' do
     let(:returned_gid) { result.dig('data', 'remixProject', 'project', 'id') }
     let(:remixed_project) { GlobalID.find(returned_gid) }
 

--- a/spec/lib/phrase_identifier_spec.rb
+++ b/spec/lib/phrase_identifier_spec.rb
@@ -12,18 +12,17 @@ RSpec.describe PhraseIdentifier do
       let(:phrase_regex) { /^[abc]-[abc]-[abc]$/ }
 
       before do
-        Word.delete_all
-        words.each { |word| Word.new(word:).save! }
+        allow(described_class).to receive(:words).and_return(words)
       end
 
       it { is_expected.to match phrase_regex }
     end
 
     context 'when there are no available combinations' do
-      let(:identifier) { create(:word).word }
+      let(:identifier) { Faker::Verb.base }
 
       before do
-        Word.delete_all
+        allow(described_class).to receive(:words).and_return([identifier])
         create(:project, identifier:)
       end
 
@@ -31,7 +30,9 @@ RSpec.describe PhraseIdentifier do
     end
 
     context 'when no words are in the database' do
-      before { Word.delete_all }
+      before do
+        allow(described_class).to receive(:words).and_return([])
+      end
 
       it { expect { generate }.to raise_exception(PhraseIdentifier::Error) }
     end

--- a/spec/lib/project_loader_spec.rb
+++ b/spec/lib/project_loader_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'project_loader'
 
-RSpec.describe ProjectLoader, :sample_words do
+RSpec.describe ProjectLoader do
   let(:identifier) { PhraseIdentifier.generate }
   let(:preferred_locales) { %w[locale1 locale2] }
   let(:loaded_project) do

--- a/spec/models/filesystem_project_spec.rb
+++ b/spec/models/filesystem_project_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 describe FilesystemProject do
-  before do
-    PhraseIdentifier.seed!
-  end
-
   it 'imports all starter projects' do
     expect { described_class.import_all! }.not_to raise_error
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Project do
     stub_user_info_api
   end
 
-  describe 'associations', :sample_words do
+  describe 'associations' do
     it { is_expected.to belong_to(:school).optional(true) }
     it { is_expected.to belong_to(:lesson).optional(true) }
     it { is_expected.to belong_to(:parent).optional(true) }
@@ -95,7 +95,7 @@ RSpec.describe Project do
     end
   end
 
-  describe 'check_unique_not_null', :sample_words do
+  describe 'check_unique_not_null' do
     let(:saved_project) { create(:project) }
 
     it 'generates an identifier if nil' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,10 +95,6 @@ RSpec.configure do |config|
     config.after  { Bullet.end_request }
   end
 
-  config.before do |example|
-    create_list(:word, 10) if example.metadata[:sample_words]
-  end
-
   config.before(:each, type: :system) do
     driven_by :rack_test
   end


### PR DESCRIPTION
There are less than 1000 rows in the file which means it really doesn't take long to load and parse, so I don't really see the point in storing them in the database. I've also cached them in memory, so that we don't reload them in every iteration of the `10.times` loop.

Previously the app didn't work unless we'd seeded the database which was an extra complication for developers and deployments. This change removes that complication.

My actual motivation for making the change is to make the deployment of a new instance of the app at test-editor-api.raspberrypi.org simpler.