### PR TITLE
Prepare for generating school codes

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -2,17 +2,6 @@
 
 module Admin
   class SchoolsController < Admin::ApplicationController
-    def authorized_action?(resource, action)
-      case action
-      when :verify_school
-        resource&.rejected? || !resource&.verified?
-      when :reject_school
-        resource&.verified? || !resource&.rejected?
-      else
-        super
-      end
-    end
-
     def verify_school
       school_id = params[:school_id]
       service = SchoolVerificationService.new(school_id)

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -5,9 +5,9 @@ module Admin
     def authorized_action?(resource, action)
       case action
       when :verify_school
-        resource&.rejected_at.present? || !resource&.verified?
+        resource&.rejected? || !resource&.verified?
       when :reject_school
-        resource&.verified? || resource&.rejected_at.nil?
+        resource&.verified? || !resource&.rejected?
       else
         super
       end

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -3,8 +3,7 @@
 module Admin
   class SchoolsController < Admin::ApplicationController
     def verify
-      school = School.find(params[:id])
-      service = SchoolVerificationService.new(school)
+      service = SchoolVerificationService.new(requested_resource)
 
       if service.verify
         flash[:notice] = t('administrate.controller.verify_school.success')
@@ -12,12 +11,11 @@ module Admin
         flash[:error] = t('administrate.controller.verify_school.error')
       end
 
-      redirect_to admin_school_path(school)
+      redirect_to admin_school_path(requested_resource)
     end
 
     def reject
-      school = School.find(params[:id])
-      service = SchoolVerificationService.new(school)
+      service = SchoolVerificationService.new(requested_resource)
 
       if service.reject
         flash[:notice] = t('administrate.controller.reject_school.success')
@@ -25,7 +23,7 @@ module Admin
         flash[:error] = t('administrate.controller.reject_school.error')
       end
 
-      redirect_to admin_school_path(school)
+      redirect_to admin_school_path(requested_resource)
     end
 
     def default_sorting_attribute

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class SchoolsController < Admin::ApplicationController
-    def verify_school
+    def verify
       school_id = params[:id]
       service = SchoolVerificationService.new(school_id)
 
@@ -15,7 +15,7 @@ module Admin
       redirect_to admin_school_path(id: school_id)
     end
 
-    def reject_school
+    def reject
       school_id = params[:id]
       service = SchoolVerificationService.new(school_id)
 

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -3,8 +3,8 @@
 module Admin
   class SchoolsController < Admin::ApplicationController
     def verify
-      school_id = params[:id]
-      service = SchoolVerificationService.new(school_id)
+      school = School.find(params[:id])
+      service = SchoolVerificationService.new(school)
 
       if service.verify
         flash[:notice] = t('administrate.controller.verify_school.success')
@@ -12,12 +12,12 @@ module Admin
         flash[:error] = t('administrate.controller.verify_school.error')
       end
 
-      redirect_to admin_school_path(id: school_id)
+      redirect_to admin_school_path(school)
     end
 
     def reject
-      school_id = params[:id]
-      service = SchoolVerificationService.new(school_id)
+      school = School.find(params[:id])
+      service = SchoolVerificationService.new(school)
 
       if service.reject
         flash[:notice] = t('administrate.controller.reject_school.success')
@@ -25,7 +25,7 @@ module Admin
         flash[:error] = t('administrate.controller.reject_school.error')
       end
 
-      redirect_to admin_school_path(id: school_id)
+      redirect_to admin_school_path(school)
     end
 
     def default_sorting_attribute

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -5,9 +5,9 @@ module Admin
     def authorized_action?(resource, action)
       case action
       when :verify_school
-        resource&.rejected_at.present? || resource&.verified_at.nil?
+        resource&.rejected_at.present? || !resource&.verified?
       when :reject_school
-        resource&.verified_at.present? || resource&.rejected_at.nil?
+        resource&.verified? || resource&.rejected_at.nil?
       else
         super
       end

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class SchoolsController < Admin::ApplicationController
     def verify_school
-      school_id = params[:school_id]
+      school_id = params[:id]
       service = SchoolVerificationService.new(school_id)
 
       if service.verify
@@ -16,7 +16,7 @@ module Admin
     end
 
     def reject_school
-      school_id = params[:school_id]
+      school_id = params[:id]
       service = SchoolVerificationService.new(school_id)
 
       if service.reject

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,6 +47,10 @@ class School < ApplicationRecord
     update!(verified_at: Time.zone.now)
   end
 
+  def reject
+    update(rejected_at: Time.zone.now)
+  end
+
   private
 
   # Ensure the reference is nil, not an empty string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -31,6 +31,10 @@ class School < ApplicationRecord
     User.from_userinfo(ids: creator_id).first
   end
 
+  def verified?
+    verified_at.present?
+  end
+
   private
 
   # Ensure the reference is nil, not an empty string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -19,6 +19,7 @@ class School < ApplicationRecord
   validates :creator_agree_terms_and_conditions, presence: true, acceptance: true
   validates :rejected_at, absence: { if: proc { |school| school.verified? } }
   validates :verified_at, absence: { if: proc { |school| school.rejected? } }
+  validate :verified_at_cannot_be_changed
 
   before_validation :normalize_reference
 
@@ -46,5 +47,9 @@ class School < ApplicationRecord
   # Ensure the reference is nil, not an empty string
   def normalize_reference
     self.reference = nil if reference.blank?
+  end
+
+  def verified_at_cannot_be_changed
+    errors.add(:verified_at, 'cannot be changed after verification') if verified_at_was.present? && verified_at_changed?
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -20,6 +20,7 @@ class School < ApplicationRecord
   validates :rejected_at, absence: { if: proc { |school| school.verified? } }
   validates :verified_at, absence: { if: proc { |school| school.rejected? } }
   validate :verified_at_cannot_be_changed
+  validate :rejected_at_cannot_be_changed
 
   before_validation :normalize_reference
 
@@ -51,5 +52,9 @@ class School < ApplicationRecord
 
   def verified_at_cannot_be_changed
     errors.add(:verified_at, 'cannot be changed after verification') if verified_at_was.present? && verified_at_changed?
+  end
+
+  def rejected_at_cannot_be_changed
+    errors.add(:rejected_at, 'cannot be changed after rejection') if rejected_at_was.present? && rejected_at_changed?
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -43,6 +43,10 @@ class School < ApplicationRecord
     rejected_at.present?
   end
 
+  def verify!
+    update!(verified_at: Time.zone.now)
+  end
+
   private
 
   # Ensure the reference is nil, not an empty string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -35,6 +35,10 @@ class School < ApplicationRecord
     verified_at.present?
   end
 
+  def rejected?
+    rejected_at.present?
+  end
+
   private
 
   # Ensure the reference is nil, not an empty string

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -17,6 +17,8 @@ class School < ApplicationRecord
   validates :creator_id, presence: true, uniqueness: true
   validates :creator_agree_authority, presence: true, acceptance: true
   validates :creator_agree_terms_and_conditions, presence: true, acceptance: true
+  validates :rejected_at, absence: { if: proc { |school| school.verified? } }
+  validates :verified_at, absence: { if: proc { |school| school.rejected? } }
 
   before_validation :normalize_reference
 

--- a/app/models/teacher_invitation.rb
+++ b/app/models/teacher_invitation.rb
@@ -16,7 +16,7 @@ class TeacherInvitation < ApplicationRecord
   private
 
   def school_is_verified
-    return if school.verified_at
+    return if school.verified?
 
     errors.add(:school, 'is not verified')
   end

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -10,7 +10,7 @@ class SchoolVerificationService
   # rubocop:disable Metrics/AbcSize
   def verify
     School.transaction do
-      school.update!(verified_at: Time.zone.now, rejected_at: nil)
+      school.verify!
       Role.owner.create(user_id: school.creator_id, school:)
       Role.teacher.create(user_id: school.creator_id, school:)
     end

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -8,13 +8,14 @@ class SchoolVerificationService
   def verify
     School.transaction do
       school = School.find(@school_id)
-      school.update(verified_at: Time.zone.now, rejected_at: nil)
+      school.update!(verified_at: Time.zone.now, rejected_at: nil)
+
       Role.owner.create(user_id: school.creator_id, school:)
       Role.teacher.create(user_id: school.creator_id, school:)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)
-    Rails.logger.error { "Failed to verify school #{school_id}: #{e.message}" }
+    Rails.logger.error { "Failed to verify school #{@school_id}: #{e.message}" }
     false
   else
     true

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -23,7 +23,5 @@ class SchoolVerificationService
   end
   # rubocop:enable Metrics/AbcSize
 
-  def reject
-    school.update(verified_at: nil, rejected_at: Time.zone.now)
-  end
+  delegate :reject, to: :school
 end

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class SchoolVerificationService
-  def initialize(school_id)
-    @school_id = school_id
+  attr_reader :school
+
+  def initialize(school)
+    @school = school
   end
 
+  # rubocop:disable Metrics/AbcSize
   def verify
     School.transaction do
-      school = School.find(@school_id)
       school.update!(verified_at: Time.zone.now, rejected_at: nil)
-
       Role.owner.create(user_id: school.creator_id, school:)
       Role.teacher.create(user_id: school.creator_id, school:)
     end
@@ -20,9 +21,9 @@ class SchoolVerificationService
   else
     true
   end
+  # rubocop:enable Metrics/AbcSize
 
   def reject
-    school = School.find(@school_id)
     school.update(verified_at: nil, rejected_at: Time.zone.now)
   end
 end

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -32,7 +32,7 @@ as well as a link to its edit page.
 
     <%= link_to(
       t("administrate.actions.verify_school"),
-      admin_school_verify_school_path(page.resource),
+      verify_school_admin_school_path(page.resource),
       class: "button button--verify",
       method: :post,
       style: "background-color: green; margin: 5px;",
@@ -41,7 +41,7 @@ as well as a link to its edit page.
 
     <%= link_to(
       t("administrate.actions.reject_school"),
-      admin_school_reject_school_path(page.resource),
+      reject_school_admin_school_path(page.resource),
       class: "button button--danger",
       method: :patch,
       style: "background-color: hsla(0, 88%, 33%, 1); margin: 5px 5px 5px 0;",

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -37,7 +37,7 @@ as well as a link to its edit page.
       method: :post,
       style: "background-color: green; margin: 5px;",
       data: { confirm: t("administrate.actions.confirm_verify_school") }
-    ) unless page.resource.verified? %>
+    ) unless page.resource.verified? || page.resource.rejected? %>
 
     <%= link_to(
       t("administrate.actions.reject_school"),
@@ -46,7 +46,7 @@ as well as a link to its edit page.
       method: :patch,
       style: "background-color: hsla(0, 88%, 33%, 1); margin: 5px 5px 5px 0;",
       data: { confirm: t("administrate.actions.confirm_reject_school") }
-    ) unless page.resource.rejected? %>
+    ) unless page.resource.verified? || page.resource.rejected? %>
   </div>
 </header>
 

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -32,7 +32,7 @@ as well as a link to its edit page.
 
     <%= link_to(
       t("administrate.actions.verify_school"),
-      verify_school_admin_school_path(page.resource),
+      verify_admin_school_path(page.resource),
       class: "button button--verify",
       method: :post,
       style: "background-color: green; margin: 5px;",
@@ -41,7 +41,7 @@ as well as a link to its edit page.
 
     <%= link_to(
       t("administrate.actions.reject_school"),
-      reject_school_admin_school_path(page.resource),
+      reject_admin_school_path(page.resource),
       class: "button button--danger",
       method: :patch,
       style: "background-color: hsla(0, 88%, 33%, 1); margin: 5px 5px 5px 0;",

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -37,7 +37,7 @@ as well as a link to its edit page.
       method: :post,
       style: "background-color: green; margin: 5px;",
       data: { confirm: t("administrate.actions.confirm_verify_school") }
-    ) if accessible_action?(page.resource, :verify_school) %>
+    ) unless page.resource.verified? %>
 
     <%= link_to(
       t("administrate.actions.reject_school"),
@@ -46,7 +46,7 @@ as well as a link to its edit page.
       method: :patch,
       style: "background-color: hsla(0, 88%, 33%, 1); margin: 5px 5px 5px 0;",
       data: { confirm: t("administrate.actions.confirm_reject_school") }
-    ) if accessible_action?(page.resource, :reject_school) %>
+    ) unless page.resource.rejected? %>
   </div>
 </header>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,10 @@ Rails.application.routes.draw do
     end
 
     resources :schools, only: %i[index show edit update] do
-      post :verify_school
-      patch :reject_school
+      member do
+        post :verify_school
+        patch :reject_school
+      end
     end
 
     resources :school_classes, only: %i[show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
 
     resources :schools, only: %i[index show edit update] do
       member do
-        post :verify_school
-        patch :reject_school
+        post :verify
+        patch :reject
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
     end
 
     resources :schools, only: %i[index show edit update] do
-      post :verify_school, action: :verify_school
-      patch :reject_school, action: :reject_school
+      post :verify_school
+      patch :reject_school
     end
 
     resources :school_classes, only: %i[show]

--- a/lib/concepts/school_owner/invite.rb
+++ b/lib/concepts/school_owner/invite.rb
@@ -18,7 +18,7 @@ module SchoolOwner
       def invite_owner(school, school_owner_params, token)
         email_address = school_owner_params.fetch(:email_address)
 
-        raise ArgumentError, 'school is not verified' unless school.verified_at
+        raise ArgumentError, 'school is not verified' unless school.verified?
         raise ArgumentError, "email address '#{email_address}' is invalid" unless EmailValidator.valid?(email_address)
 
         ProfileApiClient.invite_school_owner(token:, email_address:, organisation_id: school.id)

--- a/lib/concepts/school_student/create.rb
+++ b/lib/concepts/school_student/create.rb
@@ -27,7 +27,7 @@ module SchoolStudent
       end
 
       def validate(school:, username:, password:, name:)
-        raise ArgumentError, 'school is not verified' unless school.verified_at
+        raise ArgumentError, 'school is not verified' unless school.verified?
         raise ArgumentError, "username '#{username}' is invalid" if username.blank?
         raise ArgumentError, "password '#{password}' is invalid" if password.size < 8
         raise ArgumentError, "name '#{name}' is invalid" if name.blank?

--- a/lib/concepts/school_student/create_batch.rb
+++ b/lib/concepts/school_student/create_batch.rb
@@ -30,7 +30,7 @@ module SchoolStudent
       def validate(school:, sheet:)
         expected_header = ['Student Name', 'Username', 'Password']
 
-        raise ArgumentError, 'school is not verified' unless school.verified_at
+        raise ArgumentError, 'school is not verified' unless school.verified?
         raise ArgumentError, 'the spreadsheet header row is invalid' unless sheet.row(1) == expected_header
 
         @errors = []

--- a/lib/tasks/classroom_management_helper.rb
+++ b/lib/tasks/classroom_management_helper.rb
@@ -25,7 +25,7 @@ module ClassroomManagementHelper
 
   def verify_school(school)
     Rails.logger.info 'Verifying the school...'
-    SchoolVerificationService.new(school.id).verify
+    SchoolVerificationService.new(school).verify
   end
 
   def create_school_class(teacher_id, school)

--- a/spec/concepts/school_owner/invite_spec.rb
+++ b/spec/concepts/school_owner/invite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SchoolOwner::Invite, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:owner_id) { SecureRandom.uuid }
 
   let(:school_owner_params) do

--- a/spec/concepts/school_student/create_batch_spec.rb
+++ b/spec/concepts/school_student/create_batch_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SchoolStudent::CreateBatch, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:file) { fixture_file_upload('students.csv') }
 
   before do

--- a/spec/concepts/school_student/create_spec.rb
+++ b/spec/concepts/school_student/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SchoolStudent::Create, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
 
   let(:school_student_params) do
     {

--- a/spec/concepts/school_teacher/invite_spec.rb
+++ b/spec/concepts/school_teacher/invite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SchoolTeacher::Invite, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:teacher_id) { SecureRandom.uuid }
 
   let(:school_teacher_params) do

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Schools', type: :request do
       stub_user_info_api_for(creator)
       allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
 
-      post admin_school_verify_school_path(school)
+      post verify_school_admin_school_path(school)
     end
 
     it 'redirects to school path' do
@@ -117,7 +117,7 @@ RSpec.describe 'Schools', type: :request do
       stub_user_info_api_for(creator)
       allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
 
-      patch admin_school_reject_school_path(school)
+      patch reject_school_admin_school_path(school)
     end
 
     it 'redirects to school path' do

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Schools', type: :request do
     end
   end
 
-  describe 'POST #verify_school' do
+  describe 'POST #verify' do
     let(:creator) { create(:user) }
     let(:verified_at) { nil }
     let(:school) { create(:school, creator_id: creator.id, verified_at:) }
@@ -75,7 +75,7 @@ RSpec.describe 'Schools', type: :request do
       stub_user_info_api_for(creator)
       allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
 
-      post verify_school_admin_school_path(school)
+      post verify_admin_school_path(school)
     end
 
     it 'redirects to school path' do
@@ -107,7 +107,7 @@ RSpec.describe 'Schools', type: :request do
     end
   end
 
-  describe 'PUT #reject_school' do
+  describe 'PUT #reject' do
     let(:creator) { create(:user) }
     let(:school) { create(:school, creator_id: creator.id) }
     let(:rejection_result) { nil }
@@ -117,7 +117,7 @@ RSpec.describe 'Schools', type: :request do
       stub_user_info_api_for(creator)
       allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
 
-      patch reject_school_admin_school_path(school)
+      patch reject_admin_school_path(school)
     end
 
     it 'redirects to school path' do

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Schools', type: :request do
 
     before do
       stub_user_info_api_for(creator)
-      allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
+      allow(SchoolVerificationService).to receive(:new).with(school).and_return(verification_service)
 
       post verify_admin_school_path(school)
     end
@@ -115,7 +115,7 @@ RSpec.describe 'Schools', type: :request do
 
     before do
       stub_user_info_api_for(creator)
-      allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
+      allow(SchoolVerificationService).to receive(:new).with(school).and_return(verification_service)
 
       patch reject_admin_school_path(school)
     end

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Schools', type: :request do
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    sign_in_as(admin_user)
+  end
+
+  describe 'GET #index' do
+    it 'responds 200' do
+      get admin_schools_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #show' do
+    let(:creator) { create(:user) }
+    let(:verified_at) { nil }
+    let(:rejected_at) { nil }
+    let(:school) { create(:school, creator_id: creator.id, verified_at:, rejected_at:) }
+
+    before do
+      stub_user_info_api_for(creator)
+      get admin_school_path(school)
+    end
+
+    it 'responds 200' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'includes link to verify school' do
+      expect(response.body).to include(I18n.t('administrate.actions.verify_school'))
+    end
+
+    it 'includes link to reject school' do
+      expect(response.body).to include(I18n.t('administrate.actions.reject_school'))
+    end
+
+    describe 'when the school is verified' do
+      let(:verified_at) { Time.zone.now }
+
+      it 'does not include a link to verify school' do
+        expect(response.body).not_to include(I18n.t('administrate.actions.verify_school'))
+      end
+
+      it 'includes link to reject school' do
+        expect(response.body).to include(I18n.t('administrate.actions.reject_school'))
+      end
+    end
+
+    describe 'when the school is rejected' do
+      let(:rejected_at) { Time.zone.now }
+
+      it 'includes a link to verify school' do
+        expect(response.body).to include(I18n.t('administrate.actions.verify_school'))
+      end
+
+      it 'does not include a link to reject school' do
+        expect(response.body).not_to include(I18n.t('administrate.actions.reject_school'))
+      end
+    end
+  end
+
+  describe 'POST #verify_school' do
+    let(:creator) { create(:user) }
+    let(:verified_at) { nil }
+    let(:school) { create(:school, creator_id: creator.id, verified_at:) }
+    let(:verification_result) { nil }
+    let(:verification_service) { instance_double(SchoolVerificationService, verify: verification_result) }
+
+    before do
+      stub_user_info_api_for(creator)
+      allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
+
+      post admin_school_verify_school_path(school)
+    end
+
+    it 'redirects to school path' do
+      expect(response).to redirect_to(admin_school_path(school))
+    end
+
+    describe 'when verification was successful' do
+      let(:verification_result) { true }
+
+      before do
+        follow_redirect!
+      end
+
+      it 'displays success message' do
+        expect(response.body).to include(I18n.t('administrate.controller.verify_school.success'))
+      end
+    end
+
+    describe 'when verification was unsuccessful' do
+      let(:verification_result) { false }
+
+      before do
+        follow_redirect!
+      end
+
+      it 'displays failure message' do
+        expect(response.body).to include(I18n.t('administrate.controller.verify_school.error'))
+      end
+    end
+  end
+
+  describe 'PUT #reject_school' do
+    let(:creator) { create(:user) }
+    let(:school) { create(:school, creator_id: creator.id) }
+    let(:rejection_result) { nil }
+    let(:verification_service) { instance_double(SchoolVerificationService, reject: rejection_result) }
+
+    before do
+      stub_user_info_api_for(creator)
+      allow(SchoolVerificationService).to receive(:new).with(school.id).and_return(verification_service)
+
+      patch admin_school_reject_school_path(school)
+    end
+
+    it 'redirects to school path' do
+      expect(response).to redirect_to(admin_school_path(school))
+    end
+
+    describe 'when rejection was successful' do
+      let(:rejection_result) { true }
+
+      before do
+        follow_redirect!
+      end
+
+      it 'displays success message' do
+        expect(response.body).to include(I18n.t('administrate.controller.reject_school.success'))
+      end
+    end
+
+    describe 'when rejection was unsuccessful' do
+      let(:rejection_result) { false }
+
+      before do
+        follow_redirect!
+      end
+
+      it 'displays failure message' do
+        expect(response.body).to include(I18n.t('administrate.controller.reject_school.error'))
+      end
+    end
+  end
+
+  private
+
+  def sign_in_as(user)
+    allow(User).to receive(:from_omniauth).and_return(user)
+    get '/auth/callback'
+  end
+end

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -46,16 +46,16 @@ RSpec.describe 'Schools', type: :request do
         expect(response.body).not_to include(I18n.t('administrate.actions.verify_school'))
       end
 
-      it 'includes link to reject school' do
-        expect(response.body).to include(I18n.t('administrate.actions.reject_school'))
+      it 'does not include a link to reject school' do
+        expect(response.body).not_to include(I18n.t('administrate.actions.reject_school'))
       end
     end
 
     describe 'when the school is rejected' do
       let(:rejected_at) { Time.zone.now }
 
-      it 'includes a link to verify school' do
-        expect(response.body).to include(I18n.t('administrate.actions.verify_school'))
+      it 'does not include a link to verify school' do
+        expect(response.body).not_to include(I18n.t('administrate.actions.verify_school'))
       end
 
       it 'does not include a link to reject school' do

--- a/spec/features/school_owner/inviting_a_school_owner_spec.rb
+++ b/spec/features/school_owner/inviting_a_school_owner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Inviting a school owner', type: :request do
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:owner) { create(:owner, school:) }
 
   let(:params) do

--- a/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
+++ b/spec/features/school_student/creating_a_batch_of_school_students_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Creating a batch of school students', type: :request do
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:student_id) { SecureRandom.uuid }
   let(:owner) { create(:owner, school:) }
 

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Creating a school student', type: :request do
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:owner) { create(:owner, school:) }
 
   let(:params) do

--- a/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
+++ b/spec/features/school_teacher/inviting_a_school_teacher_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Inviting a school teacher', type: :request do
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
-  let(:school) { create(:school, verified_at: Time.zone.now) }
+  let(:school) { create(:verified_school) }
   let(:teacher_id) { SecureRandom.uuid }
   let(:owner) { create(:owner, school:) }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -229,4 +229,16 @@ RSpec.describe School do
       expect(school).not_to be_verified
     end
   end
+
+  describe '#rejected?' do
+    it 'returns true when rejected_at is present' do
+      school.rejected_at = Time.zone.now
+      expect(school).to be_rejected
+    end
+
+    it 'returns false when rejected_at is blank' do
+      school.rejected_at = nil
+      expect(school).not_to be_rejected
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -195,6 +195,12 @@ RSpec.describe School do
       school.update(verified_at: nil)
       expect(school.errors[:verified_at]).to include('cannot be changed after verification')
     end
+
+    it "cannot change #rejected_at once it's been set" do
+      school.update!(rejected_at: Time.zone.now)
+      school.update(rejected_at: nil)
+      expect(school.errors[:rejected_at]).to include('cannot be changed after rejection')
+    end
   end
 
   describe '#creator' do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -180,12 +180,12 @@ RSpec.describe School do
 
     it 'cannot have #rejected_at set when #verified_at is present' do
       school.verify!
-      school.update(rejected_at: Time.zone.now)
+      school.reject
       expect(school.errors[:rejected_at]).to include('must be blank')
     end
 
     it 'cannot have #verified_at set when #rejected_at is present' do
-      school.update!(rejected_at: Time.zone.now)
+      school.reject
       school.update(verified_at: Time.zone.now)
       expect(school.errors[:verified_at]).to include('must be blank')
     end
@@ -197,7 +197,7 @@ RSpec.describe School do
     end
 
     it "cannot change #rejected_at once it's been set" do
-      school.update!(rejected_at: Time.zone.now)
+      school.reject
       school.update(rejected_at: nil)
       expect(school.errors[:rejected_at]).to include('cannot be changed after rejection')
     end
@@ -279,6 +279,22 @@ RSpec.describe School do
     it 'raises ActiveRecord::RecordInvalid if verification fails' do
       school.rejected_at = Time.zone.now
       expect { school.verify! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe '#reject' do
+    it 'sets rejected_at to the current time' do
+      school.reject
+      expect(school.rejected_at).to be_within(1.second).of(Time.zone.now)
+    end
+
+    it 'returns true on successful rejection' do
+      expect(school.reject).to be(true)
+    end
+
+    it 'returns false on unsuccessful rejection' do
+      school.verified_at = Time.zone.now
+      expect(school.reject).to be(false)
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -177,6 +177,18 @@ RSpec.describe School do
       school.creator_agree_terms_and_conditions = false
       expect(school).to be_invalid
     end
+
+    it 'cannot have #rejected_at set when #verified_at is present' do
+      school.update!(verified_at: Time.zone.now)
+      school.update(rejected_at: Time.zone.now)
+      expect(school.errors[:rejected_at]).to include('must be blank')
+    end
+
+    it 'cannot have #verified_at set when #rejected_at is present' do
+      school.update!(rejected_at: Time.zone.now)
+      school.update(verified_at: Time.zone.now)
+      expect(school.errors[:verified_at]).to include('must be blank')
+    end
   end
 
   describe '#creator' do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -217,4 +217,16 @@ RSpec.describe School do
       expect { described_class.find_for_user!(user) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '#verified?' do
+    it 'returns true when verified_at is present' do
+      school.verified_at = Time.zone.now
+      expect(school).to be_verified
+    end
+
+    it 'returns false when verified_at is blank' do
+      school.verified_at = nil
+      expect(school).not_to be_verified
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe School do
     end
 
     it 'cannot have #rejected_at set when #verified_at is present' do
-      school.update!(verified_at: Time.zone.now)
+      school.verify!
       school.update(rejected_at: Time.zone.now)
       expect(school.errors[:rejected_at]).to include('must be blank')
     end
@@ -191,7 +191,7 @@ RSpec.describe School do
     end
 
     it "cannot change #verified_at once it's been set" do
-      school.update!(verified_at: Time.zone.now)
+      school.verify!
       school.update(verified_at: nil)
       expect(school.errors[:verified_at]).to include('cannot be changed after verification')
     end
@@ -263,6 +263,22 @@ RSpec.describe School do
     it 'returns false when rejected_at is blank' do
       school.rejected_at = nil
       expect(school).not_to be_rejected
+    end
+  end
+
+  describe '#verify!' do
+    it 'sets verified_at to the current time' do
+      school.verify!
+      expect(school.verified_at).to be_within(1.second).of(Time.zone.now)
+    end
+
+    it 'returns true on successful verification' do
+      expect(school.verify!).to be(true)
+    end
+
+    it 'raises ActiveRecord::RecordInvalid if verification fails' do
+      school.rejected_at = Time.zone.now
+      expect { school.verify! }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -189,6 +189,12 @@ RSpec.describe School do
       school.update(verified_at: Time.zone.now)
       expect(school.errors[:verified_at]).to include('must be blank')
     end
+
+    it "cannot change #verified_at once it's been set" do
+      school.update!(verified_at: Time.zone.now)
+      school.update(verified_at: nil)
+      expect(school.errors[:verified_at]).to include('cannot be changed after verification')
+    end
   end
 
   describe '#creator' do

--- a/spec/models/teacher_invitation_spec.rb
+++ b/spec/models/teacher_invitation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe TeacherInvitation do
   end
 
   it 'sends an invitation email after create' do
-    school = create(:school, verified_at: Time.zone.now)
+    school = create(:verified_school)
 
     invitation = described_class.create!(email_address: 'teacher@example.com', school:)
 

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe SchoolVerificationService do
     it 'grants the creator the owner role for the school' do
       expect(school_creator).to be_school_owner(school)
     end
+
+    it 'grants the creator the teacher role for the school' do
+      expect(school_creator).to be_school_teacher(school)
+    end
   end
 
   describe '#reject' do

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -10,21 +10,62 @@ RSpec.describe SchoolVerificationService do
   let(:organisation_id) { SecureRandom.uuid }
 
   describe '#verify' do
-    before do
-      service.verify
-      school.reload
+    describe 'when school can be saved' do
+      it 'sets verified_at to a date' do
+        service.verify
+        expect(school.reload.verified_at).to be_a(ActiveSupport::TimeWithZone)
+      end
+
+      it 'grants the creator the owner role for the school' do
+        service.verify
+        expect(school_creator).to be_school_owner(school)
+      end
+
+      it 'grants the creator the teacher role for the school' do
+        service.verify
+        expect(school_creator).to be_school_teacher(school)
+      end
+
+      it 'returns true' do
+        expect(service.verify).to be(true)
+      end
     end
 
-    it 'sets verified_at to a date' do
-      expect(school.verified_at).to be_a(ActiveSupport::TimeWithZone)
+    describe 'when school cannot be saved' do
+      before do
+        school.update_attribute(:website, 'invalid') # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      it 'does not set verified_at' do
+        service.verify
+        expect(school.reload.verified_at).to be_nil
+      end
+
+      it 'does not create owner role' do
+        service.verify
+        expect(school_creator).not_to be_school_owner(school)
+      end
+
+      it 'does not create teacher role' do
+        service.verify
+        expect(school_creator).not_to be_school_teacher(school)
+      end
+
+      it 'returns false' do
+        expect(service.verify).to be(false)
+      end
     end
 
-    it 'grants the creator the owner role for the school' do
-      expect(school_creator).to be_school_owner(school)
-    end
+    describe 'when the school cannot be found' do
+      before do
+        allow(Sentry).to receive(:capture_exception)
+        allow(School).to receive(:find).with(school.id).and_raise(ActiveRecord::RecordNotFound)
+        service.verify
+      end
 
-    it 'grants the creator the teacher role for the school' do
-      expect(school_creator).to be_school_teacher(school)
+      it 'reports the error in Sentry' do
+        expect(Sentry).to have_received(:capture_exception)
+      end
     end
   end
 

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe SchoolVerificationService do
-  let(:school) { create(:school, creator_id: school_creator.id) }
+  let(:website) { 'http://example.com' }
+  let(:school) { build(:school, creator_id: school_creator.id, website:) }
   let(:user) { create(:user) }
   let(:school_creator) { create(:user) }
   let(:service) { described_class.new(school) }
@@ -11,6 +12,11 @@ RSpec.describe SchoolVerificationService do
 
   describe '#verify' do
     describe 'when school can be saved' do
+      it 'saves the school' do
+        service.verify
+        expect(school).to be_persisted
+      end
+
       it 'sets verified_at to a date' do
         service.verify
         expect(school.reload.verified_at).to be_a(ActiveSupport::TimeWithZone)
@@ -32,13 +38,11 @@ RSpec.describe SchoolVerificationService do
     end
 
     describe 'when school cannot be saved' do
-      before do
-        school.update_attribute(:website, 'invalid') # rubocop:disable Rails/SkipsModelValidations
-      end
+      let(:website) { 'invalid' }
 
-      it 'does not set verified_at' do
+      it 'does not save the school' do
         service.verify
-        expect(school.reload.verified_at).to be_nil
+        expect(school).not_to be_persisted
       end
 
       it 'does not create owner role' do

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -83,12 +83,12 @@ RSpec.describe SchoolVerificationService do
       school.reload
     end
 
-    it 'sets verified_at to nil' do
-      expect(school.verified_at).to be_nil
+    it 'does not reset verified_at' do
+      expect(school.verified_at).to be_present
     end
 
-    it 'sets rejected_at to a date' do
-      expect(school.rejected_at).to be_a(ActiveSupport::TimeWithZone)
+    it 'does not set rejected_at' do
+      expect(school.rejected_at).to be_nil
     end
   end
 end

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SchoolVerificationService do
   let(:school) { create(:school, creator_id: school_creator.id) }
   let(:user) { create(:user) }
   let(:school_creator) { create(:user) }
-  let(:service) { described_class.new(school.id) }
+  let(:service) { described_class.new(school) }
   let(:organisation_id) { SecureRandom.uuid }
 
   describe '#verify' do
@@ -53,18 +53,6 @@ RSpec.describe SchoolVerificationService do
 
       it 'returns false' do
         expect(service.verify).to be(false)
-      end
-    end
-
-    describe 'when the school cannot be found' do
-      before do
-        allow(Sentry).to receive(:capture_exception)
-        allow(School).to receive(:find).with(school.id).and_raise(ActiveRecord::RecordNotFound)
-        service.verify
-      end
-
-      it 'reports the error in Sentry' do
-        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end


### PR DESCRIPTION
This is mostly a refactoring PR in preparation for creating a school in Profile API upon verification in Editor API. Once we're creating schools in Profile API we'll need to keep them in sync with the data in Editor API. To make that easier this PR restricts a verified school from being rejected so that we don't have to handle updating/deleting schools in Profile API (at least for now).

This PR also:

- tightens up validation so that a school can only have one of `verified_at` or `rejected_at` set at a time, and so that once set those values can't be changed.
- adds tests around verification and rejection of schools in the admin UI before then simplifying those controller actions.
- fixes a bug in `SchoolVerificationService#verify` whereby a failed verification would appear to have been successful to the user.