### PR TITLE
Add app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "addons": [
+    {
+      "plan": "heroku-postgresql",
+      "options": {
+        "version": "14"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add the Heroku Postgres add-on when the app is deployed to Heroku.

Our Review Apps were failing because our `release` phase was running before Postgres was available. Specifying the Postgres add-on in app.json appears to solve this problem.