### PR TITLE
Fix copy in teacher invitation email

### DIFF
--- a/app/views/invitation_mailer/invite_teacher.text.erb
+++ b/app/views/invitation_mailer/invite_teacher.text.erb
@@ -2,7 +2,7 @@ You have been invited to join:
 
 <%= @school.name %>
 
-Being part of this school account will allow you to access the school dashboard in the Code Editor and create coding lessons for students.
+Being part of this school account will allow you to access the school dashboard in the Code Editor and create coding projects for students.
 
 Join school:
 


### PR DESCRIPTION
Replacing "create coding lessons for students" with "create coding projects for students" as per the copy review with Max and Mel.