### PR TITLE
Make `User.from_token` robust to invalid token

### DIFF
--- a/lib/hydra_public_api_client.rb
+++ b/lib/hydra_public_api_client.rb
@@ -20,6 +20,9 @@ class HydraPublicApiClient
 
     response = get('userinfo', {}, { Authorization: "Bearer #{token}" })
     response.body.to_h
+  rescue Faraday::UnauthorizedError => e
+    Sentry.capture_exception(e)
+    nil
   end
 
   private


### PR DESCRIPTION
Previously, when an API request was made using an expired or invalid access token, a `Faraday::UnauthorizedError` was raised and the request failed.

Recently we've seen a bunch of [these exceptions][3] happening due to some other problems in editor-standalone and/or in the editor-ui web component - see [this issue][1] for more details.

Failing hard with an exception like this seems a bit over the top when the user is trying to view a public project for which they don't need to be logged-in. And it seems as if `User.from_token` might have been [expecting][2] `HydraPublicApiClient.fetch_oauth_user` to return `nil` when the token was invalid when in fact it returns a `401 Unauthorized` HTTP status code which results in a `Faraday::UnauthorizedError` exception being raised.

This commit rescues the `Faraday::UnauthorizedError` exception, captures the exception in Sentry in case we want to know about it, but then returns `nil`. This means that if the user is trying to carry out an action that does not require them to be logged-in, they can still do so despite their access token not being valid.

[1]: https://github.com/RaspberryPiFoundation/editor-ui/issues/1044
[2]: https://github.com/RaspberryPiFoundation/editor-api/blob/055741503b0ad295e44993c9f55b2fc95e912beb/app/models/user.rb#L91
[3]: https://rpf.sentry.io/issues/5135885959/events/?project=6143981