### PR TITLE
Create schools in Profile API upon verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,5 @@ SMEE_TUNNEL=https://smee.io/MLq0n9kvAes2vydX
 
 HOST_URL=http://localhost:3009
 EDITOR_PUBLIC_URL=http://localhost:3012
+
+PROFILE_API_KEY=test # This has to match the value set in Profile (https://github.com/RaspberryPiFoundation/profile/blob/ca10a4f360b6fe2b04be76264e03283054126b0f/.env.example#L45).

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def verify
       service = SchoolVerificationService.new(requested_resource)
 
-      if service.verify
+      if service.verify(token: current_user.token)
         flash[:notice] = t('administrate.controller.verify_school.success')
       else
         flash[:error] = t('administrate.controller.verify_school.error')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,7 @@ class User
 
     args = auth.extra.raw_info.to_h.slice(*ATTRIBUTES)
     args['id'] = auth.uid
+    args['token'] = auth.credentials&.token
 
     new(args)
   end

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -11,8 +11,8 @@ class SchoolVerificationService
   def verify
     School.transaction do
       school.verify!
-      Role.owner.create(user_id: school.creator_id, school:)
-      Role.teacher.create(user_id: school.creator_id, school:)
+      Role.owner.create!(user_id: school.creator_id, school:)
+      Role.teacher.create!(user_id: school.creator_id, school:)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -8,11 +8,12 @@ class SchoolVerificationService
   end
 
   # rubocop:disable Metrics/AbcSize
-  def verify
+  def verify(token:)
     School.transaction do
       school.verify!
       Role.owner.create!(user_id: school.creator_id, school:)
       Role.teacher.create!(user_id: school.creator_id, school:)
+      ProfileApiClient.create_school(token:, school:)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/db/migrate/20240617104323_add_school_code.rb
+++ b/db/migrate/20240617104323_add_school_code.rb
@@ -1,0 +1,6 @@
+class AddSchoolCode < ActiveRecord::Migration[7.1]
+  def change
+    add_column :schools, :code, :string
+    add_index :schools, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,6 +242,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_122250) do
     t.string "creator_department"
     t.boolean "creator_agree_authority"
     t.boolean "creator_agree_terms_and_conditions"
+    t.string "code"
+    t.index ["code"], name: "index_schools_on_code", unique: true
     t.index ["creator_id"], name: "index_schools_on_creator_id", unique: true
     t.index ["reference"], name: "index_schools_on_reference", unique: true
   end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -4,6 +4,20 @@ class ProfileApiClient
   class << self
     # TODO: Replace with HTTP requests once the profile API has been built.
 
+    def create_school(token:, school:)
+      response = connection.post('/api/v1/schools') do |request|
+        apply_default_headers(request, token)
+        request.body = {
+          id: school.id,
+          schoolCode: school.code
+        }.to_json
+      end
+
+      raise "School not created in Profile API. HTTP response code: #{response.status}" unless response.status == 201
+
+      JSON.parse(response.body)
+    end
+
     # The API should enforce these constraints:
     # - The token has the school-owner or school-teacher role for the given organisation ID
     # - The token user or given user should not be under 13
@@ -180,6 +194,20 @@ class ProfileApiClient
       # code so that SchoolOwner::Remove propagates the error in the response.
       response = {}
       response.deep_symbolize_keys
+    end
+
+    private
+
+    def connection
+      Faraday.new(ENV.fetch('IDENTITY_URL'))
+    end
+
+    def apply_default_headers(request, token)
+      request.headers['Accept'] = 'application/json'
+      request.headers['Authorization'] = "Bearer #{token}"
+      request.headers['Content-Type'] = 'application/json'
+      request.headers['X-API-KEY'] = ENV.fetch('PROFILE_API_KEY')
+      request
     end
   end
 end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -5,6 +5,8 @@ class ProfileApiClient
     # TODO: Replace with HTTP requests once the profile API has been built.
 
     def create_school(token:, school:)
+      return { 'id' => school.id, 'schoolCode' => school.code } if ENV['BYPASS_OAUTH'].present?
+
       response = connection.post('/api/v1/schools') do |request|
         apply_default_headers(request, token)
         request.body = {

--- a/lib/school_code_generator.rb
+++ b/lib/school_code_generator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SchoolCodeGenerator
+  MAX_CODE = 1_000_000
+
+  def self.generate
+    number = Random.new.rand(MAX_CODE)
+    code = format('%06d', number)
+
+    code.match(/(\d\d)(\d\d)(\d\d)/) do |m|
+      [m[1], m[2], m[3]].join('-')
+    end
+  end
+end

--- a/lib/tasks/classroom_management_helper.rb
+++ b/lib/tasks/classroom_management_helper.rb
@@ -25,7 +25,9 @@ module ClassroomManagementHelper
 
   def verify_school(school)
     Rails.logger.info 'Verifying the school...'
-    SchoolVerificationService.new(school).verify
+    school.verify!
+    Role.owner.create!(user_id: school.creator_id, school:)
+    Role.teacher.create!(user_id: school.creator_id, school:)
   end
 
   def create_school_class(teacher_id, school)

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -14,5 +14,6 @@ FactoryBot.define do
 
   factory :verified_school, parent: :school do
     verified_at { Time.current }
+    code { SchoolCodeGenerator.generate }
   end
 end

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Schools', type: :request do
     let(:creator) { create(:user) }
     let(:verified_at) { nil }
     let(:rejected_at) { nil }
-    let(:school) { create(:school, creator_id: creator.id, verified_at:, rejected_at:) }
+    let(:code) { nil }
+    let(:school) { create(:school, creator_id: creator.id, verified_at:, rejected_at:, code:) }
 
     before do
       stub_user_info_api_for(creator)
@@ -41,6 +42,7 @@ RSpec.describe 'Schools', type: :request do
 
     describe 'when the school is verified' do
       let(:verified_at) { Time.zone.now }
+      let(:code) { '00-00-00' }
 
       it 'does not include a link to verify school' do
         expect(response.body).not_to include(I18n.t('administrate.actions.verify_school'))

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProfileApiClient do
+  describe '.create_school' do
+    let(:api_url) { 'http://example.com' }
+    let(:api_key) { 'api-key' }
+    let(:token) { SecureRandom.uuid }
+    let(:school) { build(:school, id: SecureRandom.uuid, code: SecureRandom.uuid) }
+
+    before do
+      stub_request(:post, "#{api_url}/api/v1/schools").to_return(status: 201, body: '{}')
+      allow(ENV).to receive(:fetch).with('IDENTITY_URL').and_return(api_url)
+      allow(ENV).to receive(:fetch).with('PROFILE_API_KEY').and_return(api_key)
+    end
+
+    it 'makes a request to the profile api host' do
+      described_class.create_school(token:, school:)
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools")
+    end
+
+    it 'includes token in the authorization request header' do
+      described_class.create_school(token:, school:)
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { authorization: "Bearer #{token}" })
+    end
+
+    it 'includes the profile api key in the x-api-key request header' do
+      described_class.create_school(token:, school:)
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'x-api-key' => api_key })
+    end
+
+    it 'sets content-type of request to json' do
+      described_class.create_school(token:, school:)
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'sets accept header to json' do
+      described_class.create_school(token:, school:)
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'accept' => 'application/json' })
+    end
+
+    it 'sends the school id and code in the request body as json' do
+      described_class.create_school(token:, school:)
+      expected_body = { id: school.id, schoolCode: school.code }.to_json
+      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(body: expected_body)
+    end
+
+    it 'returns the created school if successful' do
+      data = { 'id' => 'school-id', 'schoolCode' => 'school-code' }
+      stub_request(:post, "#{api_url}/api/v1/schools")
+        .to_return(status: 201, body: data.to_json)
+      expect(described_class.create_school(token:, school:)).to eq(data)
+    end
+
+    it 'raises exception if anything other than a 201 status code is returned' do
+      stub_request(:post, "#{api_url}/api/v1/schools")
+        .to_return(status: 200)
+
+      expect { described_class.create_school(token:, school:) }.to raise_error(RuntimeError)
+    end
+
+    it 'includes details of underlying response when exception is raised' do
+      stub_request(:post, "#{api_url}/api/v1/schools")
+        .to_return(status: 401)
+
+      expect { described_class.create_school(token:, school:) }.to raise_error('School not created in Profile API. HTTP response code: 401')
+    end
+  end
+end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -66,5 +66,21 @@ RSpec.describe ProfileApiClient do
 
       expect { described_class.create_school(token:, school:) }.to raise_error('School not created in Profile API. HTTP response code: 401')
     end
+
+    describe 'when BYPASS_OAUTH is true' do
+      before do
+        allow(ENV).to receive(:[]).with('BYPASS_OAUTH').and_return(true)
+      end
+
+      it 'does not make a request to Profile API' do
+        described_class.create_school(token:, school:)
+        expect(WebMock).not_to have_requested(:post, "#{api_url}/api/v1/schools")
+      end
+
+      it 'returns the id and code of the school supplied' do
+        expected = { 'id' => school.id, 'schoolCode' => school.code }
+        expect(described_class.create_school(token:, school:)).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/lib/school_code_generator_spec.rb
+++ b/spec/lib/school_code_generator_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SchoolCodeGenerator do
+  describe '.generate' do
+    it 'uses Random#rand to generate a random number up to the maximum' do
+      random = instance_double(Random)
+      allow(random).to receive(:rand).with(SchoolCodeGenerator::MAX_CODE).and_return(123)
+      allow(Random).to receive(:new).and_return(random)
+
+      expect(described_class.generate).to eq('00-01-23')
+    end
+
+    it 'generates a string containing 3 pairs of digits' do
+      expect(described_class.generate).to match(/\d\d-\d\d-\d\d/)
+    end
+
+    it 'generates a different code each time' do
+      expect(described_class.generate).not_to eq(described_class.generate)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe User do
     end
     let(:info) { info_without_organisations }
     let(:user) { described_class.new(info) }
+    let(:credentials) { { token: 'token' } }
 
     let(:auth) do
       OmniAuth::AuthHash.new(
@@ -125,7 +126,8 @@ RSpec.describe User do
           uid: id,
           extra: {
             raw_info: info
-          }
+          },
+          credentials:
         }
       )
     end
@@ -140,6 +142,10 @@ RSpec.describe User do
 
     it 'returns a user with the correct name' do
       expect(auth_subject.name).to eq 'John Doe'
+    end
+
+    it 'returns a user with the access token supplied in credentials' do
+      expect(auth_subject.token).to eq 'token'
     end
 
     it 'returns a user with the correct email' do
@@ -162,6 +168,14 @@ RSpec.describe User do
       let(:auth) { nil }
 
       it { is_expected.to be_nil }
+    end
+
+    context 'with no credentials set' do
+      let(:credentials) { nil }
+
+      it 'returns a user with no token' do
+        expect(auth_subject.token).to be_nil
+      end
     end
   end
 

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe SchoolVerificationService do
         expect(school.reload.verified_at).to be_a(ActiveSupport::TimeWithZone)
       end
 
+      it 'generates school code' do
+        service.verify
+        expect(school.reload.code).to be_present
+      end
+
       it 'grants the creator the owner role for the school' do
         service.verify
         expect(school_creator).to be_school_owner(school)

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -9,36 +9,46 @@ RSpec.describe SchoolVerificationService do
   let(:school_creator) { create(:user) }
   let(:service) { described_class.new(school) }
   let(:organisation_id) { SecureRandom.uuid }
+  let(:token) { 'token' }
+
+  before do
+    allow(ProfileApiClient).to receive(:create_school)
+  end
 
   describe '#verify' do
     describe 'when school can be saved' do
       it 'saves the school' do
-        service.verify
+        service.verify(token:)
         expect(school).to be_persisted
       end
 
       it 'sets verified_at to a date' do
-        service.verify
+        service.verify(token:)
         expect(school.reload.verified_at).to be_a(ActiveSupport::TimeWithZone)
       end
 
       it 'generates school code' do
-        service.verify
+        service.verify(token:)
         expect(school.reload.code).to be_present
       end
 
       it 'grants the creator the owner role for the school' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).to be_school_owner(school)
       end
 
       it 'grants the creator the teacher role for the school' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).to be_school_teacher(school)
       end
 
+      it 'creates the school in Profile API' do
+        service.verify(token:)
+        expect(ProfileApiClient).to have_received(:create_school).with(token:, school:)
+      end
+
       it 'returns true' do
-        expect(service.verify).to be(true)
+        expect(service.verify(token:)).to be(true)
       end
     end
 
@@ -46,22 +56,55 @@ RSpec.describe SchoolVerificationService do
       let(:website) { 'invalid' }
 
       it 'does not save the school' do
-        service.verify
+        service.verify(token:)
         expect(school).not_to be_persisted
       end
 
       it 'does not create owner role' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).not_to be_school_owner(school)
       end
 
       it 'does not create teacher role' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).not_to be_school_teacher(school)
       end
 
+      it 'does not create school in Profile API' do
+        expect(ProfileApiClient).not_to have_received(:create_school)
+      end
+
       it 'returns false' do
-        expect(service.verify).to be(false)
+        expect(service.verify(token:)).to be(false)
+      end
+    end
+
+    describe 'when the school cannot be created in Profile API' do
+      before do
+        allow(ProfileApiClient).to receive(:create_school).and_raise(RuntimeError)
+      end
+
+      it 'does not save the school' do
+        service.verify(token:)
+        expect { school.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'does not create owner role' do
+        service.verify(token:)
+        expect(school_creator).not_to be_school_owner(school)
+      end
+
+      it 'does not create teacher role' do
+        service.verify(token:)
+        expect(school_creator).not_to be_school_teacher(school)
+      end
+
+      it 'does not create school in Profile API' do
+        expect(ProfileApiClient).not_to have_received(:create_school)
+      end
+
+      it 'returns false' do
+        expect(service.verify(token:)).to be(false)
       end
     end
 
@@ -73,22 +116,26 @@ RSpec.describe SchoolVerificationService do
       end
 
       it 'does not save the school' do
-        service.verify
+        service.verify(token:)
         expect { school.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'does not create owner role' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).not_to be_school_owner(school)
       end
 
       it 'does not create teacher role' do
-        service.verify
+        service.verify(token:)
         expect(school_creator).not_to be_school_teacher(school)
       end
 
+      it 'does not create school in Profile API' do
+        expect(ProfileApiClient).not_to have_received(:create_school)
+      end
+
       it 'returns false' do
-        expect(service.verify).to be(false)
+        expect(service.verify(token:)).to be(false)
       end
     end
   end
@@ -110,7 +157,7 @@ RSpec.describe SchoolVerificationService do
 
   describe 'when the school was previously verified' do
     before do
-      service.verify
+      service.verify(token:)
       service.reject
       school.reload
     end

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -59,6 +59,33 @@ RSpec.describe SchoolVerificationService do
         expect(service.verify).to be(false)
       end
     end
+
+    describe 'when teacher and owner roles cannot be created because they already have a role in another school' do
+      let(:another_school) { create(:school) }
+
+      before do
+        create(:role, user_id: school.creator_id, school: another_school)
+      end
+
+      it 'does not save the school' do
+        service.verify
+        expect { school.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'does not create owner role' do
+        service.verify
+        expect(school_creator).not_to be_school_owner(school)
+      end
+
+      it 'does not create teacher role' do
+        service.verify
+        expect(school_creator).not_to be_school_teacher(school)
+      end
+
+      it 'returns false' do
+        expect(service.verify).to be(false)
+      end
+    end
   end
 
   describe '#reject' do


### PR DESCRIPTION
This PR expands `SchoolVerificationService#verify` so that it uses the Profile API to create the school in Profile during verification. If any part of verification fails (updating the school, creating the teacher and owner roles, or creating the school in Profile API) then we abort verification and display a message saying that verification failed.

- [x] Set `PROFILE_API_KEY` in staging
- [x] Set `PROFILE_API_KEY` in production