### PR TITLE
Fix projects admin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN gem install bundler \
   && apt-get update \
   && apt-get upgrade --yes \
   && apt-get install --yes --no-install-recommends \
-  libpq5 libxml2 libxslt1.1 \
+  libpq5 libxml2 libxslt1.1 libvips \
   curl gnupg graphviz nodejs \
   && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
   && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -17,7 +17,9 @@ module Admin
     private
 
     def set_host_for_local_storage
-      ActiveStorage::Current.host = request.base_url if Rails.application.config.active_storage.service == :local
+      return unless Rails.application.config.active_storage.service == :local
+
+      ActiveStorage::Current.url_options = { host: request.base_url }
     end
   end
 end


### PR DESCRIPTION
Installing libvips in the Docker container and replacing `ActiveStorage::Current.host=` with `ActiveStorage::Current.url_options=` means that /admin/projects renders without errors and the images can be displayed.