### PR TITLE
Model users' roles

### DIFF
--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -93,7 +93,7 @@ module Api
     end
 
     def school_owner?
-      school && current_user.school_owner?(organisation_id: school.id)
+      school && current_user.school_owner?(school)
     end
 
     def school

--- a/app/controllers/api/my_school_controller.rb
+++ b/app/controllers/api/my_school_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  class MySchoolController < ApiController
+    before_action :authorize_user
+
+    def show
+      @school = School.find_for_user!(current_user)
+      @user = current_user
+      render :show, formats: [:json], status: :ok
+    end
+  end
+end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -90,7 +90,7 @@ module Api
     end
 
     def school_owner?
-      school && current_user.school_owner?(organisation_id: school.id)
+      school && current_user.school_owner?(school)
     end
 
     def school

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -62,7 +62,7 @@ module Api
     end
 
     def school_owner?
-      current_user.school_owner?(organisation_id: @school.id)
+      current_user.school_owner?(@school)
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,7 +38,7 @@ class Ability
     can %i[read create_copy update destroy], Lesson, user_id: user.id
 
     user.schools.each do |school|
-      if user.school_student?(organisation_id: school.id)
+      if user.school_student?(school)
         define_school_student_abilities(user:,
                                         organisation_id: school.id)
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -73,7 +73,7 @@ class Ability
     end
     can(%i[read create_copy], Lesson, school_id: school.id, visibility: %w[teachers students])
     can(%i[create], Project) do |project|
-      school_teacher_can_manage_project?(user:, organisation_id: school.id, project:)
+      school_teacher_can_manage_project?(user:, school:, project:)
     end
   end
   # rubocop:enable Metrics/AbcSize
@@ -94,8 +94,8 @@ class Ability
     is_my_lesson && (is_my_class || !lesson.school_class)
   end
 
-  def school_teacher_can_manage_project?(user:, organisation_id:, project:)
-    is_my_project = project.school_id == organisation_id && project.user_id == user.id
+  def school_teacher_can_manage_project?(user:, school:, project:)
+    is_my_project = project.school_id == school.id && project.user_id == user.id
     is_my_lesson = project.lesson && project.lesson.user_id == user.id
 
     is_my_project && (is_my_lesson || !project.lesson)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,23 +40,23 @@ class Ability
     user.schools.each do |school|
       define_school_student_abilities(user:, school:) if user.school_student?(school)
       define_school_teacher_abilities(user:, school:) if user.school_teacher?(school)
-      define_school_owner_abilities(organisation_id: school.id) if user.school_owner?(school)
+      define_school_owner_abilities(school:) if user.school_owner?(school)
     end
   end
   # rubocop:enable Metrics/AbcSize
 
   private
 
-  def define_school_owner_abilities(organisation_id:)
-    can(%i[read update destroy], School, id: organisation_id)
-    can(%i[read create update destroy], SchoolClass, school: { id: organisation_id })
-    can(%i[read create destroy], ClassMember, school_class: { school: { id: organisation_id } })
+  def define_school_owner_abilities(school:)
+    can(%i[read update destroy], School, id: school.id)
+    can(%i[read create update destroy], SchoolClass, school: { id: school.id })
+    can(%i[read create destroy], ClassMember, school_class: { school: { id: school.id } })
     can(%i[read create destroy], :school_owner)
     can(%i[read create destroy], :school_teacher)
     can(%i[read create create_batch update destroy], :school_student)
-    can(%i[create create_copy], Lesson, school_id: organisation_id)
-    can(%i[read update destroy], Lesson, school_id: organisation_id, visibility: %w[teachers students public])
-    can(%i[create], Project, school_id: organisation_id)
+    can(%i[create create_copy], Lesson, school_id: school.id)
+    can(%i[read update destroy], Lesson, school_id: school.id, visibility: %w[teachers students public])
+    can(%i[create], Project, school_id: school.id)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -69,7 +69,7 @@ class Ability
     can(%i[read], :school_teacher)
     can(%i[read create create_batch update], :school_student)
     can(%i[create destroy], Lesson) do |lesson|
-      school_teacher_can_manage_lesson?(user:, organisation_id: school.id, lesson:)
+      school_teacher_can_manage_lesson?(user:, school:, lesson:)
     end
     can(%i[read create_copy], Lesson, school_id: school.id, visibility: %w[teachers students])
     can(%i[create], Project) do |project|
@@ -87,8 +87,8 @@ class Ability
   end
   # rubocop:enable Layout/LineLength
 
-  def school_teacher_can_manage_lesson?(user:, organisation_id:, lesson:)
-    is_my_lesson = lesson.school_id == organisation_id && lesson.user_id == user.id
+  def school_teacher_can_manage_lesson?(user:, school:, lesson:)
+    is_my_lesson = lesson.school_id == school.id && lesson.user_id == user.id
     is_my_class = lesson.school_class && lesson.school_class.teacher_id == user.id
 
     is_my_lesson && (is_my_class || !lesson.school_class)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,10 +37,6 @@ class Ability
     # Any authenticated user can manage their own lessons.
     can %i[read create_copy update destroy], Lesson, user_id: user.id
 
-    user.organisation_ids.each do |organisation_id|
-      define_school_owner_abilities(organisation_id:) if user.school_owner?(organisation_id:)
-    end
-
     user.schools.each do |school|
       if user.school_student?(organisation_id: school.id)
         define_school_student_abilities(user:,
@@ -50,6 +46,7 @@ class Ability
         define_school_teacher_abilities(user:,
                                         organisation_id: school.id)
       end
+      define_school_owner_abilities(organisation_id: school.id) if user.school_owner?(organisation_id: school.id)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,10 +38,7 @@ class Ability
     can %i[read create_copy update destroy], Lesson, user_id: user.id
 
     user.schools.each do |school|
-      if user.school_student?(school)
-        define_school_student_abilities(user:,
-                                        organisation_id: school.id)
-      end
+      define_school_student_abilities(user:, school:) if user.school_student?(school)
       if user.school_teacher?(school)
         define_school_teacher_abilities(user:,
                                         organisation_id: school.id)
@@ -79,11 +76,11 @@ class Ability
   end
 
   # rubocop:disable Layout/LineLength
-  def define_school_student_abilities(user:, organisation_id:)
-    can(%i[read], School, id: organisation_id)
-    can(%i[read], SchoolClass, school: { id: organisation_id }, members: { student_id: user.id })
-    can(%i[read], Lesson, school_id: organisation_id, visibility: 'students', school_class: { members: { student_id: user.id } })
-    can(%i[create], Project, school_id: organisation_id, user_id: user.id, lesson_id: nil)
+  def define_school_student_abilities(user:, school:)
+    can(%i[read], School, id: school.id)
+    can(%i[read], SchoolClass, school: { id: school.id }, members: { student_id: user.id })
+    can(%i[read], Lesson, school_id: school.id, visibility: 'students', school_class: { members: { student_id: user.id } })
+    can(%i[create], Project, school_id: school.id, user_id: user.id, lesson_id: nil)
   end
   # rubocop:enable Layout/LineLength
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,7 +46,7 @@ class Ability
         define_school_teacher_abilities(user:,
                                         organisation_id: school.id)
       end
-      define_school_owner_abilities(organisation_id: school.id) if user.school_owner?(organisation_id: school.id)
+      define_school_owner_abilities(organisation_id: school.id) if user.school_owner?(school)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,12 +39,15 @@ class Ability
 
     user.organisation_ids.each do |organisation_id|
       define_school_owner_abilities(organisation_id:) if user.school_owner?(organisation_id:)
-      define_school_teacher_abilities(user:, organisation_id:) if user.school_teacher?(organisation_id:)
     end
 
     user.schools.each do |school|
       if user.school_student?(organisation_id: school.id)
         define_school_student_abilities(user:,
+                                        organisation_id: school.id)
+      end
+      if user.school_teacher?(organisation_id: school.id)
+        define_school_teacher_abilities(user:,
                                         organisation_id: school.id)
       end
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,7 +40,13 @@ class Ability
     user.organisation_ids.each do |organisation_id|
       define_school_owner_abilities(organisation_id:) if user.school_owner?(organisation_id:)
       define_school_teacher_abilities(user:, organisation_id:) if user.school_teacher?(organisation_id:)
-      define_school_student_abilities(user:, organisation_id:) if user.school_student?(organisation_id:)
+    end
+
+    user.schools.each do |school|
+      if user.school_student?(organisation_id: school.id)
+        define_school_student_abilities(user:,
+                                        organisation_id: school.id)
+      end
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,7 +42,7 @@ class Ability
         define_school_student_abilities(user:,
                                         organisation_id: school.id)
       end
-      if user.school_teacher?(organisation_id: school.id)
+      if user.school_teacher?(school)
         define_school_teacher_abilities(user:,
                                         organisation_id: school.id)
       end

--- a/app/models/class_member.rb
+++ b/app/models/class_member.rb
@@ -30,7 +30,7 @@ class ClassMember < ApplicationRecord
     return unless student_id_changed? && errors.blank?
 
     _, user = with_student
-    return unless user && !user.school_student?(organisation_id: school.id)
+    return unless user && !user.school_student?(school)
 
     msg = "'#{student_id}' does not have the 'school-student' role for organisation '#{school.id}'"
     errors.add(:student, msg)

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -65,7 +65,7 @@ class Lesson < ApplicationRecord
 
     return if user.blank?
     return if user.school_owner?(organisation_id: school.id)
-    return if user.school_teacher?(organisation_id: school.id)
+    return if user.school_teacher?(school)
 
     msg = "'#{user_id}' does not have the 'school-owner' or 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -57,20 +57,18 @@ class Lesson < ApplicationRecord
     self.school ||= school_class&.school
   end
 
-  # rubocop:disable Metrics/AbcSize
   def user_has_the_school_owner_or_school_teacher_role_for_the_school
     return unless user_id_changed? && errors.blank? && school
 
     _, user = with_user
 
     return if user.blank?
-    return if user.school_owner?(organisation_id: school.id)
+    return if user.school_owner?(school)
     return if user.school_teacher?(school)
 
     msg = "'#{user_id}' does not have the 'school-owner' or 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)
   end
-  # rubocop:enable Metrics/AbcSize
 
   def user_is_the_school_teacher_for_the_school_class
     return if !school_class || user_id == school_class.teacher_id

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,7 +58,7 @@ class Project < ApplicationRecord
     _, user = with_user
 
     return if user.blank?
-    return if user.org_roles(organisation_id: school_id).any?
+    return if user.school_roles(organisation_id: school_id).any?
 
     msg = "'#{user_id}' does not have any roles for for organisation '#{school_id}'"
     errors.add(:user, msg)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,7 +58,7 @@ class Project < ApplicationRecord
     _, user = with_user
 
     return if user.blank?
-    return if user.school_roles(organisation_id: school_id).any?
+    return if user.school_roles(school).any?
 
     msg = "'#{user_id}' does not have any roles for for organisation '#{school_id}'"
     errors.add(:user, msg)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -7,4 +7,21 @@ class Role < ApplicationRecord
 
   validates :user_id, presence: true
   validates :role, presence: true, uniqueness: { scope: %i[school_id user_id] }
+  validate :students_cannot_have_additional_roles
+
+  private
+
+  def students_cannot_have_additional_roles
+    other_roles = Role.where(user_id:)
+
+    if other_roles.student.any?
+      errors.add(:base, "Cannot create #{role} role as this user already has the student role for this school")
+    elsif student? && other_roles.any?
+      other_role_names = [
+        other_roles.map(&:role).join(' and '),
+        'role'.pluralize(other_roles.length)
+      ].join(' ')
+      errors.add(:base, "Cannot create student role as this user already has the #{other_role_names} for this school")
+    end
+  end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Role < ApplicationRecord
+  belongs_to :school
+
+  enum :role, %i[student teacher owner]
+
+  validates :user_id, presence: true
+  validates :role, presence: true, uniqueness: { scope: %i[school_id user_id] }
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -8,6 +8,7 @@ class Role < ApplicationRecord
   validates :user_id, presence: true
   validates :role, presence: true, uniqueness: { scope: %i[school_id user_id] }
   validate :students_cannot_have_additional_roles
+  validate :users_can_only_have_roles_in_one_school
 
   private
 
@@ -23,5 +24,12 @@ class Role < ApplicationRecord
       ].join(' ')
       errors.add(:base, "Cannot create student role as this user already has the #{other_role_names} for this school")
     end
+  end
+
+  def users_can_only_have_roles_in_one_school
+    schools = Role.where(user_id:).map(&:school)
+    return if schools.empty? || (schools.any? && schools.first == school)
+
+    errors.add(:base, 'Cannot create role as this user already has a role in a different school')
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -14,6 +14,7 @@ class School < ApplicationRecord
   validates :municipality, presence: true
   validates :country_code, presence: true, inclusion: { in: ISO3166::Country.codes }
   validates :reference, uniqueness: { case_sensitive: false, allow_nil: true }, presence: false
+  validates :creator_id, presence: true
   validates :creator_agree_authority, presence: true, acceptance: true
   validates :creator_agree_terms_and_conditions, presence: true, acceptance: true
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -4,6 +4,7 @@ class School < ApplicationRecord
   has_many :classes, class_name: :SchoolClass, inverse_of: :school, dependent: :destroy
   has_many :lessons, dependent: :nullify
   has_many :projects, dependent: :nullify
+  has_many :roles, dependent: :nullify
 
   VALID_URL_REGEX = %r{\A(?:https?://)?(?:www.)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,6}(/.*)?\z}ix
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,6 +19,10 @@ class School < ApplicationRecord
 
   before_validation :normalize_reference
 
+  def self.find_for_user!(user)
+    Role.find_by!(user_id: user.id).school
+  end
+
   def user
     User.from_userinfo(ids: creator_id).first
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,7 +19,7 @@ class School < ApplicationRecord
   before_validation :normalize_reference
 
   def user
-    User.from_userinfo(ids: user_id).first
+    User.from_userinfo(ids: creator_id).first
   end
 
   private

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -28,7 +28,7 @@ class SchoolClass < ApplicationRecord
     return unless teacher_id_changed? && errors.blank?
 
     _, user = with_teacher
-    return unless user && !user.school_teacher?(organisation_id: school.id)
+    return unless user && !user.school_teacher?(school)
 
     msg = "'#{teacher_id}' does not have the 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User
     ATTRIBUTES.index_with { |_k| nil }
   end
 
+  def schools
+    School.joins(:roles).merge(Role.where(user_id: id)).distinct
+  end
+
   def organisation_ids
     organisations&.keys || []
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User
   end
 
   def school_roles(school)
-    organisations[school.id.to_s]&.to_s&.split(',')&.map(&:strip) || []
+    Role.where(school:, user_id: id).map(&:role)
   end
 
   def org_role?(organisation_id:, role:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,8 +47,8 @@ class User
     Role.owner.find_by(school_id: organisation_id, user_id: id)
   end
 
-  def school_teacher?(organisation_id:)
-    Role.teacher.find_by(school_id: organisation_id, user_id: id)
+  def school_teacher?(school)
+    Role.teacher.find_by(school:, user_id: id)
   end
 
   def school_student?(school)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User
   end
 
   def school_owner?(organisation_id:)
-    org_role?(organisation_id:, role: 'school-owner')
+    Role.owner.find_by(school_id: organisation_id, user_id: id)
   end
 
   def school_teacher?(organisation_id:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,10 +39,6 @@ class User
     Role.where(school:, user_id: id).map(&:role)
   end
 
-  def org_role?(organisation_id:, role:)
-    org_roles(organisation_id:).include?(role.to_s)
-  end
-
   def school_owner?(school)
     Role.owner.find_by(school:, user_id: id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,9 +70,6 @@ class User
       info = info.stringify_keys
       args = info.slice(*ATTRIBUTES)
 
-      # TODO: remove once the UserInfoApi returns the 'organisations' key.
-      temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
       new(args)
     end
   end
@@ -89,9 +86,6 @@ class User
     args = auth.extra.raw_info.to_h.slice(*ATTRIBUTES)
     args['id'] = auth.uid
 
-    # TODO: remove once the OmniAuth info returns the 'organisations' key.
-    temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
     new(args)
   end
 
@@ -107,16 +101,6 @@ class User
     args['id'] ||= auth['sub']
     args['token'] = token
 
-    # TODO: remove once the HydraPublicApi returns the 'organisations' key.
-    temporarily_add_organisations_until_the_profile_app_is_updated(args)
-
     new(args)
-  end
-
-  def self.temporarily_add_organisations_until_the_profile_app_is_updated(hash)
-    return hash if hash.key?('organisations')
-
-    # Use the same organisation ID as the one from users.json for now.
-    hash.merge!('organisations' => { '12345678-1234-1234-1234-123456789abc' => hash['roles'] })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User
     id
     name
     nickname
-    organisations
     picture
     postcode
     profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,8 +51,8 @@ class User
     Role.teacher.find_by(school_id: organisation_id, user_id: id)
   end
 
-  def school_student?(organisation_id:)
-    Role.student.find_by(school_id: organisation_id, user_id: id)
+  def school_student?(school)
+    Role.student.find_by(school:, user_id: id)
   end
 
   def admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,8 +43,8 @@ class User
     org_roles(organisation_id:).include?(role.to_s)
   end
 
-  def school_owner?(organisation_id:)
-    Role.owner.find_by(school_id: organisation_id, user_id: id)
+  def school_owner?(school)
+    Role.owner.find_by(school:, user_id: id)
   end
 
   def school_teacher?(school)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,10 +31,6 @@ class User
     School.joins(:roles).merge(Role.where(user_id: id)).distinct
   end
 
-  def organisation_ids
-    organisations&.keys || []
-  end
-
   def school_roles(school)
     Role.where(school:, user_id: id).map(&:role)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,8 +35,8 @@ class User
     organisations&.keys || []
   end
 
-  def school_roles(organisation_id:)
-    organisations[organisation_id.to_s]&.to_s&.split(',')&.map(&:strip) || []
+  def school_roles(school)
+    organisations[school.id.to_s]&.to_s&.split(',')&.map(&:strip) || []
   end
 
   def org_role?(organisation_id:, role:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User
   end
 
   def school_teacher?(organisation_id:)
-    org_role?(organisation_id:, role: 'school-teacher')
+    Role.teacher.find_by(school_id: organisation_id, user_id: id)
   end
 
   def school_student?(organisation_id:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User
     organisations&.keys || []
   end
 
-  def org_roles(organisation_id:)
+  def school_roles(organisation_id:)
     organisations[organisation_id.to_s]&.to_s&.split(',')&.map(&:strip) || []
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User
   end
 
   def school_student?(organisation_id:)
-    org_role?(organisation_id:, role: 'school-student')
+    Role.student.find_by(school_id: organisation_id, user_id: id)
   end
 
   def admin?

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -10,6 +10,7 @@ class SchoolVerificationService
     School.transaction do
       school = School.find(@school_id)
       school.update(verified_at: Time.zone.now, rejected_at: nil)
+      Role.owner.create(user_id: school.creator_id, school:)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/app/views/api/my_school/show.json.jbuilder
+++ b/app/views/api/my_school/show.json.jbuilder
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+json.call(
+  @school,
+  :id,
+  :name,
+  :website,
+  :reference,
+  :address_line_1,
+  :address_line_2,
+  :municipality,
+  :administrative_area,
+  :postal_code,
+  :country_code,
+  :verified_at,
+  :created_at,
+  :updated_at
+)
+json.roles @user.school_roles(@school)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
 
     resource :project_errors, only: %i[create]
 
+    resource :school, only: [:show], controller: 'my_school'
     resources :schools, only: %i[index show create update destroy] do
       resources :classes, only: %i[index show create update destroy], controller: 'school_classes' do
         resources :members, only: %i[index create destroy], controller: 'class_members'

--- a/db/migrate/20240509104834_add_roles.rb
+++ b/db/migrate/20240509104834_add_roles.rb
@@ -1,0 +1,12 @@
+class AddRoles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :roles do |t|
+      t.belongs_to :user, type: :uuid
+      t.belongs_to :school, type: :uuid, foreign_key: true
+      t.integer :role
+      t.timestamps
+    end
+
+    add_index :roles, [:user_id, :school_id, :role], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -173,6 +173,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_23_143911) do
     t.index ["school_id"], name: "index_projects_on_school_id"
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.uuid "user_id"
+    t.uuid "school_id"
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["school_id"], name: "index_roles_on_school_id"
+    t.index ["user_id", "school_id", "role"], name: "index_roles_on_user_id_and_school_id_and_role", unique: true
+    t.index ["user_id"], name: "index_roles_on_user_id"
+  end
+
   create_table "school_classes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false
     t.uuid "teacher_id", null: false
@@ -215,5 +226,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_23_143911) do
   add_foreign_key "project_errors", "projects"
   add_foreign_key "projects", "lessons"
   add_foreign_key "projects", "schools"
+  add_foreign_key "roles", "schools"
   add_foreign_key "school_classes", "schools"
 end

--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :role, aliases: [:owner_role] do
+    school
+    user_id { SecureRandom.uuid }
+    role    { :owner }
+  end
+
+  factory :teacher_role, parent: :role do
+    role { :teacher }
+  end
+
+  factory :student_role, parent: :role do
+    role { :student }
+  end
+end

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     address_line_1 { 'Address Line 1' }
     municipality { 'Greater London' }
     country_code { 'GB' }
+    creator_id { SecureRandom.uuid }
     creator_agree_authority { true }
     creator_agree_terms_and_conditions { true }
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     name { Faker::Name.name }
     email { Faker::Internet.email }
-    organisations { {} }
 
     factory :admin_user do
       roles { 'editor-admin' }

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Creating a class member', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Creating a class member', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Deleting a class member', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Listing class members', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Listing class members', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Archiving a lesson', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       delete("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Archiving a lesson', type: :request do
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
       user_id = SecureRandom.uuid
       stub_user_info_api_for_unknown_users(user_id:)
-      authenticate_as_school_teacher
+      authenticate_as_school_teacher(school_id: school.id)
       lesson.update!(user_id:)
 
       delete("/api/lessons/#{lesson.id}", headers:)

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Creating a copy of a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       post("/api/lessons/#{lesson.id}/copy", headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     it 'responds 403 Forbidden when the current user is a school-teacher for a different class' do
       teacher_id = SecureRandom.uuid
       stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      authenticate_as_school_teacher
+      authenticate_as_school_teacher(school_id: school.id)
       school_class.update!(teacher_id:)
 
       post('/api/lessons', headers:, params:)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe 'Creating a lesson', type: :request do
 
     it 'responds 403 Forbidden when the user is a school-owner for a different school' do
       Role.teacher.find_by(user_id: teacher_id, school:).delete
+      Role.owner.find_by(user_id: owner_id, school:).delete
       school.update!(id: SecureRandom.uuid)
 
       post('/api/lessons', headers:, params:)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe 'Creating a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+      Role.teacher.find_by(user_id: teacher_id, school:).delete
       school.update!(id: SecureRandom.uuid)
 
       post('/api/lessons', headers:, params:)

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Listing lessons', type: :request do
     end
 
     it 'does not include the lesson when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)
@@ -164,7 +164,7 @@ RSpec.describe 'Listing lessons', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it "does not include the lesson when the user is not a school-student within the lesson's class" do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       get('/api/lessons', headers:)
       data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)
@@ -135,7 +135,7 @@ RSpec.describe 'Showing a lesson', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it "responds 403 Forbidden when the user is a school-student but isn't within the lesson's class" do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Updating a lesson', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       put("/api/lessons/#{lesson.id}", headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Updating a lesson', type: :request do
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
       user_id = SecureRandom.uuid
       stub_user_info_api_for_unknown_users(user_id:)
-      authenticate_as_school_teacher
+      authenticate_as_school_teacher(school_id: school.id)
       lesson.update!(user_id:)
 
       put("/api/lessons/#{lesson.id}", headers:, params:)

--- a/spec/features/my_school/showing_my_school_spec.rb
+++ b/spec/features/my_school/showing_my_school_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Showing my school', type: :request do
+  before do
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
+  end
+
+  let!(:school) { create(:school, name: 'school-name') }
+  let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:owner_id) { SecureRandom.uuid }
+
+  it 'responds 200 OK' do
+    get('/api/school', headers:)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "includes the school details and user's roles in the JSON" do
+    school_json = school.to_json(only: %i[id name website reference address_line_1 address_line_2 municipality administrative_area postal_code country_code verified_at created_at updated_at])
+    expected_data = JSON.parse(school_json, symbolize_names: true).merge(roles: ['owner'])
+
+    get('/api/school', headers:)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data).to eq(expected_data)
+  end
+
+  it "responds 404 Not Found when the user doesn't have a role in any school" do
+    Role.find_by(school:, user_id: owner_id).delete
+    get('/api/school', headers:)
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'responds 401 Unauthorized when no token is given' do
+    get '/api/school'
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a project', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_user_info_api_for_teacher(teacher_id:, school_id: school.id)
     mock_phrase_generation
   end
@@ -12,6 +12,7 @@ RSpec.describe 'Creating a project', type: :request do
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:teacher_id) { SecureRandom.uuid }
   let(:school) { create(:school) }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -108,6 +109,7 @@ RSpec.describe 'Creating a project', type: :request do
 
     it 'responds 403 Forbidden when the user is a school-owner for a different school' do
       Role.teacher.find_by(user_id: teacher_id, school:).delete
+      Role.owner.find_by(user_id: owner_id, school:).delete
       school.update!(id: SecureRandom.uuid)
 
       post('/api/projects', headers:, params:)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'Creating a project', type: :request do
     # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the current user is not the owner of the lesson' do
       user_id = SecureRandom.uuid
-      authenticate_as_school_teacher
+      authenticate_as_school_teacher(school_id: school.id)
       stub_user_info_api_for_unknown_users(user_id:)
       lesson.update!(user_id:)
 

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+      Role.teacher.find_by(user_id: teacher_id, school:).delete
       school.update!(id: SecureRandom.uuid)
 
       post('/api/projects', headers:, params:)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe 'Creating a project', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
-      authenticate_as_school_student
+      authenticate_as_school_student(school_id: school.id)
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:forbidden)

--- a/spec/features/project/updating_a_project_spec.rb
+++ b/spec/features/project/updating_a_project_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a project', type: :request do
   before do
-    authenticate_as_school_owner(owner_id:)
+    authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
 
     create(:component, project:, name: 'main', extension: 'py', content: 'print("hi")')
   end

--- a/spec/features/school/creating_a_school_spec.rb
+++ b/spec/features/school/creating_a_school_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school', type: :request do
   before do
-    authenticate_as_school_owner
+    authenticate_as_school_owner(school_id: SecureRandom.uuid)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Deleting a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     delete("/api/schools/#{school.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Deleting a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school/deleting_a_school_spec.rb
+++ b/spec/features/school/deleting_a_school_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a school', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 204 No Content' do
     delete("/api/schools/#{school.id}", headers:)
@@ -21,6 +22,7 @@ RSpec.describe 'Deleting a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}", headers:)

--- a/spec/features/school/showing_a_school_spec.rb
+++ b/spec/features/school/showing_a_school_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 
 RSpec.describe 'Showing a school', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
   end
 
   let!(:school) { create(:school, name: 'Test School') }
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}", headers:)
@@ -33,6 +34,7 @@ RSpec.describe 'Showing a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user belongs to a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}", headers:)

--- a/spec/features/school/updating_a_school_spec.rb
+++ b/spec/features/school/updating_a_school_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Updating a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is not a school-owner' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     put("/api/schools/#{school.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school/updating_a_school_spec.rb
+++ b/spec/features/school/updating_a_school_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a school', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
   end
 
   let!(:school) { create(:school) }
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -58,6 +59,7 @@ RSpec.describe 'Updating a school', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     put("/api/schools/#{school.id}", headers:, params:)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.teacher.find_by(user_id: teacher_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/classes", headers:, params:)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school class', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_user_info_api_for_teacher(teacher_id:, school_id: school.id)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:teacher_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -95,6 +96,7 @@ RSpec.describe 'Creating a school class', type: :request do
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
     Role.teacher.find_by(user_id: teacher_id, school:).delete
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/classes", headers:, params:)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Creating a school class', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/classes", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Deleting a school class', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Showing a school class', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Showing a school class', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is not a school-student for the class' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Updating a school class', type: :request do
   # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Updating a school class', type: :request do
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
     teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
     school_class.update!(teacher_id:)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/owners", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     post("/api/schools/#{school.id}/owners", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Inviting a school owner', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_invite_school_owner
   end
 
@@ -41,6 +41,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/owners", headers:, params:)

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school owners', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(owner_id:, school_id: school.id)
     stub_profile_api_list_school_owners(user_id: owner_id)
     stub_user_info_api_for_owner(owner_id:, school_id: school.id)
   end
@@ -38,6 +38,7 @@ RSpec.describe 'Listing school owners', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/owners", headers:)

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Listing school owners', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     get("/api/schools/#{school.id}/owners", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Removing a school owner', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_remove_school_owner
   end
 
@@ -23,6 +23,7 @@ RSpec.describe 'Removing a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}/owners/#{owner_id}", headers:)

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Removing a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     delete("/api/schools/#{school.id}/owners/#{owner_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_owner/removing_a_school_owner_spec.rb
+++ b/spec/features/school_owner/removing_a_school_owner_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Removing a school owner', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}/owners/#{owner_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a batch of school students', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_create_school_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school, verified_at: Time.zone.now) }
   let(:student_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:file) { fixture_file_upload('students.csv') }
 
@@ -37,6 +38,7 @@ RSpec.describe 'Creating a batch of school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/students/batch", headers:, params: { file: })

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Creating a batch of school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/students/batch", headers:, params: { file: })
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Creating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/students", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a school student', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_create_school_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -49,6 +50,7 @@ RSpec.describe 'Creating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/students", headers:, params:)

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a school student', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_delete_school_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:student_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 204 No Content' do
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
@@ -23,6 +24,7 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Listing school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     get("/api/schools/#{school.id}/students", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Listing school students', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.student.find_by(user_id: student_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/students", headers:)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school students', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_list_school_students(user_id: student_id)
     stub_user_info_api_for_student(student_id:, school_id: school.id)
   end
@@ -12,6 +12,7 @@ RSpec.describe 'Listing school students', type: :request do
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:student_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}/students", headers:)
@@ -39,6 +40,7 @@ RSpec.describe 'Listing school students', type: :request do
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
     Role.student.find_by(user_id: student_id, school:).delete
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/students", headers:)

--- a/spec/features/school_student/updating_a_school_student_spec.rb
+++ b/spec/features/school_student/updating_a_school_student_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Updating a school student', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_update_school_student
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:student_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -40,6 +41,7 @@ RSpec.describe 'Updating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     put("/api/schools/#{school.id}/students/#{student_id}", headers:, params:)

--- a/spec/features/school_student/updating_a_school_student_spec.rb
+++ b/spec/features/school_student/updating_a_school_student_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Updating a school student', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     put("/api/schools/#{school.id}/students/#{student_id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     post("/api/schools/#{school.id}/teachers", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     post("/api/schools/#{school.id}/teachers", headers:, params:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Inviting a school teacher', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_invite_school_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school, verified_at: Time.zone.now) }
   let(:teacher_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   let(:params) do
     {
@@ -41,6 +42,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     post("/api/schools/#{school.id}/teachers", headers:, params:)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Listing school teachers', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_list_school_teachers(user_id: teacher_id)
     stub_user_info_api_for_teacher(teacher_id:, school_id: school.id)
   end
@@ -12,6 +12,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:teacher_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}/teachers", headers:)
@@ -39,6 +40,7 @@ RSpec.describe 'Listing school teachers', type: :request do
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
     Role.teacher.find_by(user_id: teacher_id, school:).delete
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/teachers", headers:)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     get("/api/schools/#{school.id}/teachers", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/listing_school_teachers_spec.rb
+++ b/spec/features/school_teacher/listing_school_teachers_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Listing school teachers', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.teacher.find_by(user_id: teacher_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     get("/api/schools/#{school.id}/teachers", headers:)

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Removing a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-teacher' do
-    authenticate_as_school_teacher
+    authenticate_as_school_teacher(school_id: school.id)
 
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Removing a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do
-    authenticate_as_school_student
+    authenticate_as_school_student(school_id: school.id)
 
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)
     expect(response).to have_http_status(:forbidden)

--- a/spec/features/school_teacher/removing_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/removing_a_school_teacher_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe 'Removing a school teacher', type: :request do
   before do
-    authenticate_as_school_owner(school_id: school.id)
+    authenticate_as_school_owner(school_id: school.id, owner_id:)
     stub_profile_api_remove_school_teacher
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:teacher_id) { SecureRandom.uuid }
+  let(:owner_id) { SecureRandom.uuid }
 
   it 'responds 204 No Content' do
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)
@@ -23,6 +24,7 @@ RSpec.describe 'Removing a school teacher', type: :request do
   end
 
   it 'responds 403 Forbidden when the user is a school-owner for a different school' do
+    Role.owner.find_by(user_id: owner_id, school:).delete
     school.update!(id: SecureRandom.uuid)
 
     delete("/api/schools/#{school.id}/teachers/#{teacher_id}", headers:)

--- a/spec/fixtures/users.json
+++ b/spec/fixtures/users.json
@@ -16,10 +16,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-owner",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-owner"
-      }
+      "roles": "school-owner"
     },
     {
       "id": "11111111-1111-1111-1111-111111111111",
@@ -37,10 +34,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-teacher",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-teacher"
-      }
+      "roles": "school-teacher"
     },
     {
       "id": "22222222-2222-2222-2222-222222222222",
@@ -58,10 +52,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-student",
-      "organisations": {
-        "12345678-1234-1234-1234-123456789abc": "school-student"
-      }
+      "roles": "school-student"
     },
     {
       "id": "33333333-3333-3333-3333-333333333333",

--- a/spec/fixtures/users.json
+++ b/spec/fixtures/users.json
@@ -16,7 +16,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-owner"
+      "roles": ""
     },
     {
       "id": "11111111-1111-1111-1111-111111111111",
@@ -34,7 +34,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-teacher"
+      "roles": ""
     },
     {
       "id": "22222222-2222-2222-2222-222222222222",
@@ -52,7 +52,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-student"
+      "roles": ""
     },
     {
       "id": "33333333-3333-3333-3333-333333333333",
@@ -70,7 +70,7 @@
       "updatedAt": "2024-01-01T12:00:00.000Z",
       "discardedAt": null,
       "lastLoggedInAt": "2024-01-01T12:00:00.000Z",
-      "roles": "school-student"
+      "roles": ""
     }
   ]
 }

--- a/spec/graphql/mutations/create_component_mutation_spec.rb
+++ b/spec/graphql/mutations/create_component_mutation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'mutation CreateComponent() { ... }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     it 'returns the component ID' do

--- a/spec/graphql/mutations/create_project_mutation_spec.rb
+++ b/spec/graphql/mutations/create_project_mutation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'mutation CreateProject() { ... }' do
     let(:current_user) { stubbed_user }
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
       mock_phrase_generation
     end
 

--- a/spec/graphql/mutations/delete_project_mutation_spec.rb
+++ b/spec/graphql/mutations/delete_project_mutation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
   subject(:result) { execute_query(query: mutation, variables:) }
 
   before do
-    authenticate_as_school_owner
+    authenticate_as_school_owner(school_id: SecureRandom.uuid)
   end
 
   let(:mutation) { 'mutation DeleteProject($project: DeleteProjectInput!) { deleteProject(input: $project) { id } }' }
@@ -41,7 +41,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
       let(:current_user) { stubbed_user }
 
       before do
-        authenticate_as_school_owner(owner_id: stubbed_user.id)
+        authenticate_as_school_owner(owner_id: stubbed_user.id, school_id: SecureRandom.uuid)
       end
 
       it 'deletes the project' do

--- a/spec/graphql/mutations/delete_project_mutation_spec.rb
+++ b/spec/graphql/mutations/delete_project_mutation_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'mutation DeleteProject() { ... }' do
 
       context 'with another users project' do
         before do
-          authenticate_as_school_teacher
+          authenticate_as_school_teacher(school_id: SecureRandom.uuid)
         end
 
         it 'returns an error' do

--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
   let(:remix_origin) { 'editor.com' }
 
   before do
-    authenticate_as_school_owner
+    authenticate_as_school_owner(school_id: SecureRandom.uuid)
     project
   end
 

--- a/spec/graphql/mutations/remix_project_mutation_spec.rb
+++ b/spec/graphql/mutations/remix_project_mutation_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'mutation RemixProject() { ... }' do
 
   context 'when user cannot view original project' do
     before do
-      authenticate_as_school_teacher
+      authenticate_as_school_teacher(school_id: SecureRandom.uuid)
     end
 
     it 'returns "not permitted to read" error' do

--- a/spec/graphql/mutations/update_component_mutation_spec.rb
+++ b/spec/graphql/mutations/update_component_mutation_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'mutation UpdateComponent() { ... }' do
 
       context 'with another users component' do
         before do
-          authenticate_as_school_teacher
+          authenticate_as_school_teacher(school_id: SecureRandom.uuid)
         end
 
         it 'returns an error' do

--- a/spec/graphql/mutations/update_component_mutation_spec.rb
+++ b/spec/graphql/mutations/update_component_mutation_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'mutation UpdateComponent() { ... }' do
 
   context 'with an existing component' do
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     let(:project) { create(:project, user_id: stubbed_user.id) }

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
   subject(:result) { execute_query(query: mutation, variables:) }
 
   before do
-    authenticate_as_school_owner
+    authenticate_as_school_owner(school_id: SecureRandom.uuid)
   end
 
   let(:mutation) { 'mutation UpdateProject($project: UpdateProjectInput!) { updateProject(input: $project) { project { id } } }' }
@@ -30,7 +30,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
     before do
       # Instantiate project
       project
-      authenticate_as_school_owner(owner_id: stubbed_user.id)
+      authenticate_as_school_owner(owner_id: stubbed_user.id, school_id: SecureRandom.uuid)
     end
 
     context 'when unauthenticated' do

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
 
       context 'with another users project' do
         before do
-          authenticate_as_school_teacher
+          authenticate_as_school_teacher(school_id: SecureRandom.uuid)
         end
 
         it 'returns an error' do

--- a/spec/graphql/queries/project_query_spec.rb
+++ b/spec/graphql/queries/project_query_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'query { project { ... } }' do
       let(:project) { create(:project, user_id: stubbed_user.id) }
 
       before do
-        authenticate_as_school_owner
+        authenticate_as_school_owner(school_id: SecureRandom.uuid)
       end
 
       it 'returns the project global id' do

--- a/spec/graphql/queries/projects_query_spec.rb
+++ b/spec/graphql/queries/projects_query_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'projects { }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     it { expect(query).to be_a_valid_graphql_query }
@@ -87,7 +87,7 @@ RSpec.describe 'projects { }' do
     let(:project) { create(:project, user_id: stubbed_user.id) }
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     it { expect(query).to be_a_valid_graphql_query }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Ability do
 
     context 'when user is a school student' do
       before do
-        user.organisations = { school.id => 'school-student' }
+        create(:student_role, user_id: user.id, school:)
       end
 
       it { is_expected.to be_able_to(:read, school) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Ability do
 
     context 'when user is a school teacher' do
       before do
-        user.organisations = { school.id => 'school-teacher' }
+        create(:teacher_role, user_id: user.id, school:)
       end
 
       it { is_expected.to be_able_to(:read, school) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Ability do
 
     context 'when user is a school owner' do
       before do
-        user.organisations = { school.id => 'school-owner' }
+        create(:owner_role, user_id: user.id, school:)
       end
 
       it { is_expected.to be_able_to(:read, school) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -114,12 +114,46 @@ RSpec.describe Ability do
   end
 
   describe 'School' do
-    let(:school) { build(:school, creator_id: user_id, verified_at: nil) }
+    let(:school) { create(:school) }
+    let(:user) { build(:user) }
 
     context 'when user is not a school-owner but is the creator of the school' do
-      let(:user) { build(:user, id: user_id) }
+      before do
+        user.id = user_id
+        school.update(creator_id: user_id, verified_at: nil)
+      end
 
       it { is_expected.to be_able_to(:read, school) }
+    end
+
+    context 'when user is a school owner' do
+      before do
+        user.organisations = { school.id => 'school-owner' }
+      end
+
+      it { is_expected.to be_able_to(:read, school) }
+      it { is_expected.to be_able_to(:update, school) }
+      it { is_expected.to be_able_to(:destroy, school) }
+    end
+
+    context 'when user is a school teacher' do
+      before do
+        user.organisations = { school.id => 'school-teacher' }
+      end
+
+      it { is_expected.to be_able_to(:read, school) }
+      it { is_expected.not_to be_able_to(:update, school) }
+      it { is_expected.not_to be_able_to(:destroy, school) }
+    end
+
+    context 'when user is a school student' do
+      before do
+        user.organisations = { school.id => 'school-student' }
+      end
+
+      it { is_expected.to be_able_to(:read, school) }
+      it { is_expected.not_to be_able_to(:update, school) }
+      it { is_expected.not_to be_able_to(:destroy, school) }
     end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -138,5 +138,26 @@ RSpec.describe Role do
         expect(role.errors[:base]).to include('Cannot create student role as this user already has the owner and teacher roles for this school')
       end
     end
+
+    context 'when a user has a role within a school' do
+      let(:user) { build(:user) }
+      let(:school_1) { build(:school) }
+      let(:school_2) { build(:school) }
+
+      before do
+        create(:role, user_id: user.id, school: school_1)
+      end
+
+      it 'prevents the user from having a role within a different school' do
+        role = build(:role, user_id: user.id, school: school_2)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain that a user can only have roles within a single school' do
+        role = build(:role, user_id: user.id, school: school_2)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create role as this user already has a role in a different school')
+      end
+    end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -38,5 +38,105 @@ RSpec.describe Role do
       duplicate_role = build(:role, school: role.school, user_id: role.user_id, role: role.role)
       expect(duplicate_role).to be_invalid
     end
+
+    context 'when the student role exists for a user and school' do
+      let(:user) { build(:user) }
+      let(:school) { build(:school) }
+
+      before do
+        create(:student_role, user_id: user.id, school:)
+      end
+
+      it 'prevents an owner role being created for the user and school' do
+        role = build(:owner_role, user_id: user.id, school:)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain why the owner role cannot be created' do
+        role = build(:owner_role, user_id: user.id, school:)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create owner role as this user already has the student role for this school')
+      end
+
+      it 'prevents a teacher role being created for the user and school' do
+        role = build(:teacher_role, user_id: user.id, school:)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain why the teacher role cannot be created' do
+        role = build(:teacher_role, user_id: user.id, school:)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create teacher role as this user already has the student role for this school')
+      end
+    end
+
+    context 'when the teacher role exists for a user and school' do
+      let(:user) { build(:user) }
+      let(:school) { build(:school) }
+
+      before do
+        create(:teacher_role, user_id: user.id, school:)
+      end
+
+      it 'allows an owner role to be created for the user and school' do
+        expect(create(:owner_role, user_id: user.id, school:)).to be_persisted
+      end
+
+      it 'prevents a student role being created for the user and school' do
+        role = build(:student_role, user_id: user.id, school:)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain why the student role cannot be created' do
+        role = build(:student_role, user_id: user.id, school:)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create student role as this user already has the teacher role for this school')
+      end
+    end
+
+    context 'when the owner role exists for a user and school' do
+      let(:user) { build(:user) }
+      let(:school) { build(:school) }
+
+      before do
+        create(:owner_role, user_id: user.id, school:)
+      end
+
+      it 'allows a teacher role to be created for the user and school' do
+        expect(create(:teacher_role, user_id: user.id, school:)).to be_persisted
+      end
+
+      it 'prevents a student role being created for the user and school' do
+        role = build(:student_role, user_id: user.id, school:)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain why the student role cannot be created' do
+        role = build(:student_role, user_id: user.id, school:)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create student role as this user already has the owner role for this school')
+      end
+    end
+
+    context 'when the owner and teacher roles exist for a user and school' do
+      let(:user) { build(:user) }
+      let(:school) { build(:school) }
+
+      before do
+        create(:owner_role, user_id: user.id, school:)
+        create(:teacher_role, user_id: user.id, school:)
+      end
+
+      it 'prevents a student role being created for the user and school' do
+        role = build(:student_role, user_id: user.id, school:)
+        expect(role).to be_invalid
+      end
+
+      it 'adds a message to explain why the student role cannot be created' do
+        role = build(:student_role, user_id: user.id, school:)
+        role.valid?
+        expect(role.errors[:base]).to include('Cannot create student role as this user already has the owner and teacher roles for this school')
+      end
+    end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Role do
+  describe 'validations' do
+    subject(:role) { build(:role) }
+
+    it 'has a valid default factory' do
+      expect(role).to be_valid
+    end
+
+    it 'can save the default factory' do
+      expect { role.save! }.not_to raise_error
+    end
+
+    it 'requires a school' do
+      role.school = nil
+      expect(role).to be_invalid
+    end
+
+    it 'requires a user_id' do
+      role.user_id = nil
+      expect(role).to be_invalid
+    end
+
+    it 'requires a role' do
+      role.role = nil
+      expect(role).to be_invalid
+    end
+
+    it 'requires a valid role' do
+      expect { role.role = 'made-up-role' }.to raise_exception(ArgumentError, /is not a valid role/)
+    end
+
+    it 'requires role to be unique for the combination of user and school' do
+      role.save
+      duplicate_role = build(:role, school: role.school, user_id: role.user_id, role: role.role)
+      expect(duplicate_role).to be_invalid
+    end
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe School do
 
   let(:student_id) { SecureRandom.uuid }
   let(:teacher_id) { SecureRandom.uuid }
-  let(:school) { create(:school) }
+  let(:school) { create(:school, creator_id: SecureRandom.uuid) }
 
   describe 'associations' do
     it 'has many classes' do
@@ -152,6 +152,23 @@ RSpec.describe School do
     it 'requires creator_agree_terms_and_conditions to be true' do
       school.creator_agree_terms_and_conditions = false
       expect(school).to be_invalid
+    end
+  end
+
+  describe '#user' do
+    let(:creator_id) { SecureRandom.uuid }
+
+    before do
+      school.update!(creator_id:)
+      stub_user_info_api_for_owner(owner_id: creator_id, school_id: school.id)
+    end
+
+    it 'returns a User instance' do
+      expect(school.user).to be_instance_of(User)
+    end
+
+    it 'returns the user from the UserInfo API matching the creator_id' do
+      expect(school.user.id).to eq(creator_id)
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe School do
       expect(school).to be_invalid
     end
 
+    it 'requires a creator_id' do
+      school.creator_id = nil
+      expect(school).to be_invalid
+    end
+
     it 'rejects a badly formed url for website' do
       school.website = 'http://.example.com'
       expect(school).to be_invalid

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe School do
     end
 
     it 'has many roles' do
+      Role.delete_all
       create(:student_role, school:)
       create(:owner_role, school:)
       expect(school.roles.size).to eq(2)

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -31,11 +31,18 @@ RSpec.describe School do
       expect(school.projects.size).to eq(2)
     end
 
+    it 'has many roles' do
+      create(:student_role, school:)
+      create(:owner_role, school:)
+      expect(school.roles.size).to eq(2)
+    end
+
     context 'when a school is destroyed' do
       let!(:school_class) { create(:school_class, school:, teacher_id:) }
       let!(:lesson_1) { create(:lesson, user_id: teacher_id, school_class:) }
       let!(:lesson_2) { create(:lesson, user_id: teacher_id, school:) }
       let!(:project) { create(:project, user_id: student_id, school:) }
+      let!(:role) { create(:role, school:) }
 
       before do
         create(:class_member, school_class:, student_id:)
@@ -69,6 +76,15 @@ RSpec.describe School do
       it 'nullifies the school_id field on projects' do
         school.destroy!
         expect(project.reload.school_id).to be_nil
+      end
+
+      it 'does not destroy roles' do
+        expect { school.destroy! }.not_to change(Role, :count)
+      end
+
+      it 'nullifies the school_id field on roles' do
+        school.destroy!
+        expect(role.reload.school_id).to be_nil
       end
     end
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -188,4 +188,16 @@ RSpec.describe School do
       expect(school.user.id).to eq(creator_id)
     end
   end
+
+  describe '.find_for_user!' do
+    it 'returns the school that the user has a role in' do
+      user = User.where(id: teacher_id).first
+      expect(described_class.find_for_user!(user)).to eq(school)
+    end
+
+    it "raises ActiveRecord::RecordNotFound if the user doesn't have a role in a school" do
+      user = build(:user)
+      expect { described_class.find_for_user!(user) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -261,21 +261,21 @@ RSpec.describe User do
   end
 
   describe '#school_roles' do
-    subject(:user) { build(:user, roles:, organisations:) }
+    subject(:user) { build(:user) }
 
     let(:school) { create(:school) }
-    let(:organisations) { { '12345678-1234-1234-1234-123456789abc' => roles } }
 
     context 'when the user has no roles' do
-      let(:roles) { '' }
-
       it 'returns an empty array if the user has no role in this school' do
         expect(user.school_roles(school)).to be_empty
       end
     end
 
     context 'when the user has an organisation and roles' do
-      let(:roles) { 'owner,teacher' }
+      before do
+        create(:role, school:, user_id: user.id, role: 'owner')
+        create(:role, school:, user_id: user.id, role: 'teacher')
+      end
 
       it 'returns an array of the roles the user has at the school' do
         expect(user.school_roles(school)).to match_array(%w[owner teacher])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe User do
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:name) }
   it { is_expected.to respond_to(:email) }
-  it { is_expected.to respond_to(:organisations) }
 
   describe '.from_userinfo' do
     subject(:users) { described_class.from_userinfo(ids:) }
@@ -42,10 +41,6 @@ RSpec.describe User do
     it 'returns a user with the correct email' do
       expect(user.email).to eq 'school-owner@example.com'
     end
-
-    it 'returns a user with the correct organisations' do
-      expect(user.organisations).to eq(organisation_id => 'school-owner')
-    end
   end
 
   describe '.from_token' do
@@ -71,10 +66,6 @@ RSpec.describe User do
 
     it 'returns a user with the correct email' do
       expect(user.email).to eq 'school-owner@example.com'
-    end
-
-    it 'returns a user with the correct organisations' do
-      expect(user.organisations).to eq(organisation_id => 'school-owner')
     end
 
     context 'when BYPASS_AUTH is true' do
@@ -136,14 +127,6 @@ RSpec.describe User do
 
     it 'returns a user with the correct email' do
       expect(user.email).to eq 'john.doe@example.com'
-    end
-
-    context 'when info includes organisations' do
-      let(:info) { info_without_organisations.merge!('organisations' => { 'c78ab987-5fa8-482e-a9cf-a5e93513349b' => 'school-student' }) }
-
-      it 'returns a user with the supplied organisations' do
-        expect(auth_subject.organisations).to eq('c78ab987-5fa8-482e-a9cf-a5e93513349b' => 'school-student')
-      end
     end
 
     context 'with unusual keys in info' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,16 +47,6 @@ RSpec.describe User do
     it 'returns a user with the correct organisations' do
       expect(user.organisations).to eq(organisation_id => 'school-owner')
     end
-
-    context 'when no organisations are returned' do
-      let(:ids) { [SecureRandom.uuid] }
-
-      it 'returns a user with the correct organisations' do
-        stub_user_info_api_for_student_without_organisations(student_id: ids.first)
-
-        expect(user.organisations).to eq('12345678-1234-1234-1234-123456789abc' => 'school-student')
-      end
-    end
   end
 
   describe '.from_token' do
@@ -86,16 +76,6 @@ RSpec.describe User do
 
     it 'returns a user with the correct organisations' do
       expect(user.organisations).to eq(organisation_id => 'school-owner')
-    end
-
-    context 'when no organisations are returned' do
-      before do
-        authenticate_as_school_student_without_organisations
-      end
-
-      it 'returns a user with the correct organisations' do
-        expect(user.organisations).to eq('12345678-1234-1234-1234-123456789abc' => 'school-student')
-      end
     end
 
     context 'when BYPASS_AUTH is true' do
@@ -157,10 +137,6 @@ RSpec.describe User do
 
     it 'returns a user with the correct email' do
       expect(user.email).to eq 'john.doe@example.com'
-    end
-
-    it 'returns a user with the correct organisations' do
-      expect(auth_subject.organisations).to eq('12345678-1234-1234-1234-123456789abc' => 'school-student')
     end
 
     context 'when info includes organisations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -228,9 +228,19 @@ RSpec.describe User do
   end
 
   describe '#school_owner?' do
-    subject { user.school_owner?(organisation_id:) }
+    subject(:user) { create(:user) }
 
-    include_examples 'role_check', 'school-owner'
+    let(:school) { create(:school) }
+
+    it 'returns true when the user has the owner role for this school' do
+      create(:owner_role, school:, user_id: user.id)
+      expect(user).to be_school_owner(organisation_id: school.id)
+    end
+
+    it 'returns false when the user does not have the owner role for this school' do
+      create(:teacher_role, school:, user_id: user.id)
+      expect(user).not_to be_school_owner(organisation_id: school.id)
+    end
   end
 
   describe '#school_teacher?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -260,6 +260,29 @@ RSpec.describe User do
     end
   end
 
+  describe '#org_roles' do
+    subject(:user) { build(:user, roles:, organisations:) }
+
+    let(:school) { create(:school) }
+    let(:organisations) { { '12345678-1234-1234-1234-123456789abc' => roles } }
+
+    context 'when the user has no roles' do
+      let(:roles) { '' }
+
+      it 'returns an empty array if the user has no role in this school' do
+        expect(user.org_roles(organisation_id: school.id)).to be_empty
+      end
+    end
+
+    context 'when the user has an organisation and roles' do
+      let(:roles) { 'owner,teacher' }
+
+      it 'returns an array of the roles the user has at the school' do
+        expect(user.org_roles(organisation_id: school.id)).to match_array(%w[owner teacher])
+      end
+    end
+  end
+
   describe '.where' do
     subject(:user) { described_class.where(id: owner_id).first }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe User do
       let(:roles) { '' }
 
       it 'returns an empty array if the user has no role in this school' do
-        expect(user.school_roles(organisation_id: school.id)).to be_empty
+        expect(user.school_roles(school)).to be_empty
       end
     end
 
@@ -278,7 +278,7 @@ RSpec.describe User do
       let(:roles) { 'owner,teacher' }
 
       it 'returns an array of the roles the user has at the school' do
-        expect(user.school_roles(organisation_id: school.id)).to match_array(%w[owner teacher])
+        expect(user.school_roles(school)).to match_array(%w[owner teacher])
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe User do
   it { is_expected.to respond_to(:name) }
   it { is_expected.to respond_to(:email) }
   it { is_expected.to respond_to(:organisations) }
-  it { is_expected.to respond_to(:organisation_ids) }
 
   describe '.from_userinfo' do
     subject(:users) { described_class.from_userinfo(ids:) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,9 +234,19 @@ RSpec.describe User do
   end
 
   describe '#school_teacher?' do
-    subject { user.school_teacher?(organisation_id:) }
+    subject(:user) { create(:user) }
 
-    include_examples 'role_check', 'school-teacher'
+    let(:school) { create(:school) }
+
+    it 'returns true when the user has the teacher role for this school' do
+      create(:teacher_role, school:, user_id: user.id)
+      expect(user).to be_school_teacher(organisation_id: school.id)
+    end
+
+    it 'returns false when the user does not have the teacher role for this school' do
+      create(:owner_role, school:, user_id: user.id)
+      expect(user).not_to be_school_teacher(organisation_id: school.id)
+    end
   end
 
   describe '#school_student?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -266,12 +266,12 @@ RSpec.describe User do
 
     it 'returns true when the user has the student role for this school' do
       create(:student_role, school:, user_id: user.id)
-      expect(user).to be_school_student(organisation_id: school.id)
+      expect(user).to be_school_student(school)
     end
 
     it 'returns false when the user does not have the student role for this school' do
       create(:owner_role, school:, user_id: user.id)
-      expect(user).not_to be_school_student(organisation_id: school.id)
+      expect(user).not_to be_school_student(school)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  subject { build(:user) }
+  subject(:user) { build(:user) }
 
   let(:school) { create(:school) }
   let(:organisation_id) { school.id }
@@ -309,6 +309,33 @@ RSpec.describe User do
       it 'returns a stubbed user' do
         expect(user.name).to eq('School Owner')
       end
+    end
+  end
+
+  describe '#schools' do
+    it 'includes schools where the user has the owner role' do
+      create(:owner_role, school:, user_id: user.id)
+      expect(user.schools).to eq([school])
+    end
+
+    it 'includes schools where the user has the teacher role' do
+      create(:teacher_role, school:, user_id: user.id)
+      expect(user.schools).to eq([school])
+    end
+
+    it 'includes schools where the user has the student role' do
+      create(:student_role, school:, user_id: user.id)
+      expect(user.schools).to eq([school])
+    end
+
+    it 'does not include schools where the user has no role' do
+      expect(user.schools).to be_empty
+    end
+
+    it 'only includes a school once even if the user has multiple roles' do
+      create(:owner_role, school:, user_id: user.id)
+      create(:teacher_role, school:, user_id: user.id)
+      expect(user.schools).to eq([school])
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -240,9 +240,19 @@ RSpec.describe User do
   end
 
   describe '#school_student?' do
-    subject { user.school_student?(organisation_id:) }
+    subject(:user) { create(:user) }
 
-    include_examples 'role_check', 'school-student'
+    let(:school) { create(:school) }
+
+    it 'returns true when the user has the student role for this school' do
+      create(:student_role, school:, user_id: user.id)
+      expect(user).to be_school_student(organisation_id: school.id)
+    end
+
+    it 'returns false when the user does not have the student role for this school' do
+      create(:owner_role, school:, user_id: user.id)
+      expect(user).not_to be_school_student(organisation_id: school.id)
+    end
   end
 
   describe '#admin?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe User do
     end
   end
 
-  describe '#org_roles' do
+  describe '#school_roles' do
     subject(:user) { build(:user, roles:, organisations:) }
 
     let(:school) { create(:school) }
@@ -270,7 +270,7 @@ RSpec.describe User do
       let(:roles) { '' }
 
       it 'returns an empty array if the user has no role in this school' do
-        expect(user.org_roles(organisation_id: school.id)).to be_empty
+        expect(user.school_roles(organisation_id: school.id)).to be_empty
       end
     end
 
@@ -278,7 +278,7 @@ RSpec.describe User do
       let(:roles) { 'owner,teacher' }
 
       it 'returns an array of the roles the user has at the school' do
-        expect(user.org_roles(organisation_id: school.id)).to match_array(%w[owner teacher])
+        expect(user.school_roles(organisation_id: school.id)).to match_array(%w[owner teacher])
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,12 +234,12 @@ RSpec.describe User do
 
     it 'returns true when the user has the owner role for this school' do
       create(:owner_role, school:, user_id: user.id)
-      expect(user).to be_school_owner(organisation_id: school.id)
+      expect(user).to be_school_owner(school)
     end
 
     it 'returns false when the user does not have the owner role for this school' do
       create(:teacher_role, school:, user_id: user.id)
-      expect(user).not_to be_school_owner(organisation_id: school.id)
+      expect(user).not_to be_school_owner(school)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -250,12 +250,12 @@ RSpec.describe User do
 
     it 'returns true when the user has the teacher role for this school' do
       create(:teacher_role, school:, user_id: user.id)
-      expect(user).to be_school_teacher(organisation_id: school.id)
+      expect(user).to be_school_teacher(school)
     end
 
     it 'returns false when the user does not have the teacher role for this school' do
       create(:owner_role, school:, user_id: user.id)
-      expect(user).not_to be_school_teacher(organisation_id: school.id)
+      expect(user).not_to be_school_teacher(school)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,43 +14,6 @@ RSpec.describe User do
   it { is_expected.to respond_to(:organisations) }
   it { is_expected.to respond_to(:organisation_ids) }
 
-  shared_examples 'role_check' do |role|
-    let(:organisations) { {} }
-    let(:user) { build(:user, organisations:) }
-
-    it { is_expected.to be_falsey }
-
-    context 'with a blank roles entry' do
-      let(:organisations) { { organisation_id => ' ' } }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'with an unrelated role given' do
-      let(:organisations) { { organisation_id => 'foo' } }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context "with a #{role} role given" do
-      let(:organisations) { { organisation_id => role } }
-
-      it { is_expected.to be_truthy }
-
-      context 'with unrelated roles too' do
-        let(:organisations) { { organisation_id => "foo,bar,#{role},quux" } }
-
-        it { is_expected.to be_truthy }
-      end
-
-      context 'with weird extra whitespace in role' do
-        let(:organisations) { { organisation_id => " #{role} " } }
-
-        it { is_expected.to be_truthy }
-      end
-    end
-  end
-
   describe '.from_userinfo' do
     subject(:users) { described_class.from_userinfo(ids:) }
 

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'POST /graphql' do
 
       context 'when the token is valid' do
         before do
-          authenticate_as_school_owner
+          authenticate_as_school_owner(school_id: SecureRandom.uuid)
         end
 
         it 'sets the current_user in the context' do

--- a/spec/requests/projects/create_spec.rb
+++ b/spec/requests/projects/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create project requests' do
 
     context 'when creating project is successful' do
       before do
-        authenticate_as_school_owner
+        authenticate_as_school_owner(school_id: SecureRandom.uuid)
 
         response = OperationResponse.new
         response[:project] = project
@@ -26,7 +26,7 @@ RSpec.describe 'Create project requests' do
 
     context 'when creating project fails' do
       before do
-        authenticate_as_school_owner
+        authenticate_as_school_owner(school_id: SecureRandom.uuid)
 
         response = OperationResponse.new
         response[:error] = 'Error creating project'

--- a/spec/requests/projects/destroy_spec.rb
+++ b/spec/requests/projects/destroy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Project delete requests' do
     let(:owner_id) { SecureRandom.uuid }
 
     before do
-      authenticate_as_school_owner(owner_id:)
+      authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
     end
 
     context 'when deleting a project the user owns' do

--- a/spec/requests/projects/images_spec.rb
+++ b/spec/requests/projects/images_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Images requests' do
       let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
       before do
-        authenticate_as_school_teacher
+        authenticate_as_school_teacher(school_id: SecureRandom.uuid)
       end
 
       it 'returns forbidden response' do

--- a/spec/requests/projects/images_spec.rb
+++ b/spec/requests/projects/images_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Images requests' do
       let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
       before do
-        authenticate_as_school_owner(owner_id:)
+        authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
       end
 
       it 'attaches file to project' do

--- a/spec/requests/projects/index_spec.rb
+++ b/spec/requests/projects/index_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Project index requests' do
     before do
       # create non user projects
       create_list(:project, 2)
-      authenticate_as_school_owner(owner_id:)
+      authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
     end
 
     it 'returns success response' do
@@ -46,7 +46,7 @@ RSpec.describe 'Project index requests' do
 
   context 'when the projects index has pagination' do
     before do
-      authenticate_as_school_owner(owner_id:)
+      authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
       create_list(:project, 10, user_id: stubbed_user.id)
     end
 

--- a/spec/requests/projects/remix_spec.rb
+++ b/spec/requests/projects/remix_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Remix requests' do
     end
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     describe '#show' do
@@ -62,7 +62,7 @@ RSpec.describe 'Remix requests' do
 
       context 'when project cannot be saved' do
         before do
-          authenticate_as_school_owner
+          authenticate_as_school_owner(school_id: SecureRandom.uuid)
           error_response = OperationResponse.new
           error_response[:error] = 'Something went wrong'
           allow(Project::CreateRemix).to receive(:call).and_return(error_response)

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Project show requests' do
     let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
     before do
-      authenticate_as_school_owner(owner_id:)
+      authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
     end
 
     context 'when loading own project' do

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Project update requests' do
     end
 
     before do
-      authenticate_as_school_owner(owner_id:)
+      authenticate_as_school_owner(owner_id:, school_id: SecureRandom.uuid)
     end
 
     it 'returns success response' do
@@ -82,7 +82,7 @@ RSpec.describe 'Project update requests' do
     let(:params) { { project: { components: [] } } }
 
     before do
-      authenticate_as_school_owner
+      authenticate_as_school_owner(school_id: SecureRandom.uuid)
     end
 
     it 'returns forbidden response' do

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe SchoolVerificationService do
-  let(:school) { create(:school) }
+  let(:school) { create(:school, creator_id: school_creator.id) }
   let(:user) { create(:user) }
+  let(:school_creator) { create(:user) }
   let(:service) { described_class.new(school.id, user) }
   let(:organisation_id) { SecureRandom.uuid }
 
@@ -16,6 +17,10 @@ RSpec.describe SchoolVerificationService do
 
     it 'sets verified_at to a date' do
       expect(school.verified_at).to be_a(ActiveSupport::TimeWithZone)
+    end
+
+    it 'grants the creator the owner role for the school' do
+      expect(school_creator).to be_school_owner(school)
     end
   end
 

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -39,7 +39,7 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 1, user_id: teacher_id, school_id:)
   end
 
-  def authenticate_as_school_student(student_id: SecureRandom.uuid, school_id: SecureRandom.uuid)
+  def authenticate_as_school_student(school_id:, student_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 2, user_id: student_id, school_id:)
   end
 

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -14,6 +14,7 @@ module UserProfileMock
 
   def stub_user_info_api_for_teacher(teacher_id:, school_id:)
     stub_user_info_api_for(user_index: 1, user_id: teacher_id, school_id:)
+    create_teacher_role(school_id:, teacher_id:)
   end
 
   def stub_user_info_api_for_student(student_id:, school_id:)
@@ -38,6 +39,7 @@ module UserProfileMock
 
   def authenticate_as_school_teacher(school_id:, teacher_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 1, user_id: teacher_id, school_id:)
+    create_teacher_role(school_id:, teacher_id:)
   end
 
   def authenticate_as_school_student(school_id:, student_id: SecureRandom.uuid)
@@ -88,5 +90,12 @@ module UserProfileMock
     return if Role.student.exists?(user_id: student_id, school_id:)
 
     create(:student_role, user_id: student_id, school_id:)
+  end
+
+  def create_teacher_role(school_id:, teacher_id:)
+    return unless School.exists?(id: school_id)
+    return if Role.teacher.exists?(user_id: teacher_id, school_id:)
+
+    create(:teacher_role, user_id: teacher_id, school_id:)
   end
 end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -10,6 +10,7 @@ module UserProfileMock
 
   def stub_user_info_api_for_owner(owner_id:, school_id:)
     stub_user_info_api_for(user_index: 0, user_id: owner_id, school_id:)
+    create_owner_role(school_id:, owner_id:)
   end
 
   def stub_user_info_api_for_teacher(teacher_id:, school_id:)
@@ -35,6 +36,7 @@ module UserProfileMock
 
   def authenticate_as_school_owner(school_id:, owner_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 0, user_id: owner_id, school_id:)
+    create_owner_role(school_id:, owner_id:)
   end
 
   def authenticate_as_school_teacher(school_id:, teacher_id: SecureRandom.uuid)
@@ -97,5 +99,12 @@ module UserProfileMock
     return if Role.teacher.exists?(user_id: teacher_id, school_id:)
 
     create(:teacher_role, user_id: teacher_id, school_id:)
+  end
+
+  def create_owner_role(school_id:, owner_id:)
+    return unless School.exists?(id: school_id)
+    return if Role.owner.exists?(user_id: owner_id, school_id:)
+
+    create(:owner_role, user_id: owner_id, school_id:)
   end
 end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -35,7 +35,7 @@ module UserProfileMock
     stub_hydra_public_api(user_index: 0, user_id: owner_id, school_id:)
   end
 
-  def authenticate_as_school_teacher(teacher_id: SecureRandom.uuid, school_id: SecureRandom.uuid)
+  def authenticate_as_school_teacher(school_id:, teacher_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 1, user_id: teacher_id, school_id:)
   end
 

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -18,6 +18,7 @@ module UserProfileMock
 
   def stub_user_info_api_for_student(student_id:, school_id:)
     stub_user_info_api_for(user_index: 2, user_id: student_id, school_id:)
+    create_student_role(school_id:, student_id:)
   end
 
   def stub_user_info_api_for_student_without_organisations(student_id:)
@@ -41,6 +42,7 @@ module UserProfileMock
 
   def authenticate_as_school_student(school_id:, student_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 2, user_id: student_id, school_id:)
+    create_student_role(school_id:, student_id:)
   end
 
   def authenticate_as_school_student_without_organisations(student_id: SecureRandom.uuid)
@@ -80,5 +82,11 @@ module UserProfileMock
     stub_request(:get, "#{UserInfoApiClient::API_URL}/users")
       .with(headers: { Authorization: "Bearer #{UserInfoApiClient::API_KEY}" }, body: /#{user_id}/)
       .to_return({ body: { users: }.to_json, headers: { 'Content-Type' => 'application/json' } })
+  end
+
+  def create_student_role(school_id:, student_id:)
+    return if Role.student.exists?(user_id: student_id, school_id:)
+
+    create(:student_role, user_id: student_id, school_id:)
   end
 end

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -31,7 +31,7 @@ module UserProfileMock
     stub_user_info_api(user_id: user_attrs['id'], users: [user_attrs])
   end
 
-  def authenticate_as_school_owner(owner_id: SecureRandom.uuid, school_id: SecureRandom.uuid)
+  def authenticate_as_school_owner(school_id:, owner_id: SecureRandom.uuid)
     stub_hydra_public_api(user_index: 0, user_id: owner_id, school_id:)
   end
 


### PR DESCRIPTION
GitHub Issue: https://github.com/RaspberryPiFoundation/editor-api/issues/285

The new `Role` model is used to record the roles a `User` has in a given `School`. Valid roles are "owner", "teacher" and "student". Users can have both "owner" and "teacher" roles at the same time, but cannot have either of those roles as well as the "student" role.

A user that creates a school is automatically given the "owner" role when that school is verified.

The frontend designs assume a user is only ever associated with a single school so we add the `Role#users_can_only_have_roles_in_one_school` validation to attempt to enforce that in the data.

The new /api/school endpoint returns the `School` that the logged in user has a role in. We'll need to update [the `getUserSchool` function](https://github.com/RaspberryPiFoundation/editor-standalone/blob/d069a92f3b3eefbbc23a6b8c11593a25a76a5044/src/utils/apiCallHandler.js#L130) to request this endpoint instead of /api/schools.

---

You can manually add roles for the two seed users with:

```
# Add Roles for john.doe@example.com

rails r 'Role.student.create!(user_id: "bbb9b8fd-f357-4238-983d-6f87b99bdbb2", school: School.last)'
rails r 'Role.teacher.create!(user_id: "bbb9b8fd-f357-4238-983d-6f87b99bdbb2", school: School.last)'
rails r 'Role.owner.create!(user_id: "bbb9b8fd-f357-4238-983d-6f87b99bdbb2", school: School.last)'

# Add Roles for jane.doe@example.com

rails r 'Role.student.create!(user_id: "583ba872-b16e-46e1-9f7d-df89d267550d", school: School.last)'
rails r 'Role.teacher.create!(user_id: "583ba872-b16e-46e1-9f7d-df89d267550d", school: School.last)'
rails r 'Role.owner.create!(user_id: "583ba872-b16e-46e1-9f7d-df89d267550d", school: School.last)'
```