### PR TITLE
Create students in Profile API

### DIFF
--- a/app/controllers/api/school_students_controller.rb
+++ b/app/controllers/api/school_students_controller.rb
@@ -5,6 +5,7 @@ module Api
     before_action :authorize_user
     load_and_authorize_resource :school
     authorize_resource :school_student, class: false
+    before_action :create_safeguarding_flags
 
     def index
       result = SchoolStudent::List.call(school: @school, token: current_user.token)
@@ -61,6 +62,29 @@ module Api
 
     def school_student_params
       params.require(:school_student).permit(:username, :password, :name)
+    end
+
+    def create_safeguarding_flags
+      create_teacher_safeguarding_flag
+      create_owner_safeguarding_flag
+    end
+
+    def create_teacher_safeguarding_flag
+      return unless current_user.school_teacher?(@school)
+
+      ProfileApiClient.create_safeguarding_flag(
+        token: current_user.token,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher]
+      )
+    end
+
+    def create_owner_safeguarding_flag
+      return unless current_user.school_owner?(@school)
+
+      ProfileApiClient.create_safeguarding_flag(
+        token: current_user.token,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner]
+      )
     end
   end
 end

--- a/app/services/school_verification_service.rb
+++ b/app/services/school_verification_service.rb
@@ -13,7 +13,7 @@ class SchoolVerificationService
       school.verify!
       Role.owner.create!(user_id: school.creator_id, school:)
       Role.teacher.create!(user_id: school.creator_id, school:)
-      ProfileApiClient.create_school(token:, school:)
+      ProfileApiClient.create_school(token:, id: school.id, code: school.code)
     end
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/lib/concepts/school_student/create_batch.rb
+++ b/lib/concepts/school_student/create_batch.rb
@@ -23,7 +23,7 @@ module SchoolStudent
         validate(school:, sheet:)
 
         non_header_rows_with_content(sheet:).each do |name, username, password|
-          ProfileApiClient.create_school_student(token:, username:, password:, name:, organisation_id: school.id)
+          ProfileApiClient.create_school_student(token:, username:, password:, name:, school_id: school.id)
         end
       end
 

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -17,7 +17,7 @@ class ProfileApiClient
 
       raise "School not created in Profile API (status code #{response.status})" unless response.status == 201
 
-      JSON.parse(response.body)
+      response.body
     end
 
     # The API should enforce these constraints:
@@ -203,6 +203,7 @@ class ProfileApiClient
     def connection
       Faraday.new(ENV.fetch('IDENTITY_URL')) do |faraday|
         faraday.request :json
+        faraday.response :json
       end
     end
 

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -12,7 +12,7 @@ class ProfileApiClient
         request.body = {
           id:,
           schoolCode: code
-        }.to_json
+        }
       end
 
       raise "School not created in Profile API (status code #{response.status})" unless response.status == 201
@@ -201,13 +201,14 @@ class ProfileApiClient
     private
 
     def connection
-      Faraday.new(ENV.fetch('IDENTITY_URL'))
+      Faraday.new(ENV.fetch('IDENTITY_URL')) do |faraday|
+        faraday.request :json
+      end
     end
 
     def apply_default_headers(request, token)
       request.headers['Accept'] = 'application/json'
       request.headers['Authorization'] = "Bearer #{token}"
-      request.headers['Content-Type'] = 'application/json'
       request.headers['X-API-KEY'] = ENV.fetch('PROFILE_API_KEY')
       request
     end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -4,14 +4,14 @@ class ProfileApiClient
   class << self
     # TODO: Replace with HTTP requests once the profile API has been built.
 
-    def create_school(token:, school:)
-      return { 'id' => school.id, 'schoolCode' => school.code } if ENV['BYPASS_OAUTH'].present?
+    def create_school(token:, id:, code:)
+      return { 'id' => id, 'schoolCode' => code } if ENV['BYPASS_OAUTH'].present?
 
       response = connection.post('/api/v1/schools') do |request|
         apply_default_headers(request, token)
         request.body = {
-          id: school.id,
-          schoolCode: school.code
+          id:,
+          schoolCode: code
         }.to_json
       end
 

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -197,6 +197,16 @@ class ProfileApiClient
       response.deep_symbolize_keys
     end
 
+    def safeguarding_flags(token:)
+      response = connection(token).get('/api/v1/safeguarding-flags')
+
+      unless response.status == 200
+        raise "Safeguarding flags cannot be retrieved from Profile API (status code #{response.status})"
+      end
+
+      response.body.map(&:deep_symbolize_keys)
+    end
+
     private
 
     def connection(token)

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -222,6 +222,14 @@ class ProfileApiClient
       raise "Safeguarding flag not created in Profile API (status code #{response.status})"
     end
 
+    def delete_safeguarding_flag(token:, flag:)
+      response = connection(token).delete("/api/v1/safeguarding-flags/#{flag}")
+
+      return if response.status == 204
+
+      raise "Safeguarding flag not deleted from Profile API (status code #{response.status})"
+    end
+
     private
 
     def connection(token)

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ProfileApiClient
+  SAFEGUARDING_FLAGS = {
+    teacher: 'school:teacher',
+    owner: 'school:owner'
+  }.freeze
+
   class << self
     # TODO: Replace with HTTP requests once the profile API has been built.
 
@@ -205,6 +210,16 @@ class ProfileApiClient
       end
 
       response.body.map(&:deep_symbolize_keys)
+    end
+
+    def create_safeguarding_flag(token:, flag:)
+      response = connection(token).post('/api/v1/safeguarding-flags') do |request|
+        request.body = { flag: }
+      end
+
+      return if response.status == 201 || response.status == 303
+
+      raise "Safeguarding flag not created in Profile API (status code #{response.status})"
     end
 
     private

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -7,8 +7,7 @@ class ProfileApiClient
     def create_school(token:, id:, code:)
       return { 'id' => id, 'schoolCode' => code } if ENV['BYPASS_OAUTH'].present?
 
-      response = connection.post('/api/v1/schools') do |request|
-        apply_default_headers(request, token)
+      response = connection(token).post('/api/v1/schools') do |request|
         request.body = {
           id:,
           schoolCode: code
@@ -200,18 +199,16 @@ class ProfileApiClient
 
     private
 
-    def connection
+    def connection(token)
       Faraday.new(ENV.fetch('IDENTITY_URL')) do |faraday|
         faraday.request :json
         faraday.response :json
+        faraday.headers = {
+          'Accept' => 'application/json',
+          'Authorization' => "Bearer #{token}",
+          'X-API-KEY' => ENV.fetch('PROFILE_API_KEY')
+        }
       end
-    end
-
-    def apply_default_headers(request, token)
-      request.headers['Accept'] = 'application/json'
-      request.headers['Authorization'] = "Bearer #{token}"
-      request.headers['X-API-KEY'] = ENV.fetch('PROFILE_API_KEY')
-      request
     end
   end
 end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -15,7 +15,7 @@ class ProfileApiClient
         }.to_json
       end
 
-      raise "School not created in Profile API. HTTP response code: #{response.status}" unless response.status == 201
+      raise "School not created in Profile API (status code #{response.status})" unless response.status == 201
 
       JSON.parse(response.body)
     end

--- a/spec/concepts/school_student/create_batch_spec.rb
+++ b/spec/concepts/school_student/create_batch_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SchoolStudent::CreateBatch, type: :unit do
 
     # TODO: Replace with WebMock assertion once the profile API has been built.
     expect(ProfileApiClient).to have_received(:create_school_student)
-      .with(token:, username: 'jane123', password: 'secret123', name: 'Jane Doe', organisation_id: school.id)
+      .with(token:, username: 'jane123', password: 'secret123', name: 'Jane Doe', school_id: school.id)
   end
 
   it "makes a profile API call to create John Doe's account" do
@@ -29,7 +29,7 @@ RSpec.describe SchoolStudent::CreateBatch, type: :unit do
 
     # TODO: Replace with WebMock assertion once the profile API has been built.
     expect(ProfileApiClient).to have_received(:create_school_student)
-      .with(token:, username: 'john123', password: 'secret456', name: 'John Doe', organisation_id: school.id)
+      .with(token:, username: 'john123', password: 'secret456', name: 'John Doe', school_id: school.id)
   end
 
   context 'when an .xlsx file is provided' do

--- a/spec/features/school_student/creating_a_school_student_spec.rb
+++ b/spec/features/school_student/creating_a_school_student_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Creating a school student', type: :request do
   before do
     authenticated_in_hydra_as(owner)
     stub_profile_api_create_school_student
+    stub_profile_api_create_safeguarding_flag
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -22,6 +23,16 @@ RSpec.describe 'Creating a school student', type: :request do
     }
   end
 
+  it 'creates the school owner safeguarding flag' do
+    post("/api/schools/#{school.id}/students", headers:, params:)
+    expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner])
+  end
+
+  it 'does not create the school teacher safeguarding flag' do
+    post("/api/schools/#{school.id}/students", headers:, params:)
+    expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher])
+  end
+
   it 'responds 204 No Content' do
     post("/api/schools/#{school.id}/students", headers:, params:)
     expect(response).to have_http_status(:no_content)
@@ -33,6 +44,22 @@ RSpec.describe 'Creating a school student', type: :request do
 
     post("/api/schools/#{school.id}/students", headers:, params:)
     expect(response).to have_http_status(:no_content)
+  end
+
+  it 'does not create the school owner safeguarding flag when the user is a school teacher' do
+    teacher = create(:teacher, school:)
+    authenticated_in_hydra_as(teacher)
+
+    post("/api/schools/#{school.id}/students", headers:, params:)
+    expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner])
+  end
+
+  it 'creates the school teacher safeguarding flag when the user is a school teacher' do
+    teacher = create(:teacher, school:)
+    authenticated_in_hydra_as(teacher)
+
+    post("/api/schools/#{school.id}/students", headers:, params:)
+    expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher])
   end
 
   it 'responds 400 Bad Request when params are missing' do

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -6,12 +6,23 @@ RSpec.describe 'Deleting a school student', type: :request do
   before do
     authenticated_in_hydra_as(owner)
     stub_profile_api_delete_school_student
+    stub_profile_api_create_safeguarding_flag
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:student_id) { SecureRandom.uuid }
   let(:owner) { create(:owner, school:) }
+
+  it 'creates the school owner safeguarding flag' do
+    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner])
+  end
+
+  it 'does not create the school teacher safeguarding flag' do
+    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher])
+  end
 
   it 'responds 204 No Content' do
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
@@ -37,6 +48,22 @@ RSpec.describe 'Deleting a school student', type: :request do
 
     delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
     expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'does not create the school owner safeguarding flag when logged in as a teacher' do
+    teacher = create(:teacher, school:)
+    authenticated_in_hydra_as(teacher)
+
+    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner])
+  end
+
+  it 'does not create the school teacher safeguarding flag when logged in as a teacher' do
+    teacher = create(:teacher, school:)
+    authenticated_in_hydra_as(teacher)
+
+    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher])
   end
 
   it 'responds 403 Forbidden when the user is a school-student' do

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -12,6 +12,25 @@ RSpec.describe ProfileApiClient do
     allow(ENV).to receive(:fetch).with('PROFILE_API_KEY').and_return(api_key)
   end
 
+  describe ProfileApiClient::CreateStudent422Error do
+    subject(:exception) { described_class.new(error) }
+
+    let(:error_code) { 'ERR_USER_EXISTS' }
+    let(:error) { { 'username' => 'username', 'error' => error_code } }
+
+    it 'includes status code, username and translated error code in the message' do
+      expect(exception.message).to eq("Student not created in Profile API (status code 422, username 'username', error 'username has already been taken')")
+    end
+
+    context "when the error isn't recognised" do
+      let(:error_code) { 'unrecognised-code' }
+
+      it 'includes a default error message' do
+        expect(exception.message).to match(/error 'unknown error'/)
+      end
+    end
+  end
+
   describe '.create_school' do
     let(:school) { build(:school, id: SecureRandom.uuid, code: SecureRandom.uuid) }
     let(:create_school_url) { "#{api_url}/api/v1/schools" }
@@ -280,6 +299,86 @@ RSpec.describe ProfileApiClient do
 
     def delete_safeguarding_flag
       described_class.delete_safeguarding_flag(token:, flag:)
+    end
+  end
+
+  describe '.create_school_student' do
+    let(:username) { 'username' }
+    let(:password) { 'password' }
+    let(:name) { 'name' }
+    let(:school) { build(:school, id: SecureRandom.uuid) }
+    let(:create_students_url) { "#{api_url}/api/v1/schools/#{school.id}/students" }
+
+    before do
+      stub_request(:post, create_students_url).to_return(status: 201, body: '{}', headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'makes a request to the profile api host' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url)
+    end
+
+    it 'includes token in the authorization request header' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { authorization: "Bearer #{token}" })
+    end
+
+    it 'includes the profile api key in the x-api-key request header' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'x-api-key' => api_key })
+    end
+
+    it 'sets content-type of request to json' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'sets accept header to json' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'accept' => 'application/json' })
+    end
+
+    it 'sends the student details in the request body' do
+      create_school_student
+      expect(WebMock).to have_requested(:post, create_students_url).with(body: [{ name:, username:, password: }].to_json)
+    end
+
+    it 'returns the id of the created student(s) if successful' do
+      response = { created: ['student-id'] }
+      stub_request(:post, create_students_url)
+        .to_return(status: 201, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(create_school_student).to eq(response)
+    end
+
+    it 'raises 422 exception if 422 status code is returned' do
+      response = { errors: [username: 'username', error: 'ERR_USER_EXISTS'] }
+      stub_request(:post, create_students_url)
+        .to_return(status: 422, body: response.to_json, headers: { 'content-type' => 'application/json' })
+
+      expect { create_school_student }.to raise_error(ProfileApiClient::CreateStudent422Error)
+        .with_message("Student not created in Profile API (status code 422, username 'username', error 'username has already been taken')")
+    end
+
+    it 'raises exception if anything other that 201 status code is returned' do
+      stub_request(:post, create_students_url)
+        .to_return(status: 200)
+
+      expect { create_school_student }.to raise_error('Student not created in Profile API (status code 200)')
+    end
+
+    context 'when there are extraneous leading and trailing spaces in the student params' do
+      let(:username) { '  username  ' }
+      let(:password) { '  password  ' }
+      let(:name) { '  name  ' }
+
+      it 'strips the extraneous spaces' do
+        create_school_student
+        expect(WebMock).to have_requested(:post, create_students_url).with(body: [{ name: 'name', username: 'username', password: 'password' }].to_json)
+      end
+    end
+
+    def create_school_student
+      described_class.create_school_student(token:, username:, password:, name:, school_id: school.id)
     end
   end
 end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -229,4 +229,57 @@ RSpec.describe ProfileApiClient do
       described_class.create_safeguarding_flag(token:, flag:)
     end
   end
+
+  describe '.delete_safeguarding_flag' do
+    let(:flag) { 'school:owner' }
+    let(:delete_safeguarding_flag_url) { "#{api_url}/api/v1/safeguarding-flags/#{flag}" }
+
+    before do
+      stub_request(:delete, delete_safeguarding_flag_url).to_return(status: 204, body: '')
+    end
+
+    it 'makes a request to the profile api host' do
+      delete_safeguarding_flag
+      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url)
+    end
+
+    it 'includes token in the authorization request header' do
+      delete_safeguarding_flag
+      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { authorization: "Bearer #{token}" })
+    end
+
+    it 'includes the profile api key in the x-api-key request header' do
+      delete_safeguarding_flag
+      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { 'x-api-key' => api_key })
+    end
+
+    it 'sets accept header to json' do
+      delete_safeguarding_flag
+      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { 'accept' => 'application/json' })
+    end
+
+    it 'returns empty body if successful' do
+      stub_request(:delete, delete_safeguarding_flag_url)
+        .to_return(status: 204, body: '')
+      expect(delete_safeguarding_flag).to be_nil
+    end
+
+    it 'raises exception if anything other than a 204 status code is returned' do
+      stub_request(:delete, delete_safeguarding_flag_url)
+        .to_return(status: 200)
+
+      expect { delete_safeguarding_flag }.to raise_error(RuntimeError)
+    end
+
+    it 'includes details of underlying response when exception is raised' do
+      stub_request(:delete, delete_safeguarding_flag_url)
+        .to_return(status: 401)
+
+      expect { delete_safeguarding_flag }.to raise_error('Safeguarding flag not deleted from Profile API (status code 401)')
+    end
+
+    def delete_safeguarding_flag
+      described_class.delete_safeguarding_flag(token:, flag:)
+    end
+  end
 end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -160,4 +160,73 @@ RSpec.describe ProfileApiClient do
       described_class.safeguarding_flags(token:)
     end
   end
+
+  describe '.create_safeguarding_flag' do
+    let(:flag) { 'school:owner' }
+    let(:create_safeguarding_flag_url) { "#{api_url}/api/v1/safeguarding-flags" }
+
+    before do
+      stub_request(:post, create_safeguarding_flag_url).to_return(status: 201, body: '{}', headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'makes a request to the profile api host' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url)
+    end
+
+    it 'includes token in the authorization request header' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { authorization: "Bearer #{token}" })
+    end
+
+    it 'includes the profile api key in the x-api-key request header' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'x-api-key' => api_key })
+    end
+
+    it 'sets content-type of request to json' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'sets accept header to json' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'accept' => 'application/json' })
+    end
+
+    it 'sends the safeguarding flag in the request body' do
+      create_safeguarding_flag
+      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(body: { flag: }.to_json)
+    end
+
+    it 'returns empty body if created successfully' do
+      stub_request(:post, create_safeguarding_flag_url)
+        .to_return(status: 201)
+      expect(create_safeguarding_flag).to be_nil
+    end
+
+    it 'returns empty body if 303 response returned to indicate that the flag already exists' do
+      stub_request(:post, create_safeguarding_flag_url)
+        .to_return(status: 303)
+      expect(create_safeguarding_flag).to be_nil
+    end
+
+    it 'raises exception if anything other than a 201 or 303 status code is returned' do
+      stub_request(:post, create_safeguarding_flag_url)
+        .to_return(status: 200)
+
+      expect { create_safeguarding_flag }.to raise_error(RuntimeError)
+    end
+
+    it 'includes details of underlying response when exception is raised' do
+      stub_request(:post, create_safeguarding_flag_url)
+        .to_return(status: 401)
+
+      expect { create_safeguarding_flag }.to raise_error('Safeguarding flag not created in Profile API (status code 401)')
+    end
+
+    def create_safeguarding_flag
+      described_class.create_safeguarding_flag(token:, flag:)
+    end
+  end
 end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ProfileApiClient do
       stub_request(:post, create_school_url)
         .to_return(status: 401)
 
-      expect { create_school }.to raise_error('School not created in Profile API. HTTP response code: 401')
+      expect { create_school }.to raise_error('School not created in Profile API (status code 401)')
     end
 
     describe 'when BYPASS_OAUTH is true' do

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ProfileApiClient do
     private
 
     def create_school
-      described_class.create_school(token:, school:)
+      described_class.create_school(token:, id: school.id, code: school.code)
     end
   end
 end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProfileApiClient do
     it 'returns the created school if successful' do
       data = { 'id' => 'school-id', 'schoolCode' => 'school-code' }
       stub_request(:post, create_school_url)
-        .to_return(status: 201, body: data.to_json)
+        .to_return(status: 201, body: data.to_json, headers: { 'Content-Type' => 'application/json' })
       expect(create_school).to eq(data)
     end
 

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -8,63 +8,64 @@ RSpec.describe ProfileApiClient do
     let(:api_key) { 'api-key' }
     let(:token) { SecureRandom.uuid }
     let(:school) { build(:school, id: SecureRandom.uuid, code: SecureRandom.uuid) }
+    let(:create_school_url) { "#{api_url}/api/v1/schools" }
 
     before do
-      stub_request(:post, "#{api_url}/api/v1/schools").to_return(status: 201, body: '{}')
+      stub_request(:post, create_school_url).to_return(status: 201, body: '{}')
       allow(ENV).to receive(:fetch).with('IDENTITY_URL').and_return(api_url)
       allow(ENV).to receive(:fetch).with('PROFILE_API_KEY').and_return(api_key)
     end
 
     it 'makes a request to the profile api host' do
-      described_class.create_school(token:, school:)
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools")
+      create_school
+      expect(WebMock).to have_requested(:post, create_school_url)
     end
 
     it 'includes token in the authorization request header' do
-      described_class.create_school(token:, school:)
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { authorization: "Bearer #{token}" })
+      create_school
+      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { authorization: "Bearer #{token}" })
     end
 
     it 'includes the profile api key in the x-api-key request header' do
-      described_class.create_school(token:, school:)
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'x-api-key' => api_key })
+      create_school
+      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'x-api-key' => api_key })
     end
 
     it 'sets content-type of request to json' do
-      described_class.create_school(token:, school:)
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'content-type' => 'application/json' })
+      create_school
+      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'content-type' => 'application/json' })
     end
 
     it 'sets accept header to json' do
-      described_class.create_school(token:, school:)
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(headers: { 'accept' => 'application/json' })
+      create_school
+      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'accept' => 'application/json' })
     end
 
     it 'sends the school id and code in the request body as json' do
-      described_class.create_school(token:, school:)
+      create_school
       expected_body = { id: school.id, schoolCode: school.code }.to_json
-      expect(WebMock).to have_requested(:post, "#{api_url}/api/v1/schools").with(body: expected_body)
+      expect(WebMock).to have_requested(:post, create_school_url).with(body: expected_body)
     end
 
     it 'returns the created school if successful' do
       data = { 'id' => 'school-id', 'schoolCode' => 'school-code' }
-      stub_request(:post, "#{api_url}/api/v1/schools")
+      stub_request(:post, create_school_url)
         .to_return(status: 201, body: data.to_json)
-      expect(described_class.create_school(token:, school:)).to eq(data)
+      expect(create_school).to eq(data)
     end
 
     it 'raises exception if anything other than a 201 status code is returned' do
-      stub_request(:post, "#{api_url}/api/v1/schools")
+      stub_request(:post, create_school_url)
         .to_return(status: 200)
 
-      expect { described_class.create_school(token:, school:) }.to raise_error(RuntimeError)
+      expect { create_school }.to raise_error(RuntimeError)
     end
 
     it 'includes details of underlying response when exception is raised' do
-      stub_request(:post, "#{api_url}/api/v1/schools")
+      stub_request(:post, create_school_url)
         .to_return(status: 401)
 
-      expect { described_class.create_school(token:, school:) }.to raise_error('School not created in Profile API. HTTP response code: 401')
+      expect { create_school }.to raise_error('School not created in Profile API. HTTP response code: 401')
     end
 
     describe 'when BYPASS_OAUTH is true' do
@@ -73,14 +74,20 @@ RSpec.describe ProfileApiClient do
       end
 
       it 'does not make a request to Profile API' do
-        described_class.create_school(token:, school:)
-        expect(WebMock).not_to have_requested(:post, "#{api_url}/api/v1/schools")
+        create_school
+        expect(WebMock).not_to have_requested(:post, create_school_url)
       end
 
       it 'returns the id and code of the school supplied' do
         expected = { 'id' => school.id, 'schoolCode' => school.code }
-        expect(described_class.create_school(token:, school:)).to eq(expected)
+        expect(create_school).to eq(expected)
       end
+    end
+
+    private
+
+    def create_school
+      described_class.create_school(token:, school:)
     end
   end
 end

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -3,17 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe ProfileApiClient do
+  let(:api_url) { 'http://example.com' }
+  let(:api_key) { 'api-key' }
+  let(:token) { SecureRandom.uuid }
+
+  before do
+    allow(ENV).to receive(:fetch).with('IDENTITY_URL').and_return(api_url)
+    allow(ENV).to receive(:fetch).with('PROFILE_API_KEY').and_return(api_key)
+  end
+
   describe '.create_school' do
-    let(:api_url) { 'http://example.com' }
-    let(:api_key) { 'api-key' }
-    let(:token) { SecureRandom.uuid }
     let(:school) { build(:school, id: SecureRandom.uuid, code: SecureRandom.uuid) }
     let(:create_school_url) { "#{api_url}/api/v1/schools" }
 
     before do
       stub_request(:post, create_school_url).to_return(status: 201, body: '{}')
-      allow(ENV).to receive(:fetch).with('IDENTITY_URL').and_return(api_url)
-      allow(ENV).to receive(:fetch).with('PROFILE_API_KEY').and_return(api_key)
     end
 
     it 'makes a request to the profile api host' do
@@ -88,6 +92,72 @@ RSpec.describe ProfileApiClient do
 
     def create_school
       described_class.create_school(token:, id: school.id, code: school.code)
+    end
+  end
+
+  describe '.safeguarding_flags' do
+    let(:list_safeguarding_flags_url) { "#{api_url}/api/v1/safeguarding-flags" }
+
+    before do
+      stub_request(:get, list_safeguarding_flags_url).to_return(status: 200, body: '[]', headers: { 'content-type' => 'application/json' })
+    end
+
+    it 'makes a request to the profile api host' do
+      list_safeguarding_flags
+      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url)
+    end
+
+    it 'includes token in the authorization request header' do
+      list_safeguarding_flags
+      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { authorization: "Bearer #{token}" })
+    end
+
+    it 'includes the profile api key in the x-api-key request header' do
+      list_safeguarding_flags
+      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { 'x-api-key' => api_key })
+    end
+
+    it 'sets accept header to json' do
+      list_safeguarding_flags
+      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { 'accept' => 'application/json' })
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns list of safeguarding flags if successful' do
+      flags = [
+        {
+          id: '7ac79585-e187-4d2f-bf0c-a1cbe72ecc9a',
+          userId: '583ba872-b16e-46e1-9f7d-df89d267550d',
+          flag: 'school:owner',
+          isActive: 'true',
+          createdAt: '2024-07-01T12:49:18.926Z',
+          updatedAt: '2024-07-01T12:49:18.926Z'
+        }
+      ]
+      stub_request(:get, list_safeguarding_flags_url)
+        .to_return(status: 200, body: flags.to_json, headers: { 'content-type' => 'application/json' })
+      expect(list_safeguarding_flags).to eq(flags)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'raises exception if anything other than a 200 status code is returned' do
+      stub_request(:get, list_safeguarding_flags_url)
+        .to_return(status: 201)
+
+      expect { list_safeguarding_flags }.to raise_error(RuntimeError)
+    end
+
+    it 'includes details of underlying response when exception is raised' do
+      stub_request(:get, list_safeguarding_flags_url)
+        .to_return(status: 401)
+
+      expect { list_safeguarding_flags }.to raise_error('Safeguarding flags cannot be retrieved from Profile API (status code 401)')
+    end
+
+    private
+
+    def list_safeguarding_flags
+      described_class.safeguarding_flags(token:)
     end
   end
 end

--- a/spec/services/school_verification_service_spec.rb
+++ b/spec/services/school_verification_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SchoolVerificationService do
 
       it 'creates the school in Profile API' do
         service.verify(token:)
-        expect(ProfileApiClient).to have_received(:create_school).with(token:, school:)
+        expect(ProfileApiClient).to have_received(:create_school).with(token:, id: school.id, code: school.code)
       end
 
       it 'returns true' do

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -27,8 +27,8 @@ module ProfileApiMock
     allow(ProfileApiClient).to receive(:list_school_students).and_return(ids: [user_id])
   end
 
-  def stub_profile_api_create_school_student
-    allow(ProfileApiClient).to receive(:create_school_student)
+  def stub_profile_api_create_school_student(user_id: SecureRandom.uuid)
+    allow(ProfileApiClient).to receive(:create_school_student).and_return(created: [user_id])
   end
 
   def stub_profile_api_update_school_student

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -38,4 +38,8 @@ module ProfileApiMock
   def stub_profile_api_delete_school_student
     allow(ProfileApiClient).to receive(:delete_school_student)
   end
+
+  def stub_profile_api_create_safeguarding_flag
+    allow(ProfileApiClient).to receive(:create_safeguarding_flag)
+  end
 end


### PR DESCRIPTION
With this PR we're now creating students in Profile API when they're added in editor-standalone. There are a number of commits but they should all be fairly easy to follow in isolation:

- The first 5 commits refactor the `ProfileApiClient` in preparation for implementing `.create_school_student`.
- The next 3 commits add methods to `ProfileApiClient` to list, create and destroy safeguarding flags in Profile API.
- The penultimate commit adds a `before_filter` to  `SchoolStudentsController` that creates the relevant (teacher and/or owner) safeguarding flags in Profile API for the authenticated user.
- The final commit modifies `.create_school_student` so that it creates a student in Profile API.

Although the create student endpoint in Profile API allows us to create multiple students in a single request, we're currently only ever calling it with a single student: even in the `SchoolStudent::CreateBatch` operation. We're also not currently using the create batch endpoint in the editor-standalone CSV import functionality, and are instead making a request for each row in the CSV file. This will need more work as it currently only displays a single error message, rather than all error messages preventing students from being created.
