### PR TITLE
Encrypt teacher invitation email address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
       POSTGRES_USER: choco
       POSTGRES_HOST: "127.0.0.1"
       RAILS_ENV: test
+      ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY: primary-key
+      ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY: deterministic-key
+      ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: derivation-salt
     steps:
       - checkout
       - browser-tools/install-firefox

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,8 @@ HOST_URL=http://localhost:3009
 EDITOR_PUBLIC_URL=http://localhost:3012
 
 PROFILE_API_KEY=test # This has to match the value set in Profile (https://github.com/RaspberryPiFoundation/profile/blob/ca10a4f360b6fe2b04be76264e03283054126b0f/.env.example#L45).
+
+# Run bin/rails db:encryption:init to generate values for these if you need to encrypt securely locally.
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=primary-key
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=deterministic-key
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=derivation-salt

--- a/app/models/teacher_invitation.rb
+++ b/app/models/teacher_invitation.rb
@@ -8,6 +8,7 @@ class TeacherInvitation < ApplicationRecord
             format: { with: EmailValidator.regexp, message: I18n.t('validations.invitation.email_address') }
   validate :school_is_verified
   after_create_commit :send_invitation_email
+  encrypts :email_address
 
   generates_token_for :teacher_invitation, expires_in: 30.days do
     email_address

--- a/config/initializers/encryption.rb
+++ b/config/initializers/encryption.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.active_record.encryption.primary_key = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')
+  config.active_record.encryption.deterministic_key = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY')
+  config.active_record.encryption.key_derivation_salt = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT')
+end

--- a/spec/models/teacher_invitation_spec.rb
+++ b/spec/models/teacher_invitation_spec.rb
@@ -64,4 +64,11 @@ RSpec.describe TeacherInvitation do
 
     expect(invitation.school_name).to eq('school-name')
   end
+
+  it 'non-deterministically encrypts the email_address' do
+    school = create(:verified_school)
+    described_class.create!(email_address: 'teacher@example.com', school:)
+
+    expect(described_class.find_by(email_address: 'teacher@example.com')).to be_nil
+  end
 end


### PR DESCRIPTION
## Status

Related to: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/159

## What's changed?

This PR ensures that the `email_address` field on the `teacher_invitations` table is encrypted. We can't currently avoid storing this PII in the editor-api database (as we need to use the email adress to send the invitation email) but this change helps mitigate the risk of someone getting access to the production database. 

We haven't sent any teacher invitation emails in production yet, so we don't need to worry about migrating or encrypting any existing data. 

## Steps to perform before deploying to production

We need to set the following ENV variables on non-local environments: 

ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT

Rails provides a command, `bin/rails db:encryption:init` to generate suitable values for these, but any long non-guessable strings should be fine. 



