### PR TITLE
Upgrade sentry-rails Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'rack-cors'
 gem 'rails', '~> 7.1'
 gem 'roo'
 gem 'scout_apm'
-gem 'sentry-rails', '~> 5.5.0'
+gem 'sentry-rails'
 
 group :development, :test do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     bigdecimal (3.1.8)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    builder (3.2.4)
+    builder (3.3.0)
     bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
@@ -136,7 +136,7 @@ GEM
       xpath (~> 3.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     countries (5.7.1)
       unaccent (~> 0.3)
@@ -153,7 +153,7 @@ GEM
     drb (2.2.1)
     email_validator (2.2.4)
       activemodel
-    erubi (1.12.0)
+    erubi (1.13.0)
     et-orbi (1.2.7)
       tzinfo
     factory_bot (6.2.1)
@@ -193,7 +193,7 @@ GEM
       graphql
     hashdiff (1.0.1)
     hashie (5.0.0)
-    i18n (1.12.0)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -241,7 +241,7 @@ GEM
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    minitest (5.17.0)
+    minitest (5.23.1)
     msgpack (1.6.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
@@ -255,11 +255,11 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.5-aarch64-linux)
+    nokogiri (1.16.6-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.5-arm64-darwin)
+    nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -300,7 +300,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.0)
-    rack (2.2.6.2)
+    rack (2.2.9)
     rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-protection (3.2.0)
@@ -308,7 +308,7 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rack-session (1.0.2)
       rack (< 3)
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rackup (1.0.0)
       rack (< 3)
@@ -343,11 +343,11 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.7.0)
-    reline (0.5.8)
+    reline (0.5.9)
       io-console (~> 0.5)
     rexml (3.3.0)
       strscan
@@ -430,10 +430,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.5.0)
+    sentry-rails (5.17.3)
       railties (>= 5.0)
-      sentry-ruby (~> 5.5.0)
-    sentry-ruby (5.5.0)
+      sentry-ruby (~> 5.17.3)
+    sentry-ruby (5.17.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
@@ -454,7 +455,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.0.5)
+    stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
     tilt (2.3.0)
@@ -483,7 +484,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.15)
 
 PLATFORMS
   aarch64-linux
@@ -535,7 +536,7 @@ DEPENDENCIES
   ruby-lsp-rspec
   scout_apm
   selenium-webdriver
-  sentry-rails (~> 5.5.0)
+  sentry-rails
   shoulda-matchers (~> 5.0)
   simplecov
   webdrivers


### PR DESCRIPTION
I was seeing the following error when trying to write a test around the admin functionality in editor-api:

    NoMethodError:
      undefined method show_exceptions?' for #<ActionDispatch::Request POST
      "http://www.example.com/amin/projects" for 127.0.0.1>

It looks as though this was [fixed in Sentry in PR 2049][1] and [released in version 5.10.0][2].

The sentry-rails version constraint was added in
8d2ca2adc62c91244511fe05f3b5d8e1341566b8 but there was no explanation for it so I've assumed it's not necessary.

[1]: https://github.com/getsentry/sentry-ruby/pull/2049
[2]: https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md#5100