### PR TITLE
Allow teacher invitation to be accepted multiple times

### DIFF
--- a/app/controllers/api/teacher_invitations_controller.rb
+++ b/app/controllers/api/teacher_invitations_controller.rb
@@ -13,9 +13,8 @@ module Api
     end
 
     def accept
-      role = Role.teacher.build(user_id: current_user.id, school: @invitation.school)
-      if role.valid?
-        role.save
+      role = Role.teacher.find_or_initialize_by(user_id: current_user.id, school: @invitation.school)
+      if role.save
         @invitation.update!(accepted_at: Time.current) if @invitation.accepted_at.blank?
         head :ok
       else


### PR DESCRIPTION
## Status

- Related to:
    - #336
    - #RaspberryPiFoundation/editor-standalone#181
    - the [Invite teachers](https://github.com/orgs/RaspberryPiFoundation/projects/51/views/11?pane=issue&itemId=67112446) epic

## Points for consideration:

- Security: This shouldn't have any impact on security
- Performance: This shouldn't have any impact on performance

## What's changed?

This was unnecessarily strict which made testing in development a bit harder than it needed to be.

Previously we were always trying to create a new teacher role in the school and responding with a 422 Unprocessalbe entity (with a validation error) if the user already had that role. Now we respond with 200 OK and leave the existing role in place. We also set `TeacherInvitation#accepted_at` if it hasn't already been set.

## Steps to perform after deploying to production

None.