### PR TITLE
Add properties to existing responses

### DIFF
--- a/app/views/api/lessons/index.json.jbuilder
+++ b/app/views/api/lessons/index.json.jbuilder
@@ -17,5 +17,13 @@ json.array!(@lessons_with_users) do |lesson, user|
     :updated_at
   )
 
+  if lesson.project
+    json.project(
+      lesson.project,
+      :identifier,
+      :project_type
+    )
+  end
+
   json.user_name(user&.name)
 end

--- a/app/views/api/my_school/show.json.jbuilder
+++ b/app/views/api/my_school/show.json.jbuilder
@@ -12,6 +12,7 @@ json.call(
   :administrative_area,
   :postal_code,
   :country_code,
+  :code,
   :verified_at,
   :created_at,
   :updated_at

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe 'Listing lessons', type: :request do
     expect(data.first[:user_name]).to eq('School Teacher')
   end
 
+  it 'responds with the project JSON' do
+    get('/api/lessons', headers:)
+    data = JSON.parse(response.body, symbolize_names: true)
+    expected_project = JSON.parse(lesson.project.to_json(only: %i[identifier project_type]), symbolize_names: true)
+
+    expect(data.first[:project]).to eq(expected_project)
+  end
+
   # rubocop:disable RSpec/ExampleLength
   it "responds with nil attributes for the user if their user profile doesn't exist" do
     user_id = SecureRandom.uuid

--- a/spec/features/my_school/showing_my_school_spec.rb
+++ b/spec/features/my_school/showing_my_school_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Showing my school', type: :request do
   end
 
   it "includes the school details and user's roles in the JSON" do
-    school_json = school.to_json(only: %i[id name website reference address_line_1 address_line_2 municipality administrative_area postal_code country_code verified_at created_at updated_at])
+    school_json = school.to_json(only: %i[id name website reference address_line_1 address_line_2 municipality administrative_area postal_code country_code code verified_at created_at updated_at])
     expected_data = JSON.parse(school_json, symbolize_names: true).merge(roles: ['owner'])
 
     get('/api/school', headers:)


### PR DESCRIPTION
## What's changed?

- `code` has been added to the school show response for the dashboard
- `project` has been added to the lesson index so we can direct students to the project from the class page