### PR TITLE
Format UK school postcodes

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -91,7 +91,7 @@ class School < ApplicationRecord
   end
 
   def should_format_uk_postal_code?
-    country_code == 'GB' && postal_code.length >= 5
+    country_code == 'GB' && postal_code.to_s.length >= 5
   end
 
   def format_uk_postal_code

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -30,6 +30,8 @@ class School < ApplicationRecord
 
   before_validation :normalize_reference
 
+  before_save :format_uk_postal_code, if: :should_format_uk_postal_code?
+
   def self.find_for_user!(user)
     school = Role.find_by(user_id: user.id)&.school || find_by(creator_id: user.id)
     raise ActiveRecord::RecordNotFound unless school
@@ -65,6 +67,10 @@ class School < ApplicationRecord
     update(rejected_at: Time.zone.now)
   end
 
+  def postal_code=(str)
+    super(str.to_s.upcase)
+  end
+
   private
 
   # Ensure the reference is nil, not an empty string
@@ -82,5 +88,16 @@ class School < ApplicationRecord
 
   def code_cannot_be_changed
     errors.add(:code, 'cannot be changed after verification') if code_was.present? && code_changed?
+  end
+
+  def should_format_uk_postal_code?
+    country_code == 'GB' && postal_code.length >= 5
+  end
+
+  def format_uk_postal_code
+    cleaned_postal_code = postal_code.delete(' ')
+    # insert a space as the third-from-last character in the postcode, eg. SW1A1AA -> SW1A 1AA
+    # ensures UK postcodes are always formatted correctly (as the inward code is always 3 chars long)
+    self.postal_code = "#{cleaned_postal_code[0..-4]} #{cleaned_postal_code[-3..]}"
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -342,37 +342,37 @@ RSpec.describe School do
     it 'corrects incorrectly formatted UK postal_code' do
       school.country_code = 'GB'
       school.postal_code = 'SW1 A1AA'
-      expect { school.save }.to change(user, :postal_code).to('SW1A 1AA')
+      expect { school.save }.to change(school, :postal_code).to('SW1A 1AA')
     end
 
     it 'formats UK postal_code with 4 char outcode' do
       school.country_code = 'GB'
       school.postal_code = 'SW1A1AA'
-      expect { school.save }.to change(user, :postal_code).to('SW1A 1AA')
+      expect { school.save }.to change(school, :postal_code).to('SW1A 1AA')
     end
 
     it 'formats UK postal_code with 3 char outcode' do
       school.country_code = 'GB'
       school.postal_code = 'SW11AA'
-      expect { school.save }.to change(user, :postal_code).to('SW1 1AA')
+      expect { school.save }.to change(school, :postal_code).to('SW1 1AA')
     end
 
     it 'formats UK postal_code with 2 char outcode' do
       school.country_code = 'GB'
       school.postal_code = 'SW1AA'
-      expect { school.save }.to change(user, :postal_code).to('SW 1AA')
+      expect { school.save }.to change(school, :postal_code).to('SW 1AA')
     end
 
     it 'does not format UK postal_code for short / invalid codes' do
       school.country_code = 'GB'
       school.postal_code = 'SW1A'
-      expect { school.save }.not_to change(user, :postal_code)
+      expect { school.save }.not_to change(school, :postal_code)
     end
 
     it 'does not format postal_code for non-UK countries' do
       school.country_code = 'FR'
       school.postal_code = '123456'
-      expect { school.save }.not_to change(user, :postal_code)
+      expect { school.save }.not_to change(school, :postal_code)
     end
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe School do
     end
 
     it 'returns the school that the user has a role in' do
-      user = school.where(id: teacher.id).first
+      user = User.where(id: teacher.id).first
       expect(described_class.find_for_user!(user)).to eq(school)
     end
 


### PR DESCRIPTION
**Context**
UK postcode data is used in our reporting tools in order to measure how effective we are at reaching deprived areas (using the IMD / Indices of Multiple Deprivation: https://www.gov.uk/government/collections/english-indices-of-deprivation). This is a key part our programme impact monitoring work.

The IMD lookup relies on a correctly formatted postcode as defined by the NSPL (National Statistics Postcode Lookup) [data](https://geoportal.statistics.gov.uk/datasets/9ac0331178b0435e839f62f41cc61c16): 2-4 char outward code, a space, then a 3-char inward code.

**Problem**
Postcode validation (as in "is this an actual UK postcode that is definitely in the Royal Mail Postcode Address File / PAF") is suboptimal, as doing so with a regex is a pain and potentially error prone (with the onus to 'fix' a potentially valid postcode being put on the user). We're also currently discounting using an API to look up / validate postcodes, though this may be a valid approach going forwards.

**Proposed approach**
Whilst we don't want to take a heavy-handed approach to postcode validation, as outlined above, we do want to make sure that any postcode that meets the criteria of being "very likely to be in the PAF and NSPL data sets" is formatted in a way which makes lookups possible (in order to prevent cases such as `CB11NT`, `CB 11NT`):

* Take any >=5 char UK postcode and ensure it has one space in it before the final 3 chars / inward code.

**Additional steps**
Existing school data will need to have the same transform / corrections applied, something like:

```
UPDATE schools
SET postal_code = 
    CASE 
        WHEN LENGTH(postal_code) >= 5 AND POSITION(' ' IN postal_code) = 0
        THEN CONCAT(SUBSTRING(postal_code FROM 1 FOR LENGTH(postal_code) - 3), ' ', SUBSTRING(postal_code FROM LENGTH(postal_code) - 2))
        ELSE postal_code
    END
WHERE country_code = 'GB';
```