### PR TITLE
Add POSTMARK_API_TOKEN to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ EDITOR_PUBLIC_URL=http://localhost:3012
 
 PROFILE_API_KEY=test # This has to match the value set in Profile (https://github.com/RaspberryPiFoundation/profile/blob/ca10a4f360b6fe2b04be76264e03283054126b0f/.env.example#L45).
 
+# The application is configured to log sent emails in development. If
+# you need to send emails using Postmark set the following environment
+# variable. API tokens are available through the postmark interface:
+# https://account.postmarkapp.com/servers
+# POSTMARK_API_TOKEN=<api-token>
+
 # Run bin/rails db:encryption:init to generate values for these if you need to encrypt securely locally.
 ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=primary-key
 ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=deterministic-key


### PR DESCRIPTION
The POSTMARK_API_TOKEN variable introduced in 4ab58c49c494 doesn't need to be set in development, but it is useful to document how to set it if we want to use Postmark in development (e.g. when developing/testing HTML emails).
