### PR TITLE
Improve naming of hydra stubs

### DIFF
--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a class member', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds 201 Created when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:created)
@@ -82,7 +82,7 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a class member', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   end
 
   it 'responds 204 No Content when the user is the class teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:no_content)
@@ -41,7 +41,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing class members', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Listing class members', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Listing class members', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Archiving a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       delete("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Archiving a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+      authenticate_as_school_teacher
       lesson.update!(user_id: SecureRandom.uuid)
 
       delete("/api/lessons/#{lesson.id}", headers:)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Archiving a lesson', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a copy of a lesson', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Creating a copy of a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       post("/api/lessons/#{lesson.id}/copy", headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 201 Created when the user is a school-teacher for the school' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+      authenticate_as_school_teacher
 
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:created)
@@ -82,7 +82,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'sets the lesson user to the current user for school-teacher users' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       new_params = { lesson: params[:lesson].merge(user_id: 'ignored') }
 
       post('/api/lessons', headers:, params: new_params)
@@ -131,7 +131,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     it 'responds 201 Created when the user is the school-teacher for the class' do
       teacher_index = user_index_by_role('school-teacher')
 
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       school_class.update!(teacher_id: user_id_by_index(teacher_index))
 
       post('/api/lessons', headers:, params:)
@@ -161,7 +161,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the current user is a school-teacher for a different class' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+      authenticate_as_school_teacher
       school_class.update!(teacher_id: SecureRandom.uuid)
 
       post('/api/lessons', headers:, params:)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a lesson', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Listing lessons', type: :request do
     end
 
     it 'does not include the lesson when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)
@@ -143,7 +143,7 @@ RSpec.describe 'Listing lessons', type: :request do
     end
 
     it "includes the lesson when the user is a school-student within the lesson's class" do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
       create(:class_member, school_class:)
 
       get('/api/lessons', headers:)
@@ -153,7 +153,7 @@ RSpec.describe 'Listing lessons', type: :request do
     end
 
     it "does not include the lesson when the user is not a school-student within the lesson's class" do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Listing lessons', type: :request do
     let(:teacher_id) { user_id_by_index(teacher_index) }
 
     it 'includes the lesson when the user owns the lesson' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       lesson.update!(user_id: teacher_id)
 
       get('/api/lessons', headers:)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing lessons', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     let(:teacher_id) { user_id_by_index(teacher_index) }
 
     it 'responds 200 OK when the user owns the lesson' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       lesson.update!(user_id: teacher_id)
 
       get("/api/lessons/#{lesson.id}", headers:)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)
@@ -116,7 +116,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     end
 
     it "responds 200 OK when the user is a school-student within the lesson's class" do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
       create(:class_member, school_class:)
 
       get("/api/lessons/#{lesson.id}", headers:)
@@ -124,7 +124,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     end
 
     it "responds 403 Forbidden when the user is a school-student but isn't within the lesson's class" do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Showing a lesson', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a lesson', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Updating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       put("/api/lessons/#{lesson.id}", headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Updating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+      authenticate_as_school_teacher
       lesson.update!(user_id: SecureRandom.uuid)
 
       put("/api/lessons/#{lesson.id}", headers:, params:)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 201 Created when the user is a school-student for the school' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:created)
@@ -179,7 +179,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+      authenticate_as_school_student
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 201 Created when the user is a school-teacher for the school' do
-      stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+      authenticate_as_school_teacher
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:created)
@@ -94,7 +94,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'sets the project user to the current user for school-teacher users' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       new_params = { project: params[:project].merge(user_id: 'ignored') }
 
       post('/api/projects', headers:, params: new_params)
@@ -135,7 +135,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 201 Created when the current user is the owner of the lesson' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       lesson.update!(user_id: user_id_by_index(teacher_index))
 
       post('/api/projects', headers:, params:)
@@ -171,7 +171,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 403 Forbidden when the current user is not the owner of the lesson' do
-      stub_hydra_public_api(user_index: teacher_index)
+      authenticate_as_school_teacher
       lesson.update!(user_id: SecureRandom.uuid)
 
       post('/api/projects', headers:, params:)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a project', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
     mock_phrase_generation
   end

--- a/spec/features/project/updating_a_project_spec.rb
+++ b/spec/features/project/updating_a_project_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a project', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
 
     create(:component, project:, name: 'main', extension: 'py', content: 'print("hi")')

--- a/spec/features/school/creating_a_school_spec.rb
+++ b/spec/features/school/creating_a_school_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Deleting a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a school', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Deleting a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school/listing_schools_spec.rb
+++ b/spec/features/school/listing_schools_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing schools', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
 
     create(:school, name: 'Test School')
   end

--- a/spec/features/school/showing_a_school_spec.rb
+++ b/spec/features/school/showing_a_school_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Showing a school', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
   end
 
   let!(:school) { create(:school, name: 'Test School') }

--- a/spec/features/school/updating_a_school_spec.rb
+++ b/spec/features/school/updating_a_school_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a school', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
   end
 
   let!(:school) { create(:school) }

--- a/spec/features/school/updating_a_school_spec.rb
+++ b/spec/features/school/updating_a_school_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Updating a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not a school-owner' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     put("/api/schools/#{school.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/classes", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school class', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'responds 201 Created when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/classes", headers:, params:)
     expect(response).to have_http_status(:created)
@@ -66,7 +66,8 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'sets the class teacher to the current user for school-teacher users' do
-    stub_hydra_public_api(user_index: teacher_index)
+    authenticate_as_school_teacher
+
     new_params = { school_class: params[:school_class].merge(teacher_id: 'ignored') }
 
     post("/api/schools/#{school.id}/classes", headers:, params: new_params)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a school class', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   end
 
   it 'responds 204 No Content when the user is the class teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:no_content)
@@ -38,7 +38,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it "does not include school classes that the school-student isn't a member of" do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
     create(:school_class, school:, teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes", headers:)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it "does not include school classes that the school-teacher doesn't teach" do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     create(:school_class, school:, teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes", headers:)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school classes', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
 
     create(:class_member, school_class:)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is the class teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:ok)
@@ -79,7 +79,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is a student in the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
     create(:class_member, school_class:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
@@ -87,7 +87,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not a school-student for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Showing a school class', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a school class', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_user_info_api
   end
 

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:ok)
@@ -82,7 +82,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Inviting a school owner', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_invite_school_owner
   end
 

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/owners", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/owners", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Listing school owners', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     get("/api/schools/#{school.id}/owners", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school owners', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_list_school_owners(user_id: owner_id)
     stub_user_info_api
   end

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Listing school owners', type: :request do
   end
 
   it 'responds 200 OK when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     get("/api/schools/#{school.id}/owners", headers:)
     expect(response).to have_http_status(:ok)

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Removing a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}/owners/#{owner_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Removing a school owner', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_remove_school_owner
   end
 

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Removing a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}/owners/#{owner_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Creating a batch of school students', type: :request do
   end
 
   it 'responds 204 No Content when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/students/batch", headers:, params: { file: })
     expect(response).to have_http_status(:no_content)

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a batch of school students', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_create_school_student
   end
 

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Creating a batch of school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/students/batch", headers:, params: { file: })
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Creating a school student', type: :request do
   end
 
   it 'responds 204 No Content when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/students", headers:, params:)
     expect(response).to have_http_status(:no_content)

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school student', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_create_school_student
   end
 

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Creating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/students", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a school student', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_delete_school_student
   end
 

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school students', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_list_school_students(user_id: student_id)
     stub_user_info_api
   end

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Listing school students', type: :request do
   end
 
   it 'responds 200 OK when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     get("/api/schools/#{school.id}/students", headers:)
     expect(response).to have_http_status(:ok)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Listing school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     get("/api/schools/#{school.id}/students", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/updating_a_school_student_spec.rb
+++ b/spec/features/school_student/updating_a_school_student_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a school student', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_update_school_student
   end
 

--- a/spec/features/school_student/updating_a_school_student_spec.rb
+++ b/spec/features/school_student/updating_a_school_student_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Updating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     put("/api/schools/#{school.id}/students/#{student_id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/updating_a_school_student_spec.rb
+++ b/spec/features/school_student/updating_a_school_student_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Updating a school student', type: :request do
   end
 
   it 'responds 204 No Content when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     put("/api/schools/#{school.id}/students/#{student_id}", headers:, params:)
     expect(response).to have_http_status(:no_content)

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     post("/api/schools/#{school.id}/teachers", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Inviting a school teacher', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_invite_school_teacher
   end
 

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     post("/api/schools/#{school.id}/teachers", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   end
 
   it 'responds 200 OK when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     get("/api/schools/#{school.id}/teachers", headers:)
     expect(response).to have_http_status(:ok)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     get("/api/schools/#{school.id}/teachers", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school teachers', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_list_school_teachers(user_id: teacher_id)
     stub_user_info_api
   end

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Removing a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-teacher'))
+    authenticate_as_school_teacher
 
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Removing a school teacher', type: :request do
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     stub_profile_api_remove_school_teacher
   end
 

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Removing a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    stub_hydra_public_api(user_index: user_index_by_role('school-student'))
+    authenticate_as_school_student
 
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/graphql/mutations/create_component_mutation_spec.rb
+++ b/spec/graphql/mutations/create_component_mutation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'mutation CreateComponent() { ... }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it 'returns the component ID' do

--- a/spec/graphql/mutations/create_project_mutation_spec.rb
+++ b/spec/graphql/mutations/create_project_mutation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'mutation CreateProject() { ... }' do
     let(:current_user) { stubbed_user }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
       mock_phrase_generation
     end
 

--- a/spec/graphql/mutations/delete_project_mutation_spec.rb
+++ b/spec/graphql/mutations/delete_project_mutation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
   subject(:result) { execute_query(query: mutation, variables:) }
 
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
   end
 
   let(:mutation) { 'mutation DeleteProject($project: DeleteProjectInput!) { deleteProject(input: $project) { id } }' }
@@ -41,7 +41,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
       let(:current_user) { stubbed_user }
 
       before do
-        stub_hydra_public_api
+        authenticate_as_school_owner
       end
 
       it 'deletes the project' do

--- a/spec/graphql/mutations/delete_project_mutation_spec.rb
+++ b/spec/graphql/mutations/delete_project_mutation_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
 
       context 'with another users project' do
         before do
-          stub_hydra_public_api(user_index: 1)
+          authenticate_as_school_teacher
         end
 
         it 'returns an error' do

--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
   let(:remix_origin) { 'editor.com' }
 
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
     project
   end
 

--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
 
   context 'when user cannot view original project' do
     before do
-      stub_hydra_public_api(user_index: 1)
+      authenticate_as_school_teacher
     end
 
     it 'returns "not permitted to read" error' do

--- a/spec/graphql/mutations/update_component_mutation_spec.rb
+++ b/spec/graphql/mutations/update_component_mutation_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'mutation UpdateComponent() { ... }' do
 
   context 'with an existing component' do
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     let(:project) { create(:project, user_id: stubbed_user.id) }

--- a/spec/graphql/mutations/update_component_mutation_spec.rb
+++ b/spec/graphql/mutations/update_component_mutation_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'mutation UpdateComponent() { ... }' do
 
       context 'with another users component' do
         before do
-          stub_hydra_public_api(user_index: 1)
+          authenticate_as_school_teacher
         end
 
         it 'returns an error' do

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
 
       context 'with another users project' do
         before do
-          stub_hydra_public_api(user_index: 1)
+          authenticate_as_school_teacher
         end
 
         it 'returns an error' do

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
   subject(:result) { execute_query(query: mutation, variables:) }
 
   before do
-    stub_hydra_public_api
+    authenticate_as_school_owner
   end
 
   let(:mutation) { 'mutation UpdateProject($project: UpdateProjectInput!) { updateProject(input: $project) { project { id } } }' }
@@ -30,7 +30,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
     before do
       # Instantiate project
       project
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     context 'when unauthenticated' do

--- a/spec/graphql/queries/project_query_spec.rb
+++ b/spec/graphql/queries/project_query_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'query { project { ... } }' do
       let(:project) { create(:project, user_id: stubbed_user.id) }
 
       before do
-        stub_hydra_public_api
+        authenticate_as_school_owner
       end
 
       it 'returns the project global id' do

--- a/spec/graphql/queries/projects_query_spec.rb
+++ b/spec/graphql/queries/projects_query_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'projects { }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it { expect(query).to be_a_valid_graphql_query }
@@ -87,7 +87,7 @@ RSpec.describe 'projects { }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it { expect(query).to be_a_valid_graphql_query }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe User do
 
     context 'when no organisations are returned' do
       before do
-        stub_hydra_public_api(user_index: 3) # student without organisations
+        authenticate_as_school_student_without_organisations
       end
 
       it 'returns a user with the correct organisations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,10 +96,8 @@ RSpec.describe User do
   describe '.from_token' do
     subject(:user) { described_class.from_token(token: UserProfileMock::TOKEN) }
 
-    let(:user_index) { 0 }
-
     before do
-      stub_hydra_public_api(user_index:)
+      authenticate_as_school_owner
     end
 
     it 'returns an instance of the described class' do
@@ -123,7 +121,9 @@ RSpec.describe User do
     end
 
     context 'when no organisations are returned' do
-      let(:user_index) { 3 } # student without organisations
+      before do
+        stub_hydra_public_api(user_index: 3) # student without organisations
+      end
 
       it 'returns a user with the correct organisations' do
         expect(user.organisations).to eq(organisation_id => 'school-student')

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'POST /graphql' do
 
       context 'when the token is invalid' do
         before do
-          stub_hydra_public_api(user_index: nil)
+          unauthenticated_user
         end
 
         it_behaves_like 'an unidentified request'

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'POST /graphql' do
 
       context 'when the token is valid' do
         before do
-          stub_hydra_public_api
+          authenticate_as_school_owner
         end
 
         it 'sets the current_user in the context' do

--- a/spec/requests/projects/create_spec.rb
+++ b/spec/requests/projects/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create project requests' do
 
     context 'when creating project is successful' do
       before do
-        stub_hydra_public_api
+        authenticate_as_school_owner
 
         response = OperationResponse.new
         response[:project] = project
@@ -26,7 +26,7 @@ RSpec.describe 'Create project requests' do
 
     context 'when creating project fails' do
       before do
-        stub_hydra_public_api
+        authenticate_as_school_owner
 
         response = OperationResponse.new
         response[:error] = 'Error creating project'

--- a/spec/requests/projects/destroy_spec.rb
+++ b/spec/requests/projects/destroy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Project delete requests' do
     let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     context 'when deleting a project the user owns' do

--- a/spec/requests/projects/images_spec.rb
+++ b/spec/requests/projects/images_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Images requests' do
       let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
       before do
-        stub_hydra_public_api
+        authenticate_as_school_owner
       end
 
       it 'attaches file to project' do

--- a/spec/requests/projects/images_spec.rb
+++ b/spec/requests/projects/images_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Images requests' do
       let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
       before do
-        stub_hydra_public_api(user_index: 1)
+        authenticate_as_school_teacher
       end
 
       it 'returns forbidden response' do

--- a/spec/requests/projects/index_spec.rb
+++ b/spec/requests/projects/index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Project index requests' do
     before do
       # create non user projects
       create_list(:project, 2)
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it 'returns success response' do
@@ -45,7 +45,7 @@ RSpec.describe 'Project index requests' do
 
   context 'when the projects index has pagination' do
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
       create_list(:project, 10, user_id: stubbed_user.id)
     end
 

--- a/spec/requests/projects/remix_spec.rb
+++ b/spec/requests/projects/remix_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Remix requests' do
     end
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     describe '#show' do
@@ -62,7 +62,7 @@ RSpec.describe 'Remix requests' do
 
       context 'when project cannot be saved' do
         before do
-          stub_hydra_public_api
+          authenticate_as_school_owner
           error_response = OperationResponse.new
           error_response[:error] = 'Something went wrong'
           allow(Project::CreateRemix).to receive(:call).and_return(error_response)

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Project show requests' do
     let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     context 'when loading own project' do

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Project update requests' do
     end
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it 'returns success response' do
@@ -81,7 +81,7 @@ RSpec.describe 'Project update requests' do
     let(:params) { { project: { components: [] } } }
 
     before do
-      stub_hydra_public_api
+      authenticate_as_school_owner
     end
 
     it 'returns forbidden response' do

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Project update requests' do
     let(:project) { create(:project) }
 
     before do
-      stub_hydra_public_api(user_index: nil)
+      unauthenticated_user
     end
 
     it 'returns unauthorized' do

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -25,6 +25,10 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 1)
   end
 
+  def authenticate_as_school_student
+    stub_hydra_public_api(user_index: 2)
+  end
+
   # Stubs the API that returns user profile data for the logged in user.
   def stub_hydra_public_api(user_index: 0, token: TOKEN)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -60,9 +60,9 @@ module UserProfileMock
   private
 
   # Stubs the API that returns user profile data for the logged in user.
-  def stub_hydra_public_api(user_index: 0, token: TOKEN)
+  def stub_hydra_public_api(user_index: 0)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")
-      .with(headers: { Authorization: "Bearer #{token}" })
+      .with(headers: { Authorization: "Bearer #{TOKEN}" })
       .to_return(
         status: 200,
         headers: { content_type: 'application/json' },

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -37,17 +37,6 @@ module UserProfileMock
     stub_hydra_public_api(user_index: nil)
   end
 
-  # Stubs the API that returns user profile data for the logged in user.
-  def stub_hydra_public_api(user_index: 0, token: TOKEN)
-    stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")
-      .with(headers: { Authorization: "Bearer #{token}" })
-      .to_return(
-        status: 200,
-        headers: { content_type: 'application/json' },
-        body: user_attributes_by_index(user_index).to_json
-      )
-  end
-
   def stubbed_user
     User.from_token(token: TOKEN)
   end
@@ -66,5 +55,18 @@ module UserProfileMock
 
   def user_index_by_role(name)
     JSON.parse(USERS)['users'].find_index { |attr| attr['roles'].include?(name) }
+  end
+
+  private
+
+  # Stubs the API that returns user profile data for the logged in user.
+  def stub_hydra_public_api(user_index: 0, token: TOKEN)
+    stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")
+      .with(headers: { Authorization: "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        headers: { content_type: 'application/json' },
+        body: user_attributes_by_index(user_index).to_json
+      )
   end
 end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -33,6 +33,10 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 3)
   end
 
+  def unauthenticated_user
+    stub_hydra_public_api(user_index: nil)
+  end
+
   # Stubs the API that returns user profile data for the logged in user.
   def stub_hydra_public_api(user_index: 0, token: TOKEN)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -17,6 +17,10 @@ module UserProfileMock
       end
   end
 
+  def authenticate_as_school_owner
+    stub_hydra_public_api(user_index: 0)
+  end
+
   # Stubs the API that returns user profile data for the logged in user.
   def stub_hydra_public_api(user_index: 0, token: TOKEN)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -60,7 +60,7 @@ module UserProfileMock
   private
 
   # Stubs the API that returns user profile data for the logged in user.
-  def stub_hydra_public_api(user_index: 0)
+  def stub_hydra_public_api(user_index:)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")
       .with(headers: { Authorization: "Bearer #{TOKEN}" })
       .to_return(

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -21,6 +21,10 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 0)
   end
 
+  def authenticate_as_school_teacher
+    stub_hydra_public_api(user_index: 1)
+  end
+
   # Stubs the API that returns user profile data for the logged in user.
   def stub_hydra_public_api(user_index: 0, token: TOKEN)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -29,6 +29,10 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 2)
   end
 
+  def authenticate_as_school_student_without_organisations
+    stub_hydra_public_api(user_index: 3)
+  end
+
   # Stubs the API that returns user profile data for the logged in user.
   def stub_hydra_public_api(user_index: 0, token: TOKEN)
     stub_request(:get, "#{HydraPublicApiClient::API_URL}/userinfo")


### PR DESCRIPTION
We found the use of `UserProfileMock#stub_hydra_public_api` to be a bit inconsistent and confusing. This PR extracts a few methods with, we hope, more intention-revealing names. 