### PR TITLE
Admin: Add created_at to school index record and set default ordering

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -38,5 +38,13 @@ module Admin
 
       redirect_to admin_school_path(id: school_id)
     end
+
+    def default_sorting_attribute
+      :created_at
+    end
+
+    def default_sorting_direction
+      :desc
+    end
   end
 end

--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -38,6 +38,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     name
     reference
     country_code
+    created_at
     verified_at
     rejected_at
   ].freeze
@@ -94,5 +95,13 @@ class SchoolDashboard < Administrate::BaseDashboard
   #
   def display_resource(school)
     school.name.to_s
+  end
+
+  def default_sorting_attribute
+    :created_at
+  end
+
+  def default_sorting_direction
+    :desc
   end
 end

--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -96,12 +96,4 @@ class SchoolDashboard < Administrate::BaseDashboard
   def display_resource(school)
     school.name.to_s
   end
-
-  def default_sorting_attribute
-    :created_at
-  end
-
-  def default_sorting_direction
-    :desc
-  end
 end


### PR DESCRIPTION
Adds `created_at` field to the schools admin panel index / listing view, and sets the default order to `created_at` and `desc`.

This is to make it easier for folk verifying schools to handle the process more easily by more clearly seeing new schools which have been created and require verification.

The listing can still be ordered by any other field if needed (eg. name).