### PR TITLE
Fix_env_variables_to_allow_both_api_and_dashboard

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,8 @@
         "syler.sass-indented",
         "codezombiech.gitignore",
         "shopify.ruby-lsp",
-        "koichisasada.vscode-rdbg"
+        "koichisasada.vscode-rdbg",
+        "rangav.vscode-thunder-client"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh"

--- a/.env.example
+++ b/.env.example
@@ -7,20 +7,20 @@ AWS_SECRET_ACCESS_KEY=changeme
 
 GITHUB_WEBHOOK_SECRET=test_token
 
-POSTGRES_DB=development
 POSTGRES_HOST=db
 POSTGRES_PASSWORD=password
 POSTGRES_USER=postgres
 
-USERINFO_API_URL=http://localhost:6000
+USERINFO_API_URL=http://host.docker.internal:6000 # Internal docker address
 USERINFO_API_KEY=1234
 
-HYDRA_PUBLIC_URL=http://localhost:9001
-HYDRA_PUBLIC_TOKEN_URL=http://host.docker.internal:9001
+HYDRA_PUBLIC_URL=http://localhost:9001 # External docker address
+HYDRA_PUBLIC_API_URL=http://host.docker.internal:9001 # Internal docker address
+HYDRA_PUBLIC_TOKEN_URL=http://host.docker.internal:9001 # Internal docker address
 HYDRA_CLIENT_ID=editor-dashboard-dev
 HYDRA_CLIENT_SECRET=secret
 
-IDENTITY_URL=http://localhost:3002
+IDENTITY_URL=http://host.docker.internal:3002 # Internal docker address
 
 SMEE_TUNNEL=https://smee.io/MLq0n9kvAes2vydX
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
-  Rails.application.routes.default_url_options = { host: ENV.fetch('HOST_URL', 'http://localhost:3000') }
+  Rails.application.routes.default_url_options = { host: ENV.fetch('HOST_URL', 'http://localhost:3009') }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - POSTGRES_USER
   smee:
     image: deltaprojects/smee-client
+    platform: linux/amd64
     command: -u $SMEE_TUNNEL -t http://api:3009/github_webhooks
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,3 @@ services:
 
 volumes:
   postgres-data:
-
-networks:
-  default:
-    name: shared-development

--- a/lib/hydra_public_api_client.rb
+++ b/lib/hydra_public_api_client.rb
@@ -3,7 +3,9 @@
 require 'faraday'
 
 class HydraPublicApiClient
-  API_URL = ENV.fetch('HYDRA_PUBLIC_URL', 'http://localhost:9001')
+  # Allows us to use a different URL for API calls to auth locally
+  HYDRA_PUBLIC_API_URL = ENV.fetch('HYDRA_PUBLIC_API_URL', nil)
+  API_URL = HYDRA_PUBLIC_API_URL || ENV.fetch('HYDRA_PUBLIC_URL', 'http://localhost:9001')
 
   class << self
     def fetch_oauth_user(...)


### PR DESCRIPTION
## Status

- Ready for review

## What's changed?

- Use a different env var locally for the profile api, to allow simultaneous use of administrate and the api (at long last)
  - This is a local only env var since staging and prod share the same url
- Remove network from docker-compose for now, as unused
- Add extensions to devcontainer.json
- Fix smee architecture to amd64

## Steps to perform after deploying to production

_If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, a migration, or upgrading a Gem. That kind of thing._
