### PR TITLE
More explicit stubbing of UserInfo API

### DIFF
--- a/spec/concepts/class_member/create_spec.rb
+++ b/spec/concepts/class_member/create_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ClassMember::Create, type: :unit do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let!(:school_class) { create(:school_class) }

--- a/spec/concepts/class_member/delete_spec.rb
+++ b/spec/concepts/class_member/delete_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ClassMember::Delete, type: :unit do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let!(:class_member) { create(:class_member) }

--- a/spec/concepts/lesson/archive_spec.rb
+++ b/spec/concepts/lesson/archive_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Lesson::Archive, type: :unit do
-  before do
-    stub_user_info_api
-  end
-
   let(:lesson) { create(:lesson) }
 
   it 'returns a successful operation response' do

--- a/spec/concepts/lesson/create_spec.rb
+++ b/spec/concepts/lesson/create_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Lesson::Create, type: :unit do
     { name: 'Test Lesson', user_id: teacher_id }
   end
 
-  before do
-    stub_user_info_api
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(lesson_params:)
     expect(response.success?).to be(true)

--- a/spec/concepts/lesson/unarchive_spec.rb
+++ b/spec/concepts/lesson/unarchive_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Lesson::Unarchive, type: :unit do
-  before do
-    stub_user_info_api
-  end
-
   let(:lesson) { create(:lesson, archived_at: Time.now.utc) }
 
   it 'returns a successful operation response' do

--- a/spec/concepts/lesson/update_spec.rb
+++ b/spec/concepts/lesson/update_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe Lesson::Update, type: :unit do
     { name: 'New Name' }
   end
 
-  before do
-    stub_user_info_api
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(lesson:, lesson_params:)
     expect(response.success?).to be(true)

--- a/spec/concepts/school/create_spec.rb
+++ b/spec/concepts/school/create_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe School::Create, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
   let(:user_id) { SecureRandom.uuid }
 
-  before do
-    stub_user_info_api
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(school_params:, user_id:)
     expect(response.success?).to be(true)

--- a/spec/concepts/school/delete_spec.rb
+++ b/spec/concepts/school/delete_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe School::Delete, type: :unit do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let!(:class_member) { create(:class_member) }

--- a/spec/concepts/school/update_spec.rb
+++ b/spec/concepts/school/update_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe School::Update, type: :unit do
   let(:school) { create(:school, name: 'Test School Name') }
   let(:school_params) { { name: 'New Name' } }
 
-  before do
-    stub_user_info_api
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(school:, school_params:)
     expect(response.success?).to be(true)

--- a/spec/concepts/school_class/create_spec.rb
+++ b/spec/concepts/school_class/create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SchoolClass::Create, type: :unit do
   end
 
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_class/delete_spec.rb
+++ b/spec/concepts/school_class/delete_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe SchoolClass::Delete, type: :unit do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let!(:class_member) { create(:class_member) }

--- a/spec/concepts/school_class/update_spec.rb
+++ b/spec/concepts/school_class/update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SchoolClass::Update, type: :unit do
   let(:school_class_params) { { name: 'New Name' } }
 
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_owner/list_spec.rb
+++ b/spec/concepts/school_owner/list_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SchoolOwner::List, type: :unit do
   end
 
   it 'returns the school owners in the operation response' do
+    stub_user_info_api_for_owner
     response = described_class.call(school:, token:)
     expect(response[:school_owners].first).to be_a(User)
   end

--- a/spec/concepts/school_owner/list_spec.rb
+++ b/spec/concepts/school_owner/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SchoolOwner::List, type: :unit do
 
   before do
     stub_profile_api_list_school_owners(user_id: owner_id)
-    stub_user_info_api
+    stub_user_info_api_for_owner
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SchoolStudent::List, type: :unit do
 
   before do
     stub_profile_api_list_school_students(user_id: student_id)
-    stub_user_info_api
+    stub_user_info_api_for_student
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SchoolStudent::List, type: :unit do
   end
 
   it 'returns the school students in the operation response' do
+    stub_user_info_api_for_student
     response = described_class.call(school:, token:)
     expect(response[:school_students].first).to be_a(User)
   end

--- a/spec/concepts/school_teacher/list_spec.rb
+++ b/spec/concepts/school_teacher/list_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SchoolTeacher::List, type: :unit do
   end
 
   it 'returns the school teachers in the operation response' do
+    stub_user_info_api_for_teacher
     response = described_class.call(school:, token:)
     expect(response[:school_teachers].first).to be_a(User)
   end

--- a/spec/concepts/school_teacher/list_spec.rb
+++ b/spec/concepts/school_teacher/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SchoolTeacher::List, type: :unit do
 
   before do
     stub_profile_api_list_school_teachers(user_id: teacher_id)
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   it 'returns a successful operation response' do

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds with the student JSON' do
+    stub_user_info_api_for_student
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe 'Creating a class member', type: :request do
 
   # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the student if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
     student_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: student_id)
     new_params = { class_member: params[:class_member].merge(student_id:) }
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params: new_params)
@@ -86,13 +86,16 @@ RSpec.describe 'Creating a class member', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Creating a class member', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -49,7 +50,9 @@ RSpec.describe 'Creating a class member', type: :request do
     expect(data[:student_name]).to eq('School Student')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the student if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     student_id = SecureRandom.uuid
     new_params = { class_member: params[:class_member].merge(student_id:) }
 
@@ -58,6 +61,7 @@ RSpec.describe 'Creating a class member', type: :request do
 
     expect(data[:student_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 400 Bad Request when params are missing' do
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
@@ -83,9 +87,9 @@ RSpec.describe 'Creating a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
+    stub_user_info_api_for_unknown_users
     authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
-
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)
   end

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Deleting a class member', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -41,6 +42,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
+    stub_user_info_api_for_unknown_users
     authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -41,14 +41,17 @@ RSpec.describe 'Deleting a class member', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Listing class members', type: :request do
   end
 
   it 'responds with the students JSON' do
+    stub_user_info_api_for_student
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -36,21 +36,25 @@ RSpec.describe 'Listing class members', type: :request do
     expect(data.first[:student_name]).to eq('School Student')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for students if the user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
-    class_member.update!(student_id: SecureRandom.uuid)
+    student_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: student_id)
+    class_member.update!(student_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:student_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it 'does not include class members that belong to a different class' do
-    stub_user_info_api_for_unknown_users
+    student_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: student_id)
     different_class = create(:school_class, school:)
-    create(:class_member, school_class: different_class, student_id: SecureRandom.uuid)
+    create(:class_member, school_class: different_class, student_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
@@ -72,14 +76,17 @@ RSpec.describe 'Listing class members', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Archiving a lesson', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -66,6 +66,7 @@ RSpec.describe 'Archiving a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
+      stub_user_info_api_for_unknown_users
       authenticate_as_school_teacher
       lesson.update!(user_id: SecureRandom.uuid)
 

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -65,14 +65,17 @@ RSpec.describe 'Archiving a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      stub_user_info_api_for_unknown_users
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
       authenticate_as_school_teacher
-      lesson.update!(user_id: SecureRandom.uuid)
+      lesson.update!(user_id:)
 
       delete("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Creating a copy of a lesson', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_owner
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Creating a copy of a lesson', type: :request do
   end
 
   it 'responds with the user JSON which is set from the current user' do
+    stub_user_info_api_for_owner
     post("/api/lessons/#{lesson.id}/copy", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Creating a lesson', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -19,11 +19,13 @@ RSpec.describe 'Creating a lesson', type: :request do
   end
 
   it 'responds 201 Created' do
+    stub_user_info_api_for_owner
     post('/api/lessons', headers:, params:)
     expect(response).to have_http_status(:created)
   end
 
   it 'responds with the lesson JSON' do
+    stub_user_info_api_for_owner
     post('/api/lessons', headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 
@@ -162,6 +164,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the current user is a school-teacher for a different class' do
+      stub_user_info_api_for_unknown_users
       authenticate_as_school_teacher
       school_class.update!(teacher_id: SecureRandom.uuid)
 
@@ -170,6 +173,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 422 Unprocessable Entity when the user_id is a school-teacher for a different class' do
+      stub_user_info_api_for_unknown_users
       new_params = { lesson: params[:lesson].merge(user_id: SecureRandom.uuid) }
 
       post('/api/lessons', headers:, params: new_params)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Creating a lesson', type: :request do
   end
 
   it 'responds with the user JSON which is set from the current user' do
+    stub_user_info_api_for_owner
     post('/api/lessons', headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -163,18 +163,22 @@ RSpec.describe 'Creating a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the current user is a school-teacher for a different class' do
-      stub_user_info_api_for_unknown_users
+      teacher_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: teacher_id)
       authenticate_as_school_teacher
-      school_class.update!(teacher_id: SecureRandom.uuid)
+      school_class.update!(teacher_id:)
 
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 422 Unprocessable Entity when the user_id is a school-teacher for a different class' do
-      stub_user_info_api_for_unknown_users
-      new_params = { lesson: params[:lesson].merge(user_id: SecureRandom.uuid) }
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      new_params = { lesson: params[:lesson].merge(user_id:) }
 
       post('/api/lessons', headers:, params: new_params)
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Listing lessons', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -37,6 +37,7 @@ RSpec.describe 'Listing lessons', type: :request do
   end
 
   it "responds with nil attributes for the user if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     lesson.update!(user_id: SecureRandom.uuid)
 
     get('/api/lessons', headers:)
@@ -69,6 +70,7 @@ RSpec.describe 'Listing lessons', type: :request do
     let(:owner_id) { user_id_by_index(owner_index) }
 
     it 'includes the lesson when the user owns the lesson' do
+      stub_user_info_api_for_owner
       lesson.update!(user_id: owner_id)
 
       get('/api/lessons', headers:)
@@ -92,6 +94,7 @@ RSpec.describe 'Listing lessons', type: :request do
     let(:owner_id) { user_id_by_index(owner_index) }
 
     it 'includes the lesson when the user owns the lesson' do
+      stub_user_info_api_for_owner
       lesson.update!(user_id: owner_id)
 
       get('/api/lessons', headers:)
@@ -143,7 +146,9 @@ RSpec.describe 'Listing lessons', type: :request do
       expect(data.size).to eq(1)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it "includes the lesson when the user is a school-student within the lesson's class" do
+      stub_user_info_api_for_student
       authenticate_as_school_student
       create(:class_member, school_class:)
 
@@ -152,6 +157,7 @@ RSpec.describe 'Listing lessons', type: :request do
 
       expect(data.size).to eq(1)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it "does not include the lesson when the user is not a school-student within the lesson's class" do
       authenticate_as_school_student

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -36,15 +36,18 @@ RSpec.describe 'Listing lessons', type: :request do
     expect(data.first[:user_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the user if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
-    lesson.update!(user_id: SecureRandom.uuid)
+    user_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id:)
+    lesson.update!(user_id:)
 
     get('/api/lessons', headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:user_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'does not include archived lessons' do
     lesson.archive!

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Listing lessons', type: :request do
   end
 
   it 'responds with the user JSON' do
+    stub_user_info_api_for_teacher
     get('/api/lessons', headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Showing a lesson', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let!(:lesson) { create(:lesson, name: 'Test Lesson', visibility: 'public') }
@@ -37,6 +37,7 @@ RSpec.describe 'Showing a lesson', type: :request do
   end
 
   it "responds with nil attributes for the user if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     lesson.update!(user_id: SecureRandom.uuid)
 
     get("/api/lessons/#{lesson.id}", headers:)
@@ -56,6 +57,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     let(:owner_id) { user_id_by_index(owner_index) }
 
     it 'responds 200 OK when the user owns the lesson' do
+      stub_user_info_api_for_owner
       lesson.update!(user_id: owner_id)
 
       get("/api/lessons/#{lesson.id}", headers:)
@@ -75,6 +77,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     let(:owner_id) { user_id_by_index(owner_index) }
 
     it 'responds 200 OK when the user owns the lesson' do
+      stub_user_info_api_for_owner
       lesson.update!(user_id: owner_id)
 
       get("/api/lessons/#{lesson.id}", headers:)
@@ -118,6 +121,7 @@ RSpec.describe 'Showing a lesson', type: :request do
 
     it "responds 200 OK when the user is a school-student within the lesson's class" do
       authenticate_as_school_student
+      stub_user_info_api_for_student
       create(:class_member, school_class:)
 
       get("/api/lessons/#{lesson.id}", headers:)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -36,15 +36,18 @@ RSpec.describe 'Showing a lesson', type: :request do
     expect(data[:user_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the user if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
-    lesson.update!(user_id: SecureRandom.uuid)
+    user_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id:)
+    lesson.update!(user_id:)
 
     get("/api/lessons/#{lesson.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data[:user_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 404 Not Found when no lesson exists' do
     get('/api/lessons/not-a-real-id', headers:)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Showing a lesson', type: :request do
   end
 
   it 'responds with the user JSON' do
+    stub_user_info_api_for_teacher
     get("/api/lessons/#{lesson.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -85,14 +85,17 @@ RSpec.describe 'Updating a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      stub_user_info_api_for_unknown_users
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
       authenticate_as_school_teacher
-      lesson.update!(user_id: SecureRandom.uuid)
+      lesson.update!(user_id:)
 
       put("/api/lessons/#{lesson.id}", headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student
@@ -113,9 +116,10 @@ RSpec.describe 'Updating a lesson', type: :request do
 
     # rubocop:disable RSpec/ExampleLength
     it 'responds 422 Unprocessable Entity when trying to re-assign the lesson to a different class' do
-      stub_user_info_api_for_unknown_users
+      teacher_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: teacher_id)
       school = create(:school, id: SecureRandom.uuid)
-      school_class = create(:school_class, school:, teacher_id: SecureRandom.uuid)
+      school_class = create(:school_class, school:, teacher_id:)
 
       new_params = { lesson: params[:lesson].merge(school_class_id: school_class.id) }
       put("/api/lessons/#{lesson.id}", headers:, params: new_params)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'Updating a lesson', type: :request do
   end
 
   it 'responds with the user JSON' do
+    stub_user_info_api_for_owner
     put("/api/lessons/#{lesson.id}", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -144,8 +144,9 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 422 Unprocessable when when the user_id is not the owner of the lesson' do
-      stub_user_info_api_for_unknown_users
-      new_params = { project: params[:project].merge(user_id: SecureRandom.uuid) }
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      new_params = { project: params[:project].merge(user_id:) }
 
       post('/api/projects', headers:, params: new_params)
       expect(response).to have_http_status(:unprocessable_entity)
@@ -172,14 +173,17 @@ RSpec.describe 'Creating a project', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the current user is not the owner of the lesson' do
+      user_id = SecureRandom.uuid
       authenticate_as_school_teacher
-      stub_user_info_api_for_unknown_users
-      lesson.update!(user_id: SecureRandom.uuid)
+      stub_user_info_api_for_unknown_users(user_id:)
+      lesson.update!(user_id:)
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Creating a project', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
     mock_phrase_generation
   end
 
@@ -80,6 +80,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 201 Created when the user is a school-student for the school' do
+      stub_user_info_api_for_student
       authenticate_as_school_student
 
       post('/api/projects', headers:, params:)
@@ -143,6 +144,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 422 Unprocessable when when the user_id is not the owner of the lesson' do
+      stub_user_info_api_for_unknown_users
       new_params = { project: params[:project].merge(user_id: SecureRandom.uuid) }
 
       post('/api/projects', headers:, params: new_params)
@@ -172,6 +174,7 @@ RSpec.describe 'Creating a project', type: :request do
 
     it 'responds 403 Forbidden when the current user is not the owner of the lesson' do
       authenticate_as_school_teacher
+      stub_user_info_api_for_unknown_users
       lesson.update!(user_id: SecureRandom.uuid)
 
       post('/api/projects', headers:, params:)

--- a/spec/features/project/updating_a_project_spec.rb
+++ b/spec/features/project/updating_a_project_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Updating a project', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
 
     create(:component, project:, name: 'main', extension: 'py', content: 'print("hi")')
   end

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Deleting a school', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'responds with the teacher JSON' do
+    stub_user_info_api_for_teacher
     post("/api/schools/#{school.id}/classes", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Creating a school class', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -49,7 +49,9 @@ RSpec.describe 'Creating a school class', type: :request do
     expect(data[:teacher_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     teacher_id = SecureRandom.uuid
     new_params = { school_class: params[:school_class].merge(teacher_id:) }
 
@@ -58,6 +60,7 @@ RSpec.describe 'Creating a school class', type: :request do
 
     expect(data[:teacher_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'sets the class teacher to the specified user for school-owner users' do
     post("/api/schools/#{school.id}/classes", headers:, params:)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'Creating a school class', type: :request do
 
   # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
     teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     new_params = { school_class: params[:school_class].merge(teacher_id:) }
 
     post("/api/schools/#{school.id}/classes", headers:, params: new_params)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Deleting a school class', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -38,6 +38,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
+    stub_user_info_api_for_unknown_users
     authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -37,14 +37,17 @@ RSpec.describe 'Deleting a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Listing school classes', type: :request do
   end
 
   it 'responds with the teachers JSON' do
+    stub_user_info_api_for_teacher
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -35,21 +35,25 @@ RSpec.describe 'Listing school classes', type: :request do
     expect(data.first[:teacher_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for teachers if the user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
+    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:teacher_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-teacher doesn't teach" do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    create(:school_class, school:, teacher_id: SecureRandom.uuid)
+    create(:school_class, school:, teacher_id:)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
@@ -60,9 +64,10 @@ RSpec.describe 'Listing school classes', type: :request do
 
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-student isn't a member of" do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_student
-    create(:school_class, school:, teacher_id: SecureRandom.uuid)
+    create(:school_class, school:, teacher_id:)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -48,15 +48,18 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(data[:teacher_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
+    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data[:teacher_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 404 Not Found when no school exists' do
     get("/api/schools/not-a-real-id/classes/#{school_class.id}", headers:)
@@ -81,14 +84,17 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is not a school-student for the class' do
     authenticate_as_school_student

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds with the teacher JSON' do
+    stub_user_info_api_for_teacher
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Showing a school class', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let!(:school_class) { create(:school_class, name: 'Test School Class') }
@@ -25,6 +25,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 200 OK when the user is a student in the class' do
+    stub_user_info_api_for_student
     authenticate_as_school_student
     create(:class_member, school_class:)
 
@@ -48,6 +49,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     school_class.update!(teacher_id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
@@ -80,6 +82,7 @@ RSpec.describe 'Showing a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
+    stub_user_info_api_for_unknown_users
     authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Updating a school class', type: :request do
   before do
     authenticate_as_school_owner
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -49,7 +49,9 @@ RSpec.describe 'Updating a school class', type: :request do
     expect(data[:teacher_name]).to eq('School Teacher')
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
+    stub_user_info_api_for_unknown_users
     teacher_id = SecureRandom.uuid
     new_params = { school_class: params[:school_class].merge(teacher_id:) }
 
@@ -58,6 +60,7 @@ RSpec.describe 'Updating a school class', type: :request do
 
     expect(data[:teacher_name]).to be_nil
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 400 Bad Request when params are missing' do
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
@@ -83,6 +86,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
+    stub_user_info_api_for_unknown_users
     authenticate_as_school_teacher
     school_class.update!(teacher_id: SecureRandom.uuid)
 

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Updating a school class', type: :request do
   end
 
   it 'responds with the teacher JSON' do
+    stub_user_info_api_for_teacher
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'Updating a school class', type: :request do
 
   # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
-    stub_user_info_api_for_unknown_users
     teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     new_params = { school_class: params[:school_class].merge(teacher_id:) }
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params: new_params)
@@ -85,14 +85,17 @@ RSpec.describe 'Updating a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    stub_user_info_api_for_unknown_users
+    teacher_id = SecureRandom.uuid
+    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher
-    school_class.update!(teacher_id: SecureRandom.uuid)
+    school_class.update!(teacher_id:)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Listing school owners', type: :request do
   before do
     authenticate_as_school_owner
     stub_profile_api_list_school_owners(user_id: owner_id)
-    stub_user_info_api
+    stub_user_info_api_for_owner
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Listing school owners', type: :request do
   end
 
   it 'responds with the school owners JSON' do
+    stub_user_info_api_for_owner
     get("/api/schools/#{school.id}/owners", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Listing school students', type: :request do
   before do
     authenticate_as_school_owner
     stub_profile_api_list_school_students(user_id: student_id)
-    stub_user_info_api
+    stub_user_info_api_for_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Listing school students', type: :request do
   end
 
   it 'responds with the school students JSON' do
+    stub_user_info_api_for_student
     get("/api/schools/#{school.id}/students", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   before do
     authenticate_as_school_owner
     stub_profile_api_list_school_teachers(user_id: teacher_id)
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   end
 
   it 'responds with the school teachers JSON' do
+    stub_user_info_api_for_teacher
     get("/api/schools/#{school.id}/teachers", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -69,8 +69,9 @@ RSpec.describe ClassMember do
     end
 
     it 'ignores members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      create(:class_member, student_id: SecureRandom.uuid)
+      student_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: student_id)
+      create(:class_member, student_id:)
 
       student = described_class.all.students.first
       expect(student).to be_nil
@@ -95,8 +96,9 @@ RSpec.describe ClassMember do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      class_member = create(:class_member, student_id: SecureRandom.uuid)
+      student_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: student_id)
+      class_member = create(:class_member, student_id:)
 
       pair = described_class.all.with_students.first
       expect(pair).to eq([class_member, nil])
@@ -121,8 +123,9 @@ RSpec.describe ClassMember do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      stub_user_info_api_for_unknown_users
-      class_member = create(:class_member, student_id: SecureRandom.uuid)
+      student_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: student_id)
+      class_member = create(:class_member, student_id:)
 
       pair = class_member.with_student
       expect(pair).to eq([class_member, nil])

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ClassMember do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   describe 'associations' do
@@ -68,6 +69,7 @@ RSpec.describe ClassMember do
     end
 
     it 'ignores members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       create(:class_member, student_id: SecureRandom.uuid)
 
       student = described_class.all.students.first
@@ -93,6 +95,7 @@ RSpec.describe ClassMember do
     end
 
     it 'returns nil values for members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       class_member = create(:class_member, student_id: SecureRandom.uuid)
 
       pair = described_class.all.with_students.first
@@ -118,6 +121,7 @@ RSpec.describe ClassMember do
     end
 
     it 'returns a nil value if the member has no profile account' do
+      stub_user_info_api_for_unknown_users
       class_member = create(:class_member, student_id: SecureRandom.uuid)
 
       pair = class_member.with_student

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe ClassMember do
 
   describe '.students' do
     it 'returns User instances for the current scope' do
+      stub_user_info_api_for_student
       create(:class_member)
 
       student = described_class.all.students.first

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe ClassMember do
     end
 
     it 'requires a student that has the school-student role for the school' do
+      stub_user_info_api_for_teacher
       class_member.student_id = '11111111-1111-1111-1111-111111111111' # school-teacher
       expect(class_member).to be_invalid
     end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Lesson do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
   end
 
   describe 'associations' do
@@ -83,6 +83,7 @@ RSpec.describe Lesson do
       end
 
       it 'requires that the user that is the school-teacher for the school_class' do
+        stub_user_info_api_for_owner
         lesson.user_id = '00000000-0000-0000-0000-000000000000' # school-owner
         expect(lesson).to be_invalid
       end
@@ -152,6 +153,7 @@ RSpec.describe Lesson do
     end
 
     it 'ignores members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       create(:lesson, user_id: SecureRandom.uuid)
 
       user = described_class.all.users.first
@@ -177,6 +179,7 @@ RSpec.describe Lesson do
     end
 
     it 'returns nil values for members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       lesson = create(:lesson, user_id: SecureRandom.uuid)
 
       pair = described_class.all.with_users.first
@@ -202,6 +205,7 @@ RSpec.describe Lesson do
     end
 
     it 'returns a nil value if the member has no profile account' do
+      stub_user_info_api_for_unknown_users
       lesson = create(:lesson, user_id: SecureRandom.uuid)
 
       pair = lesson.with_user

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -153,8 +153,9 @@ RSpec.describe Lesson do
     end
 
     it 'ignores members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      create(:lesson, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      create(:lesson, user_id:)
 
       user = described_class.all.users.first
       expect(user).to be_nil
@@ -179,8 +180,9 @@ RSpec.describe Lesson do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      lesson = create(:lesson, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      lesson = create(:lesson, user_id:)
 
       pair = described_class.all.with_users.first
       expect(pair).to eq([lesson, nil])
@@ -205,8 +207,9 @@ RSpec.describe Lesson do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      stub_user_info_api_for_unknown_users
-      lesson = create(:lesson, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      lesson = create(:lesson, user_id:)
 
       pair = lesson.with_user
       expect(pair).to eq([lesson, nil])

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe Lesson do
 
   describe '.users' do
     it 'returns User instances for the current scope' do
+      stub_user_info_api_for_teacher
       create(:lesson)
 
       user = described_class.all.users.first

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Lesson do
       end
 
       it 'requires that the user that has the school-owner or school-teacher role for the school' do
+        stub_user_info_api_for_student
         lesson.user_id = '22222222-2222-2222-2222-222222222222' # school-student
         expect(lesson).to be_invalid
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Project do
 
   describe '.users' do
     it 'returns User instances for the current scope' do
+      stub_user_info_api_for_student
       create(:project)
 
       user = described_class.all.users.first

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -110,8 +110,9 @@ RSpec.describe Project do
     end
 
     it 'ignores members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      create(:project, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      create(:project, user_id:)
 
       user = described_class.all.users.first
       expect(user).to be_nil
@@ -137,8 +138,9 @@ RSpec.describe Project do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      project = create(:project, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      project = create(:project, user_id:)
 
       pair = described_class.all.with_users.first
       expect(pair).to eq([project, nil])
@@ -164,8 +166,9 @@ RSpec.describe Project do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      stub_user_info_api_for_unknown_users
-      project = create(:project, user_id: SecureRandom.uuid)
+      user_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id:)
+      project = create(:project, user_id:)
 
       pair = project.with_user
       expect(pair).to eq([project, nil])

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Project do
     end
 
     it 'ignores members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       create(:project, user_id: SecureRandom.uuid)
 
       user = described_class.all.users.first
@@ -130,6 +131,7 @@ RSpec.describe Project do
 
   describe '.with_users' do
     it 'returns an array of class members paired with their User instance' do
+      stub_user_info_api_for_student
       project = create(:project)
 
       pair = described_class.all.with_users.first
@@ -139,6 +141,7 @@ RSpec.describe Project do
     end
 
     it 'returns nil values for members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       project = create(:project, user_id: SecureRandom.uuid)
 
       pair = described_class.all.with_users.first
@@ -155,6 +158,7 @@ RSpec.describe Project do
 
   describe '#with_user' do
     it 'returns the class member paired with their User instance' do
+      stub_user_info_api_for_student
       project = create(:project)
 
       pair = project.with_user
@@ -164,6 +168,7 @@ RSpec.describe Project do
     end
 
     it 'returns a nil value if the member has no profile account' do
+      stub_user_info_api_for_unknown_users
       project = create(:project, user_id: SecureRandom.uuid)
 
       pair = project.with_user

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Project do
-  before do
-    stub_user_info_api
-  end
-
   describe 'associations' do
     it { is_expected.to belong_to(:school).optional(true) }
     it { is_expected.to belong_to(:lesson).optional(true) }

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe SchoolClass do
 
   describe '.teachers' do
     it 'returns User instances for the current scope' do
+      stub_user_info_api_for_teacher
       create(:school_class)
 
       teacher = described_class.all.teachers.first

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -90,8 +90,9 @@ RSpec.describe SchoolClass do
     end
 
     it 'ignores members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      create(:school_class, teacher_id: SecureRandom.uuid)
+      teacher_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: teacher_id)
+      create(:school_class, teacher_id:)
 
       teacher = described_class.all.teachers.first
       expect(teacher).to be_nil
@@ -116,8 +117,9 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      stub_user_info_api_for_unknown_users
-      school_class = create(:school_class, teacher_id: SecureRandom.uuid)
+      teacher_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: teacher_id)
+      school_class = create(:school_class, teacher_id:)
 
       pair = described_class.all.with_teachers.first
       expect(pair).to eq([school_class, nil])
@@ -142,8 +144,9 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      stub_user_info_api_for_unknown_users
-      school_class = create(:school_class, teacher_id: SecureRandom.uuid)
+      teacher_id = SecureRandom.uuid
+      stub_user_info_api_for_unknown_users(user_id: teacher_id)
+      school_class = create(:school_class, teacher_id:)
 
       pair = school_class.with_teacher
       expect(pair).to eq([school_class, nil])

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe SchoolClass do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   describe 'associations' do
@@ -89,6 +90,7 @@ RSpec.describe SchoolClass do
     end
 
     it 'ignores members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       create(:school_class, teacher_id: SecureRandom.uuid)
 
       teacher = described_class.all.teachers.first
@@ -114,6 +116,7 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns nil values for members where no profile account exists' do
+      stub_user_info_api_for_unknown_users
       school_class = create(:school_class, teacher_id: SecureRandom.uuid)
 
       pair = described_class.all.with_teachers.first
@@ -139,6 +142,7 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns a nil value if the member has no profile account' do
+      stub_user_info_api_for_unknown_users
       school_class = create(:school_class, teacher_id: SecureRandom.uuid)
 
       pair = school_class.with_teacher

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe SchoolClass do
     end
 
     it 'requires a teacher that has the school-teacher role for the school' do
+      stub_user_info_api_for_student
       school_class.teacher_id = '22222222-2222-2222-2222-222222222222' # school-student
       expect(school_class).to be_invalid
     end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe School do
   before do
-    stub_user_info_api
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
   end
 
   describe 'associations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe User do
     let(:user) { users.first }
 
     before do
-      stub_user_info_api
+      stub_user_info_api_for_owner
     end
 
     it 'returns an Array' do
@@ -268,7 +268,7 @@ RSpec.describe User do
     subject(:user) { described_class.where(id: '00000000-0000-0000-0000-000000000000').first }
 
     before do
-      stub_user_info_api
+      stub_user_info_api_for_owner
     end
 
     it 'returns an instance of the described class' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe User do
       let(:ids) { ['33333333-3333-3333-3333-333333333333'] } # student without organisations
 
       it 'returns a user with the correct organisations' do
+        stub_user_info_api_for_student_without_organisations
+
         expect(user.organisations).to eq(organisation_id => 'school-student')
       end
     end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -6,15 +6,41 @@ module UserProfileMock
 
   # Stubs that API that returns user profile data for a given list of UUIDs.
   def stub_user_info_api
+    stub_user_info_api_for_unknown_users
+    stub_user_info_api_for_owner
+    stub_user_info_api_for_teacher
+    stub_user_info_api_for_student
+    stub_user_info_api_for_student_without_organisations
+  end
+
+  def stub_user_info_api_for_unknown_users
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
       .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
-      .to_return do |request|
-        uuids = JSON.parse(request.body).fetch('userIds', [])
-        indexes = uuids.map { |uuid| user_index_by_uuid(uuid) }.compact
-        users = indexes.map { |user_index| user_attributes_by_index(user_index) }
+      .to_return({ body: { users: [] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+  end
 
-        { body: { users: }.to_json, headers: { 'Content-Type' => 'application/json' } }
-      end
+  def stub_user_info_api_for_owner
+    stub_user_info_api_for(user_index: 0)
+  end
+
+  def stub_user_info_api_for_teacher
+    stub_user_info_api_for(user_index: 1)
+  end
+
+  def stub_user_info_api_for_student
+    stub_user_info_api_for(user_index: 2)
+  end
+
+  def stub_user_info_api_for_student_without_organisations
+    stub_user_info_api_for(user_index: 3)
+  end
+
+  def stub_user_info_api_for(user_index:)
+    user_attrs = user_attributes_by_index(user_index)
+
+    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_attrs['id']}/)
+      .to_return({ body: { users: [user_attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
   end
 
   def authenticate_as_school_owner

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -10,7 +10,6 @@ module UserProfileMock
     stub_user_info_api_for_owner
     stub_user_info_api_for_teacher
     stub_user_info_api_for_student
-    stub_user_info_api_for_student_without_organisations
   end
 
   def stub_user_info_api_for_unknown_users

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -9,7 +9,6 @@ module UserProfileMock
     stub_user_info_api_for_unknown_users
     stub_user_info_api_for_owner
     stub_user_info_api_for_teacher
-    stub_user_info_api_for_student
   end
 
   def stub_user_info_api_for_unknown_users

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -5,9 +5,7 @@ module UserProfileMock
   TOKEN = 'fake-user-access-token'
 
   def stub_user_info_api_for_unknown_users(user_id:)
-    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
-      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_id}/)
-      .to_return({ body: { users: [] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+    stub_user_info_api(user_id:, users: [])
   end
 
   def stub_user_info_api_for_owner
@@ -28,10 +26,7 @@ module UserProfileMock
 
   def stub_user_info_api_for(user_index:)
     user_attrs = user_attributes_by_index(user_index)
-
-    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
-      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_attrs['id']}/)
-      .to_return({ body: { users: [user_attrs] }.to_json, headers: { 'Content-Type' => 'application/json' } })
+    stub_user_info_api(user_id: user_attrs['id'], users: [user_attrs])
   end
 
   def authenticate_as_school_owner
@@ -85,5 +80,11 @@ module UserProfileMock
         headers: { content_type: 'application/json' },
         body: user_attributes_by_index(user_index).to_json
       )
+  end
+
+  def stub_user_info_api(user_id:, users:)
+    stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_id}/)
+      .to_return({ body: { users: }.to_json, headers: { 'Content-Type' => 'application/json' } })
   end
 end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -8,7 +8,6 @@ module UserProfileMock
   def stub_user_info_api
     stub_user_info_api_for_unknown_users
     stub_user_info_api_for_owner
-    stub_user_info_api_for_teacher
   end
 
   def stub_user_info_api_for_unknown_users

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -4,9 +4,9 @@ module UserProfileMock
   USERS = File.read('spec/fixtures/users.json')
   TOKEN = 'fake-user-access-token'
 
-  def stub_user_info_api_for_unknown_users
+  def stub_user_info_api_for_unknown_users(user_id:)
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
-      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })
+      .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_id}/)
       .to_return({ body: { users: [] }.to_json, headers: { 'Content-Type' => 'application/json' } })
   end
 

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -4,9 +4,6 @@ module UserProfileMock
   USERS = File.read('spec/fixtures/users.json')
   TOKEN = 'fake-user-access-token'
 
-  # Stubs that API that returns user profile data for a given list of UUIDs.
-  def stub_user_info_api; end
-
   def stub_user_info_api_for_unknown_users
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
       .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" })

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -5,9 +5,7 @@ module UserProfileMock
   TOKEN = 'fake-user-access-token'
 
   # Stubs that API that returns user profile data for a given list of UUIDs.
-  def stub_user_info_api
-    stub_user_info_api_for_unknown_users
-  end
+  def stub_user_info_api; end
 
   def stub_user_info_api_for_unknown_users
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -7,7 +7,6 @@ module UserProfileMock
   # Stubs that API that returns user profile data for a given list of UUIDs.
   def stub_user_info_api
     stub_user_info_api_for_unknown_users
-    stub_user_info_api_for_owner
   end
 
   def stub_user_info_api_for_unknown_users


### PR DESCRIPTION
This is another preparatory commit towards modelling users' roles in Editor API.

The next step is to remove hardcoded user IDs from our factories. Having these explicit stubs in place will make that change easier.