### PR TITLE
Simplify `User#admin?`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User
   end
 
   def admin?
-    organisation_ids.any? { |organisation_id| org_role?(organisation_id:, role: 'editor-admin') }
+    (roles&.to_s&.split(',')&.map(&:strip) || []).include?('editor-admin')
   end
 
   def ==(other)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     organisations { {} }
 
     factory :admin_user do
-      organisations { { '12345678-1234-1234-1234-123456789abc' => 'editor-admin' } }
+      roles { 'editor-admin' }
     end
 
     skip_create

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -241,9 +241,25 @@ RSpec.describe User do
   end
 
   describe '#admin?' do
-    subject { user.admin? }
+    it 'returns true if the user has the editor-admin role in Hydra' do
+      user = build(:user, roles: 'editor-admin')
+      expect(user).to be_admin
+    end
 
-    include_examples 'role_check', 'editor-admin'
+    it 'returns false if the user does not have the editor-admin role in Hydra' do
+      user = build(:user, roles: 'another-editor-admin')
+      expect(user).not_to be_admin
+    end
+
+    it 'returns false if roles are empty in Hydra' do
+      user = build(:user, roles: '')
+      expect(user).not_to be_admin
+    end
+
+    it 'returns false if roles are nil in Hydra' do
+      user = build(:user, roles: nil)
+      expect(user).not_to be_admin
+    end
   end
 
   describe '.where' do


### PR DESCRIPTION
We don't need to go via the organisation -> roles mapping to check for the `editor-admin` role as we have access to the `roles` from Hydra directly.