### PR TITLE
List class member students

### DIFF
--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -45,7 +45,7 @@ module Api
     private
 
     def class_member_params
-      params.require(:class_member).permit(student_ids: [])
+      params.require(:class_member).permit(:student_id, student_ids: [])
     end
   end
 end

--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -11,7 +11,7 @@ module Api
       @class_members = @school_class.members.accessible_by(current_ability)
       student_ids = @class_members.pluck(:student_id)
 
-      result = SchoolStudent::List.call(school: @school, token: current_user.token, student_ids: student_ids)
+      result = SchoolStudent::List.call(school: @school, token: current_user.token, student_ids:)
 
       if result.success?
         @school_students = result[:school_students]

--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -8,8 +8,17 @@ module Api
     load_and_authorize_resource :class_member, through: :school_class, through_association: :members
 
     def index
-      @class_members_with_students = @school_class.members.accessible_by(current_ability).with_students
-      render :index, formats: [:json], status: :ok
+      @class_members = @school_class.members.accessible_by(current_ability)
+      student_ids = @class_members.pluck(:student_id)
+
+      result = SchoolStudent::List.call(school: @school, token: current_user.token, student_ids: student_ids)
+
+      if result.success?
+        @school_students = result[:school_students]
+        render :index, formats: [:json], status: :ok
+      else
+        render json: { error: result[:error] }, status: :unprocessable_entity
+      end
     end
 
     def create
@@ -36,7 +45,7 @@ module Api
     private
 
     def class_member_params
-      params.require(:class_member).permit(:student_id)
+      params.require(:class_member).permit(student_ids: [])
     end
   end
 end

--- a/app/views/api/class_members/index.json.jbuilder
+++ b/app/views/api/class_members/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.array!(@class_members_with_students) do |class_member, student|
+json.array!(@class_members, @school_students) do |class_member|
   json.call(
     class_member,
     :id,
@@ -10,6 +10,16 @@ json.array!(@class_members_with_students) do |class_member, student|
     :updated_at
   )
 
-  json.student_username(student&.username)
-  json.student_name(student&.name)
+  school_student = @school_students.find { |student| student.id == class_member.student_id }
+
+  if school_student.present?
+    json.set! :student do
+      json.call(
+        school_student,
+        :id,
+        :username,
+        :name
+      )
+    end
+  end
 end

--- a/lib/concepts/school_student/list.rb
+++ b/lib/concepts/school_student/list.rb
@@ -3,9 +3,9 @@
 module SchoolStudent
   class List
     class << self
-      def call(school:, token:)
+      def call(school:, token:, student_ids: nil)
         response = OperationResponse.new
-        response[:school_students] = list_students(school, token)
+        response[:school_students] = list_students(school, token, student_ids)
         response
       rescue StandardError => e
         Sentry.capture_exception(e)
@@ -15,8 +15,8 @@ module SchoolStudent
 
       private
 
-      def list_students(school, token)
-        student_ids = Role.student.where(school:).map(&:user_id)
+      def list_students(school, token, student_ids)
+        student_ids ||= Role.student.where(school:).map(&:user_id)
         ProfileApiClient.list_school_students(token:, school_id: school.id, student_ids:).map do |student|
           User.new(student.to_h.slice(:id, :username, :name))
         end

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -5,49 +5,99 @@ require 'rails_helper'
 RSpec.describe SchoolStudent::List, type: :unit do
   let(:token) { UserProfileMock::TOKEN }
   let(:school) { create(:school) }
-  let(:student) { create(:student, school:) }
+  let(:students) { create_list(:student, 3, school:) }
 
-  before do
-    stub_profile_api_list_school_students(school:, id: student.id, name: 'name', username: 'username')
-    stub_user_info_api_for(student)
+  context 'without student_ids' do
+    before do
+      student_attributes = students.map do |student|
+        { id: student.id, name: student.name, username: student.username }
+      end
+      stub_profile_api_list_school_students(school:, student_attributes:)
+    end
+
+    it 'returns a successful operation response' do
+      response = described_class.call(school:, token:)
+      expect(response.success?).to be(true)
+    end
+
+    it 'makes a profile API call' do
+      described_class.call(school:, token:)
+
+      # TODO: Replace with WebMock assertion once the profile API has been built.
+      expect(ProfileApiClient).to have_received(:list_school_students).with(token:, school_id: school.id, student_ids: students.map(&:id))
+    end
+
+    it 'returns a school students JSON array' do
+      response = described_class.call(school:, token:)
+      expect(response[:school_students].size).to eq(3)
+    end
+
+    it 'returns the school students in the operation response' do
+      response = described_class.call(school:, token:)
+      students.each do |student|
+        expected_user = User.new(id: student.id, name: student.name, username: student.username)
+        expect(response[:school_students]).to include(expected_user)
+      end
+    end
   end
 
-  it 'returns a successful operation response' do
-    response = described_class.call(school:, token:)
-    expect(response.success?).to be(true)
-  end
+  context 'with student_ids' do
+    let(:student_ids) { students.map(&:id).take(2) }
+    let(:filtered_students) { students.select { |student| student_ids.include?(student.id) } }
 
-  it 'makes a profile API call' do
-    described_class.call(school:, token:)
+    before do
+      student_attributes = filtered_students.map do |student|
+        { id: student.id, name: student.name, username: student.username }
+      end
+      stub_profile_api_list_school_students(school:, student_attributes:)
+    end
+  
+    it 'returns a successful operation response' do
+      response = described_class.call(school:, token:, student_ids:)
+      expect(response.success?).to be(true)
+    end
 
-    # TODO: Replace with WebMock assertion once the profile API has been built.
-    expect(ProfileApiClient).to have_received(:list_school_students).with(token:, school_id: school.id, student_ids: [student.id])
-  end
+    it 'makes a profile API call' do
+      described_class.call(school:, token:, student_ids:)
 
-  it 'returns the school students in the operation response' do
-    response = described_class.call(school:, token:)
-    expected_user = User.new(id: student.id, name: 'name', username: 'username')
-    expect(response[:school_students].first).to eq(expected_user)
+      # TODO: Replace with WebMock assertion once the profile API has been built.
+      expect(ProfileApiClient).to have_received(:list_school_students).with(token:, school_id: school.id, student_ids:)
+    end
+
+    it 'returns a filtered school students JSON array' do
+      response = described_class.call(school:, token:, student_ids:)
+      expect(response[:school_students].size).to eq(2)
+    end
+
+    it 'returns the filtered school students in the operation response' do
+      response = described_class.call(school:, token:, student_ids:)
+      filtered_students.each do |student|
+        expected_user = User.new(id: student.id, name: student.name, username: student.username)
+        expect(response[:school_students]).to include(expected_user)
+      end
+    end
   end
 
   context 'when listing fails' do
+    let(:student_ids) { [123] }
+
     before do
       allow(ProfileApiClient).to receive(:list_school_students).and_raise('Some API error')
       allow(Sentry).to receive(:capture_exception)
     end
 
     it 'returns a failed operation response' do
-      response = described_class.call(school:, token:)
+      response = described_class.call(school:, token:, student_ids:)
       expect(response.failure?).to be(true)
     end
 
     it 'returns the error message in the operation response' do
-      response = described_class.call(school:, token:)
+      response = described_class.call(school:, token:, student_ids:)
       expect(response[:error]).to match(/Some API error/)
     end
 
     it 'sent the exception to Sentry' do
-      described_class.call(school:, token:)
+      described_class.call(school:, token:, student_ids:)
       expect(Sentry).to have_received(:capture_exception).with(kind_of(StandardError))
     end
   end

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SchoolStudent::List, type: :unit do
       end
       stub_profile_api_list_school_students(school:, student_attributes:)
     end
-  
+
     it 'returns a successful operation response' do
       response = described_class.call(school:, token:, student_ids:)
       expect(response.success?).to be(true)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     end
 
     factory :student do
+      email { nil }
+      username { Faker::Internet.username }
       transient do
         school { nil }
       end

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Listing class members', type: :request do
     end
     stub_profile_api_list_school_students(school:, student_attributes:)
     students.each do |student|
-      create(:class_member, student_id: student.id, school_class: school_class)
+      create(:class_member, student_id: student.id, school_class:)
     end
   end
 

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Listing class members', type: :request do
     get("/api/schools/#{school.id}/classes/#{school_class.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    student_ids_from_response = data.map { |member| member[:student_id] }
+    student_ids_from_response = data.pluck(:student_id)
     expected_student_ids = students.map(&:id)
 
     expect(student_ids_from_response).to match_array(expected_student_ids)

--- a/spec/features/school_student/listing_school_students_spec.rb
+++ b/spec/features/school_student/listing_school_students_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Listing school students', type: :request do
   before do
     authenticated_in_hydra_as(owner)
-    stub_profile_api_list_school_students(school:, id: student.id, name: 'School Student')
+    student_attributes = [{ id: student.id, name: 'School Student' }]
+    stub_profile_api_list_school_students(school:, student_attributes:)
     stub_profile_api_create_safeguarding_flag
   end
 

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -23,14 +23,20 @@ module ProfileApiMock
     allow(ProfileApiClient).to receive(:remove_school_teacher)
   end
 
-  def stub_profile_api_list_school_students(school:, id:, username: '', name: '')
+  def stub_profile_api_list_school_students(school:, student_attributes:)
     now = Time.current.to_fs(:iso8601) # rubocop:disable Naming/VariableNumber
-    student = ProfileApiClient::Student.new(
-      schoolId: school.id,
-      id:, username:, name:,
-      createdAt: now, updatedAt: now, discardedAt: nil
-    )
-    allow(ProfileApiClient).to receive(:list_school_students).and_return([student])
+
+    students = student_attributes.map do |student_attrs|
+      ProfileApiClient::Student.new(
+        schoolId: school.id,
+        id: student_attrs[:id],
+        username: student_attrs[:username],
+        name: student_attrs[:name],
+        createdAt: now, updatedAt: now, discardedAt: nil
+      )
+    end
+
+    allow(ProfileApiClient).to receive(:list_school_students).and_return(students)
   end
 
   def stub_profile_api_create_school_student(user_id: SecureRandom.uuid)


### PR DESCRIPTION
## What's changed?

Updated class members controller to utilise `SchoolStudents:List` and return the student details in a nested `student` attribute in the class members response.

Previous Profile API mocks were for a single student so I expanded this to allow and test for a filtered subset using the `student_ids` array