### PR TITLE
Fix dependabot username in .clabot contributors list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -21,7 +21,7 @@
     "james.mead+rpf@gofreerange.com",
     "chrisroos",
     "chris.lowis@gofreerange.com",
-    "dependabot"
+    "dependabot[bot]"
   ],
   "message": "We require contributors to sign our Contributor License Agreement, and we don't have you on file. In order for us to review and merge your code, please complete [this form](https://form.raspberrypi.org/4873530) and we'll get you added and review your contribution as soon as possible."
 }


### PR DESCRIPTION
I got this wrong in PR #315. Sorry! It looks as though the username is actually ["dependabot[bot]"][1].

[1]: https://github.com/RaspberryPiFoundation/editor-api/commits?author=dependabot%5Bbot%5D