### PR TITLE
Require users to exist in model validations

### DIFF
--- a/app/models/class_member.rb
+++ b/app/models/class_member.rb
@@ -30,7 +30,7 @@ class ClassMember < ApplicationRecord
     return unless student_id_changed? && errors.blank?
 
     _, user = with_student
-    return if !user || user.school_student?(school)
+    return if user&.school_student?(school)
 
     msg = "'#{student_id}' does not have the 'school-student' role for organisation '#{school.id}'"
     errors.add(:student, msg)

--- a/app/models/class_member.rb
+++ b/app/models/class_member.rb
@@ -30,7 +30,7 @@ class ClassMember < ApplicationRecord
     return unless student_id_changed? && errors.blank?
 
     _, user = with_student
-    return unless user && !user.school_student?(school)
+    return if !user || user.school_student?(school)
 
     msg = "'#{student_id}' does not have the 'school-student' role for organisation '#{school.id}'"
     errors.add(:student, msg)

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -62,9 +62,8 @@ class Lesson < ApplicationRecord
 
     _, user = with_user
 
-    return if user.blank?
-    return if user.school_owner?(school)
-    return if user.school_teacher?(school)
+    return if user&.school_owner?(school)
+    return if user&.school_teacher?(school)
 
     msg = "'#{user_id}' does not have the 'school-owner' or 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,9 +56,7 @@ class Project < ApplicationRecord
     return unless user_id_changed? && errors.blank? && school
 
     _, user = with_user
-
-    return if user.blank?
-    return if user.school_roles(school).any?
+    return if (user&.school_roles(school) || []).any?
 
     msg = "'#{user_id}' does not have any roles for organisation '#{school_id}'"
     errors.add(:user, msg)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -60,7 +60,7 @@ class Project < ApplicationRecord
     return if user.blank?
     return if user.school_roles(school).any?
 
-    msg = "'#{user_id}' does not have any roles for for organisation '#{school_id}'"
+    msg = "'#{user_id}' does not have any roles for organisation '#{school_id}'"
     errors.add(:user, msg)
   end
 

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -28,7 +28,7 @@ class SchoolClass < ApplicationRecord
     return unless teacher_id_changed? && errors.blank?
 
     _, user = with_teacher
-    return unless user && !user.school_teacher?(school)
+    return if !user || user.school_teacher?(school)
 
     msg = "'#{teacher_id}' does not have the 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -28,7 +28,7 @@ class SchoolClass < ApplicationRecord
     return unless teacher_id_changed? && errors.blank?
 
     _, user = with_teacher
-    return if !user || user.school_teacher?(school)
+    return if user&.school_teacher?(school)
 
     msg = "'#{teacher_id}' does not have the 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -85,16 +85,12 @@ RSpec.describe 'Creating a class member', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
+
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -41,17 +41,12 @@ RSpec.describe 'Deleting a class member', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}/members/#{class_member.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -35,23 +35,19 @@ RSpec.describe 'Listing class members', type: :request do
     expect(data.first[:student_name]).to eq('School Student')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for students if the user profile doesn't exist" do
-    student_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: student_id)
-    class_member.update!(student_id:)
+    stub_user_info_api_for_unknown_users(user_id: class_member.student_id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:student_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it 'does not include class members that belong to a different class' do
     student_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: student_id)
+    stub_user_info_api_for_student(student_id:, school_id: school.id)
     different_class = create(:school_class, school:, teacher_id:)
     create(:class_member, school_class: different_class, student_id:)
 

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -71,17 +71,12 @@ RSpec.describe 'Listing class members', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -66,17 +66,12 @@ RSpec.describe 'Archiving a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      user_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id:)
       authenticate_as_school_teacher(school_id: school.id)
-      lesson.update!(user_id:)
 
       delete("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:forbidden)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student(school_id: school.id)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -165,17 +165,12 @@ RSpec.describe 'Creating a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the current user is a school-teacher for a different class' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
       authenticate_as_school_teacher(school_id: school.id)
-      school_class.update!(teacher_id:)
 
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 422 Unprocessable Entity when the user_id is a school-teacher for a different class' do
       user_id = SecureRandom.uuid

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -86,17 +86,12 @@ RSpec.describe 'Updating a lesson', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the user is another school-teacher in the school' do
-      user_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id:)
       authenticate_as_school_teacher(school_id: school.id)
-      lesson.update!(user_id:)
 
       put("/api/lessons/#{lesson.id}", headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student(school_id: school.id)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe 'Updating a lesson', type: :request do
     # rubocop:disable RSpec/ExampleLength
     it 'responds 422 Unprocessable Entity when trying to re-assign the lesson to a different class' do
       teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
       school = create(:school, id: SecureRandom.uuid)
+      stub_user_info_api_for_teacher(teacher_id:, school_id: school.id)
       school_class = create(:school_class, school:, teacher_id:)
 
       new_params = { lesson: params[:lesson].merge(school_class_id: school_class.id) }

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -177,17 +177,12 @@ RSpec.describe 'Creating a project', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'responds 403 Forbidden when the current user is not the owner of the lesson' do
-      user_id = SecureRandom.uuid
       authenticate_as_school_teacher(school_id: school.id)
-      stub_user_info_api_for_unknown_users(user_id:)
-      lesson.update!(user_id:)
 
       post('/api/projects', headers:, params:)
       expect(response).to have_http_status(:forbidden)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it 'responds 403 Forbidden when the user is a school-student' do
       authenticate_as_school_student(school_id: school.id)

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -38,17 +38,12 @@ RSpec.describe 'Deleting a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
 
     delete("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -36,23 +36,19 @@ RSpec.describe 'Listing school classes', type: :request do
     expect(data.first[:teacher_name]).to eq('School Teacher')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for teachers if the user profile doesn't exist" do
-    teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:teacher_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-teacher doesn't teach" do
     teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
+    stub_user_info_api_for_teacher(teacher_id:, school_id: school.id)
     authenticate_as_school_teacher(teacher_id:, school_id: school.id)
     create(:school_class, school:, teacher_id:)
 
@@ -63,10 +59,7 @@ RSpec.describe 'Listing school classes', type: :request do
   end
   # rubocop:enable RSpec/ExampleLength
 
-  # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-student isn't a member of" do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_student(student_id:, school_id: school.id)
     create(:school_class, school:, teacher_id:)
 
@@ -75,7 +68,6 @@ RSpec.describe 'Listing school classes', type: :request do
 
     expect(data.size).to eq(1)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 401 Unauthorized when no token is given' do
     get "/api/schools/#{school.id}/classes"

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -51,18 +51,14 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(data[:teacher_name]).to eq('School Teacher')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
-    teacher_id = SecureRandom.uuid
     stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data[:teacher_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 404 Not Found when no school exists' do
     get("/api/schools/not-a-real-id/classes/#{school_class.id}", headers:)
@@ -87,17 +83,12 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is not a school-student for the class' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -70,17 +70,12 @@ RSpec.describe 'Updating a school class', type: :request do
     expect(response).to have_http_status(:forbidden)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 403 Forbidden when the user is not the school-teacher for the class' do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
     authenticate_as_school_teacher(school_id: school.id)
-    school_class.update!(teacher_id:)
 
     put("/api/schools/#{school.id}/classes/#{school_class.id}", headers:, params:)
     expect(response).to have_http_status(:forbidden)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 403 Forbidden when the user is a school-student' do
     authenticate_as_school_student(school_id: school.id)

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe ClassMember do
       duplicate = build(:class_member, student_id: class_member.student_id, school_class: class_member.school_class)
       expect(duplicate).to be_invalid
     end
+
+    it 'requires the student_id to match a user in the UserInfo API' do
+      stub_user_info_api_for_unknown_users(user_id: student_id)
+      expect(class_member).to be_invalid
+    end
   end
 
   describe '.students' do
@@ -72,9 +77,8 @@ RSpec.describe ClassMember do
     end
 
     it 'ignores members where no profile account exists' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
       create(:class_member, student_id:, school_class:)
+      stub_user_info_api_for_unknown_users(user_id: student_id)
 
       student = described_class.all.students.first
       expect(student).to be_nil
@@ -99,9 +103,8 @@ RSpec.describe ClassMember do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
       class_member = create(:class_member, student_id:, school_class:)
+      stub_user_info_api_for_unknown_users(user_id: student_id)
 
       pair = described_class.all.with_students.first
       expect(pair).to eq([class_member, nil])
@@ -126,9 +129,8 @@ RSpec.describe ClassMember do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
       class_member = create(:class_member, student_id:, school_class:)
+      stub_user_info_api_for_unknown_users(user_id: student_id)
 
       pair = class_member.with_student
       expect(pair).to eq([class_member, nil])

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -107,6 +107,24 @@ RSpec.describe Project do
       end
     end
 
+    context "when the project has a school and a user_id that doesn't match a user in Hydra" do
+      let(:user_id) { SecureRandom.uuid }
+      let(:project) { build(:project, school:, user_id:) }
+
+      before do
+        stub_user_info_api_for_unknown_users(user_id:)
+      end
+
+      it 'is invalid' do
+        expect(project).to be_invalid
+      end
+
+      it 'adds an error message' do
+        project.valid?
+        expect(project.errors[:user]).to include("'#{user_id}' does not have any roles for organisation '#{school.id}'")
+      end
+    end
+
     context 'when the project has a lesson' do
       before do
         lesson = create(:lesson)

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -92,9 +92,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'ignores members where no profile account exists' do
-      teacher_id = SecureRandom.uuid
+      create(:school_class, teacher_id:, school:)
       stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      create(:school_class, teacher_id:)
 
       teacher = described_class.all.teachers.first
       expect(teacher).to be_nil
@@ -119,9 +118,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      teacher_id = SecureRandom.uuid
+      school_class = create(:school_class, teacher_id:, school:)
       stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      school_class = create(:school_class, teacher_id:)
 
       pair = described_class.all.with_teachers.first
       expect(pair).to eq([school_class, nil])
@@ -146,9 +144,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      school_class = create(:school_class, teacher_id:)
+      school_class = create(:school_class, teacher_id:, school:)
+      stub_user_info_api_for_unknown_users(user_id: school_class.teacher_id)
 
       pair = school_class.with_teacher
       expect(pair).to eq([school_class, nil])


### PR DESCRIPTION
Tighten up validations of:

- `ClassMember#student_id`
- `Lesson#user_id`
- `Project#user_id`
- `SchoolClass#teacher_id`

Prior to this PR, if the users identified by the IDs in the methods above didn't exist in Hydra then we'd assume the object was valid. We now default to assuming that the object is invalid if the user doesn't exist in Hydra. This feels like a safer default.