### PR TITLE
Avoid hydra in model validations

### DIFF
--- a/app/models/class_member.rb
+++ b/app/models/class_member.rb
@@ -30,7 +30,8 @@ class ClassMember < ApplicationRecord
     return unless student_id_changed? && errors.blank?
 
     _, user = with_student
-    return unless user && !user.school_student?(school)
+    return if user.blank?
+    return if user.school_student?(school)
 
     msg = "'#{student_id}' does not have the 'school-student' role for organisation '#{school.id}'"
     errors.add(:student, msg)

--- a/app/models/class_member.rb
+++ b/app/models/class_member.rb
@@ -29,8 +29,7 @@ class ClassMember < ApplicationRecord
   def student_has_the_school_student_role_for_the_school
     return unless student_id_changed? && errors.blank?
 
-    _, user = with_student
-    return if user.blank?
+    user = User.new(id: student_id)
     return if user.school_student?(school)
 
     msg = "'#{student_id}' does not have the 'school-student' role for organisation '#{school.id}'"

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -60,9 +60,7 @@ class Lesson < ApplicationRecord
   def user_has_the_school_owner_or_school_teacher_role_for_the_school
     return unless user_id_changed? && errors.blank? && school
 
-    _, user = with_user
-
-    return if user.blank?
+    user = User.new(id: user_id)
     return if user.school_owner?(school)
     return if user.school_teacher?(school)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,9 +55,7 @@ class Project < ApplicationRecord
   def user_has_a_role_within_the_school
     return unless user_id_changed? && errors.blank? && school
 
-    _, user = with_user
-
-    return if user.blank?
+    user = User.new(id: user_id)
     return if user.school_roles(school).any?
 
     msg = "'#{user_id}' does not have any roles for for organisation '#{school_id}'"

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -28,7 +28,8 @@ class SchoolClass < ApplicationRecord
     return unless teacher_id_changed? && errors.blank?
 
     _, user = with_teacher
-    return unless user && !user.school_teacher?(school)
+    return if user.blank?
+    return if user.school_teacher?(school)
 
     msg = "'#{teacher_id}' does not have the 'school-teacher' role for organisation '#{school.id}'"
     errors.add(:user, msg)

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -27,8 +27,7 @@ class SchoolClass < ApplicationRecord
   def teacher_has_the_school_teacher_role_for_the_school
     return unless teacher_id_changed? && errors.blank?
 
-    _, user = with_teacher
-    return if user.blank?
+    user = User.new(id: teacher_id)
     return if user.school_teacher?(school)
 
     msg = "'#{teacher_id}' does not have the 'school-teacher' role for organisation '#{school.id}'"

--- a/spec/concepts/class_member/create_spec.rb
+++ b/spec/concepts/class_member/create_spec.rb
@@ -3,11 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ClassMember::Create, type: :unit do
-  before do
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
-  end
-
   let!(:school_class) { create(:school_class, teacher_id: teacher.id, school:) }
   let(:school) { create(:school) }
   let(:student) { create(:student, school:) }

--- a/spec/concepts/class_member/delete_spec.rb
+++ b/spec/concepts/class_member/delete_spec.rb
@@ -3,11 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ClassMember::Delete, type: :unit do
-  before do
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
-  end
-
   let!(:class_member) { create(:class_member, student_id: student.id, school_class:) }
   let(:class_member_id) { class_member.id }
   let(:school_class) { build(:school_class, teacher_id: teacher.id, school:) }

--- a/spec/concepts/school/delete_spec.rb
+++ b/spec/concepts/school/delete_spec.rb
@@ -4,9 +4,6 @@ require 'rails_helper'
 
 RSpec.describe School::Delete, type: :unit do
   before do
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
-
     create(:class_member, student_id: student.id, school_class:)
   end
 

--- a/spec/concepts/school_class/create_spec.rb
+++ b/spec/concepts/school_class/create_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe SchoolClass::Create, type: :unit do
     { name: 'Test School Class', teacher_id: teacher.id }
   end
 
-  before do
-    stub_user_info_api_for(teacher)
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(school:, school_class_params:)
     expect(response.success?).to be(true)

--- a/spec/concepts/school_class/delete_spec.rb
+++ b/spec/concepts/school_class/delete_spec.rb
@@ -4,9 +4,6 @@ require 'rails_helper'
 
 RSpec.describe SchoolClass::Delete, type: :unit do
   before do
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
-
     create(:class_member, student_id: student.id, school_class:)
   end
 

--- a/spec/concepts/school_class/update_spec.rb
+++ b/spec/concepts/school_class/update_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe SchoolClass::Update, type: :unit do
   let(:school_class_params) { { name: 'New Name' } }
   let(:teacher) { create(:teacher, school:) }
 
-  before do
-    stub_user_info_api_for(teacher)
-  end
-
   it 'returns a successful operation response' do
     response = described_class.call(school_class:, school_class_params:)
     expect(response.success?).to be(true)

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -50,10 +50,8 @@ RSpec.describe 'Creating a class member', type: :request do
     expect(data[:student_name]).to eq('School Student')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the student if their user profile doesn't exist" do
     student_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: student_id)
     new_params = { class_member: params[:class_member].merge(student_id:) }
 
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:, params: new_params)
@@ -61,7 +59,6 @@ RSpec.describe 'Creating a class member', type: :request do
 
     expect(data[:student_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 400 Bad Request when params are missing' do
     post("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a class member', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
     stub_user_info_api_for(student)
   end
 

--- a/spec/features/class_member/deleting_a_class_member_spec.rb
+++ b/spec/features/class_member/deleting_a_class_member_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Deleting a class member', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe 'Listing class members', type: :request do
     authenticated_in_hydra_as(owner)
     stub_user_info_api_for(teacher)
     stub_user_info_api_for(student)
+    create(:class_member, student_id: student.id, school_class:)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
-  let!(:class_member) { create(:class_member, student_id: student.id, school_class:) }
   let(:school_class) { build(:school_class, teacher_id: teacher.id, school:) }
   let(:school) { create(:school) }
   let(:student) { create(:student, school:, name: 'School Student') }
@@ -36,25 +36,21 @@ RSpec.describe 'Listing class members', type: :request do
     expect(data.first[:student_name]).to eq('School Student')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for students if the user profile doesn't exist" do
-    student_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: student_id)
-    class_member.update!(student_id:)
+    stub_user_info_api_for_unknown_users(user_id: student.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:student_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it 'does not include class members that belong to a different class' do
-    student_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: student_id)
+    student = create(:student, school:)
+    stub_user_info_api_for(student)
     different_class = create(:school_class, school:, teacher_id: teacher.id)
-    create(:class_member, school_class: different_class, student_id:)
+    create(:class_member, school_class: different_class, student_id: student.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Listing class members', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
     stub_user_info_api_for(student)
     create(:class_member, student_id: student.id, school_class:)
   end
@@ -48,7 +47,6 @@ RSpec.describe 'Listing class members', type: :request do
   # rubocop:disable RSpec/ExampleLength
   it 'does not include class members that belong to a different class' do
     student = create(:student, school:)
-    stub_user_info_api_for(student)
     different_class = create(:school_class, school:, teacher_id: teacher.id)
     create(:class_member, school_class: different_class, student_id: student.id)
 

--- a/spec/features/lesson/archiving_a_lesson_spec.rb
+++ b/spec/features/lesson/archiving_a_lesson_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Archiving a lesson', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a copy of a lesson', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_copy_of_a_lesson_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a copy of a lesson', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(owner)
     stub_user_info_api_for(teacher)
   end
 

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe 'Creating a lesson', type: :request do
 
     it 'responds 422 Unprocessable Entity when the user_id is a school-teacher for a different class' do
       user_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id:)
       new_params = { lesson: params[:lesson].merge(user_id:) }
 
       post('/api/lessons', headers:, params: new_params)

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -22,13 +22,11 @@ RSpec.describe 'Creating a lesson', type: :request do
   end
 
   it 'responds 201 Created' do
-    stub_user_info_api_for(owner)
     post('/api/lessons', headers:, params:)
     expect(response).to have_http_status(:created)
   end
 
   it 'responds with the lesson JSON' do
-    stub_user_info_api_for(owner)
     post('/api/lessons', headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 
@@ -36,7 +34,6 @@ RSpec.describe 'Creating a lesson', type: :request do
   end
 
   it 'responds with the user JSON which is set from the current user' do
-    stub_user_info_api_for(owner)
     post('/api/lessons', headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe 'Listing lessons', type: :request do
     let(:owner) { create(:owner, school:) }
 
     it 'includes the lesson when the user owns the lesson' do
-      stub_user_info_api_for(owner)
       lesson.update!(user_id: owner.id)
 
       get('/api/lessons', headers:)
@@ -97,7 +96,6 @@ RSpec.describe 'Listing lessons', type: :request do
     let(:owner) { create(:owner, school:) }
 
     it 'includes the lesson when the user owns the lesson' do
-      stub_user_info_api_for(owner)
       lesson.update!(user_id: owner.id)
 
       get('/api/lessons', headers:)
@@ -156,7 +154,6 @@ RSpec.describe 'Listing lessons', type: :request do
     # rubocop:disable RSpec/ExampleLength
     it "includes the lesson when the user is a school-student within the lesson's class" do
       student = create(:student, school:)
-      stub_user_info_api_for(student)
       authenticated_in_hydra_as(student)
       create(:class_member, school_class:, student_id: student.id)
 

--- a/spec/features/lesson/showing_a_lesson_spec.rb
+++ b/spec/features/lesson/showing_a_lesson_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe 'Showing a lesson', type: :request do
     let(:owner) { create(:owner, school:) }
 
     it 'responds 200 OK when the user owns the lesson' do
-      stub_user_info_api_for(owner)
       lesson.update!(user_id: owner.id)
 
       get("/api/lessons/#{lesson.id}", headers:)
@@ -80,7 +79,6 @@ RSpec.describe 'Showing a lesson', type: :request do
     let(:owner) { create(:owner, school:) }
 
     it 'responds 200 OK when the user owns the lesson' do
-      stub_user_info_api_for(owner)
       lesson.update!(user_id: owner.id)
 
       get("/api/lessons/#{lesson.id}", headers:)
@@ -124,17 +122,14 @@ RSpec.describe 'Showing a lesson', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it "responds 200 OK when the user is a school-student within the lesson's class" do
       student = create(:student, school:)
       authenticated_in_hydra_as(student)
-      stub_user_info_api_for(student)
       create(:class_member, school_class:, student_id: student.id)
 
       get("/api/lessons/#{lesson.id}", headers:)
       expect(response).to have_http_status(:ok)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it "responds 403 Forbidden when the user is a school-student but isn't within the lesson's class" do
       student = create(:student, school:)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -112,10 +112,10 @@ RSpec.describe 'Updating a lesson', type: :request do
 
     # rubocop:disable RSpec/ExampleLength
     it 'responds 422 Unprocessable Entity when trying to re-assign the lesson to a different class' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
       school = create(:school, id: SecureRandom.uuid)
-      school_class = create(:school_class, school:, teacher_id:)
+      teacher = create(:teacher, school:)
+      stub_user_info_api_for_unknown_users(user_id: teacher.id)
+      school_class = create(:school_class, school:, teacher_id: teacher.id)
 
       new_params = { lesson: params[:lesson].merge(school_class_id: school_class.id) }
       put("/api/lessons/#{lesson.id}", headers:, params: new_params)

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe 'Updating a lesson', type: :request do
     it 'responds 422 Unprocessable Entity when trying to re-assign the lesson to a different class' do
       school = create(:school, id: SecureRandom.uuid)
       teacher = create(:teacher, school:)
-      stub_user_info_api_for_unknown_users(user_id: teacher.id)
       school_class = create(:school_class, school:, teacher_id: teacher.id)
 
       new_params = { lesson: params[:lesson].merge(school_class_id: school_class.id) }

--- a/spec/features/lesson/updating_a_lesson_spec.rb
+++ b/spec/features/lesson/updating_a_lesson_spec.rb
@@ -23,13 +23,11 @@ RSpec.describe 'Updating a lesson', type: :request do
   end
 
   it 'responds 200 OK' do
-    stub_user_info_api_for(owner)
     put("/api/lessons/#{lesson.id}", headers:, params:)
     expect(response).to have_http_status(:ok)
   end
 
   it 'responds with the lesson JSON' do
-    stub_user_info_api_for(owner)
     put("/api/lessons/#{lesson.id}", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 
@@ -37,7 +35,6 @@ RSpec.describe 'Updating a lesson', type: :request do
   end
 
   it 'responds with the user JSON' do
-    stub_user_info_api_for(owner)
     put("/api/lessons/#{lesson.id}", headers:, params:)
     data = JSON.parse(response.body, symbolize_names: true)
 
@@ -128,7 +125,6 @@ RSpec.describe 'Updating a lesson', type: :request do
     # rubocop:enable RSpec/ExampleLength
 
     it 'responds 422 Unprocessable Entity when trying to re-assign the lesson to a different user' do
-      stub_user_info_api_for(owner)
       new_params = { lesson: params[:lesson].merge(user_id: owner.id) }
       put("/api/lessons/#{lesson.id}", headers:, params: new_params)
 

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a project', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
     mock_phrase_generation
   end
 

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -148,7 +148,6 @@ RSpec.describe 'Creating a project', type: :request do
 
     it 'responds 422 Unprocessable when when the user_id is not the owner of the lesson' do
       user_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id:)
       new_params = { project: params[:project].merge(user_id:) }
 
       post('/api/projects', headers:, params: new_params)

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe 'Creating a project', type: :request do
 
     it 'responds 201 Created when the user is a school-student for the school' do
       student = create(:student, school:)
-      stub_user_info_api_for(student)
       authenticated_in_hydra_as(student)
 
       post('/api/projects', headers:, params:)

--- a/spec/features/school_class/creating_a_school_class_spec.rb
+++ b/spec/features/school_class/creating_a_school_class_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Creating a school class', type: :request do
   before do
     authenticated_in_hydra_as(teacher)
-    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_class/deleting_a_school_class_spec.rb
+++ b/spec/features/school_class/deleting_a_school_class_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Deleting a school class', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -37,25 +37,21 @@ RSpec.describe 'Listing school classes', type: :request do
     expect(data.first[:teacher_name]).to eq('School Teacher')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for teachers if the user profile doesn't exist" do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    school_class.update!(teacher_id:)
+    stub_user_info_api_for_unknown_users(user_id: teacher.id)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:teacher_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-teacher doesn't teach" do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
+    teacher = create(:teacher, school:)
+    stub_user_info_api_for(teacher)
     authenticated_in_hydra_as(teacher)
-    create(:school_class, school:, teacher_id:)
+    create(:school_class, school:, teacher_id: teacher.id)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
@@ -66,10 +62,10 @@ RSpec.describe 'Listing school classes', type: :request do
 
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-student isn't a member of" do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
+    teacher = create(:teacher, school:)
+    stub_user_info_api_for(teacher)
     authenticated_in_hydra_as(student)
-    create(:school_class, school:, teacher_id:)
+    create(:school_class, school:, teacher_id: teacher.id)
 
     get("/api/schools/#{school.id}/classes", headers:)
     data = JSON.parse(response.body, symbolize_names: true)

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Listing school classes', type: :request do
   before do
     authenticated_in_hydra_as(owner)
     stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
 
     create(:class_member, school_class:, student_id: student.id)
   end
@@ -49,7 +48,6 @@ RSpec.describe 'Listing school classes', type: :request do
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-teacher doesn't teach" do
     teacher = create(:teacher, school:)
-    stub_user_info_api_for(teacher)
     authenticated_in_hydra_as(teacher)
     create(:school_class, school:, teacher_id: teacher.id)
 
@@ -63,7 +61,6 @@ RSpec.describe 'Listing school classes', type: :request do
   # rubocop:disable RSpec/ExampleLength
   it "does not include school classes that the school-student isn't a member of" do
     teacher = create(:teacher, school:)
-    stub_user_info_api_for(teacher)
     authenticated_in_hydra_as(student)
     create(:school_class, school:, teacher_id: teacher.id)
 

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -49,18 +49,14 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(data[:teacher_name]).to eq('School Teacher')
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the teacher if their user profile doesn't exist" do
-    teacher_id = SecureRandom.uuid
-    stub_user_info_api_for_unknown_users(user_id: teacher_id)
-    school_class.update!(teacher_id:)
+    stub_user_info_api_for_unknown_users(user_id: teacher.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data[:teacher_name]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds 404 Not Found when no school exists' do
     get("/api/schools/not-a-real-id/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/showing_a_school_class_spec.rb
+++ b/spec/features/school_class/showing_a_school_class_spec.rb
@@ -26,17 +26,14 @@ RSpec.describe 'Showing a school class', type: :request do
     expect(response).to have_http_status(:ok)
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'responds 200 OK when the user is a student in the class' do
     student = create(:student, school:)
-    stub_user_info_api_for(student)
     authenticated_in_hydra_as(student)
     create(:class_member, school_class:, student_id: student.id)
 
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)
     expect(response).to have_http_status(:ok)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'responds with the school class JSON' do
     get("/api/schools/#{school.id}/classes/#{school_class.id}", headers:)

--- a/spec/features/school_class/updating_a_school_class_spec.rb
+++ b/spec/features/school_class/updating_a_school_class_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Updating a school class', type: :request do
   before do
     authenticated_in_hydra_as(teacher)
-    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_owner/listing_school_owners_spec.rb
+++ b/spec/features/school_owner/listing_school_owners_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Listing school owners', type: :request do
   before do
     authenticated_in_hydra_as(owner)
     stub_profile_api_list_school_owners(user_id: owner.id)
-    stub_user_info_api_for(owner)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe ClassMember do
     end
 
     it 'ignores members where no profile account exists' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
-      create(:class_member, student_id:, school_class:)
+      student = create(:student, school:)
+      stub_user_info_api_for_unknown_users(user_id: student.id)
+      create(:class_member, student_id: student.id, school_class:)
 
       student = described_class.all.students.first
       expect(student).to be_nil
@@ -99,9 +99,9 @@ RSpec.describe ClassMember do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
-      class_member = create(:class_member, student_id:, school_class:)
+      student = create(:student, school:)
+      stub_user_info_api_for_unknown_users(user_id: student.id)
+      class_member = create(:class_member, student_id: student.id, school_class:)
 
       pair = described_class.all.with_students.first
       expect(pair).to eq([class_member, nil])
@@ -126,9 +126,9 @@ RSpec.describe ClassMember do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      student_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: student_id)
-      class_member = create(:class_member, student_id:, school_class:)
+      student = create(:student, school:)
+      stub_user_info_api_for_unknown_users(user_id: student.id)
+      class_member = create(:class_member, student_id: student.id, school_class:)
 
       pair = class_member.with_student
       expect(pair).to eq([class_member, nil])

--- a/spec/models/class_member_spec.rb
+++ b/spec/models/class_member_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe ClassMember do
   before do
-    stub_user_info_api_for(teacher)
     stub_user_info_api_for(student)
   end
 

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe Lesson do
 
       it 'requires that the user that has the school-owner or school-teacher role for the school' do
         student = create(:student, school:)
-        stub_user_info_api_for(student)
         lesson.user_id = student.id
         expect(lesson).to be_invalid
       end
@@ -92,7 +91,6 @@ RSpec.describe Lesson do
 
       it 'requires that the user that is the school-teacher for the school_class' do
         owner = create(:owner, school:)
-        stub_user_info_api_for(owner)
         lesson.user_id = owner.id
         expect(lesson).to be_invalid
       end

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -92,9 +92,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'ignores members where no profile account exists' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      create(:school_class, teacher_id:)
+      stub_user_info_api_for_unknown_users(user_id: teacher.id)
+      create(:school_class, school:, teacher_id: teacher.id)
 
       teacher = described_class.all.teachers.first
       expect(teacher).to be_nil
@@ -119,9 +118,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns nil values for members where no profile account exists' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      school_class = create(:school_class, teacher_id:)
+      stub_user_info_api_for_unknown_users(user_id: teacher.id)
+      school_class = create(:school_class, school:, teacher_id: teacher.id)
 
       pair = described_class.all.with_teachers.first
       expect(pair).to eq([school_class, nil])
@@ -146,9 +144,8 @@ RSpec.describe SchoolClass do
     end
 
     it 'returns a nil value if the member has no profile account' do
-      teacher_id = SecureRandom.uuid
-      stub_user_info_api_for_unknown_users(user_id: teacher_id)
-      school_class = create(:school_class, teacher_id:)
+      stub_user_info_api_for_unknown_users(user_id: teacher.id)
+      school_class = create(:school_class, school:, teacher_id: teacher.id)
 
       pair = school_class.with_teacher
       expect(pair).to eq([school_class, nil])

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe SchoolClass do
   before do
     stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
   end
 
   let(:student) { create(:student, school:) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -3,11 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe School do
-  before do
-    stub_user_info_api_for(teacher)
-    stub_user_info_api_for(student)
-  end
-
   let(:student) { create(:student, school:) }
   let(:teacher) { create(:teacher, school:) }
   let(:school) { create(:school, creator_id: SecureRandom.uuid) }
@@ -195,6 +190,10 @@ RSpec.describe School do
   end
 
   describe '.find_for_user!' do
+    before do
+      stub_user_info_api_for(teacher)
+    end
+
     it 'returns the school that the user has a role in' do
       user = User.where(id: teacher.id).first
       expect(described_class.find_for_user!(user)).to eq(school)

--- a/spec/support/user_profile_mock.rb
+++ b/spec/support/user_profile_mock.rb
@@ -13,6 +13,7 @@ module UserProfileMock
 
   def authenticated_in_hydra_as(user)
     stub_hydra_public_api(user_to_hash(user))
+    stub_user_info_api_for(user)
   end
 
   def unauthenticated_in_hydra


### PR DESCRIPTION
We no longer make a request to the User Info API when validating `ClassMember`, `Lesson`, `Project` or `SchoolClass`. We were previously making requests to the User Info API based on the assumption that users' roles would be stored in Profile. Now that we're storing roles in this app we no longer need to make these requests.