### PR TITLE
Allow for dynamic hosts in CORS origin config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# localhost is set as an origin by default in development, so you probably only need to set ALLOWED_ORIGINS for debugging purposes
+ALLOWED_ORIGINS=
+
 AWS_ACCESS_KEY_ID=changeme
 AWS_S3_ACTIVE_STORAGE_BUCKET=changeme
 AWS_S3_REGION=changeme

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-ALLOWED_ORIGINS=localhost:3000,localhost:3002,localhost:3009,localhost:3010,localhost:3012,editor.rpfdev.com
-
 AWS_ACCESS_KEY_ID=changeme
 AWS_S3_ACTIVE_STORAGE_BUCKET=changeme
 AWS_S3_REGION=changeme

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-# localhost is set as an origin by default in development, so you probably only need to set ALLOWED_ORIGINS for debugging purposes
-ALLOWED_ORIGINS=
+# localhost is set as an origin by default in development (config/initializers/cors.rb)
+# so you probably only need to set ALLOWED_ORIGINS for debugging purposes
+ALLOWED_ORIGINS=""
 
 AWS_ACCESS_KEY_ID=changeme
 AWS_S3_ACTIVE_STORAGE_BUCKET=changeme

--- a/README.md
+++ b/README.md
@@ -127,11 +127,7 @@ docker-compose run api rspec spec/path/to/spec.rb
 
 ### CORS Allowed Origins
 
-Add a comma separated list to the relevant enviroment settings. E.g for development in the `.env` file:
-
-```
-ALLOWED_ORIGINS=localhost:3002,localhost:3000
-```
+Handled in `config/initializers/cors.rb`.
 
 ### Webhooks
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -24,7 +24,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     standard_cors_options
   end
 
-  # all raspberrypi.org subdomains
+  # all raspberrypi.org subdomains (*.raspberry.org)
   allow do
     origins(%r{https?://.+\.raspberrypi\.org$})
 
@@ -38,7 +38,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     standard_cors_options
   end
 
-  # Cloudflare Pages dynamic
+  # Cloudflare Pages dynamic (*.editor-standalone-eyq.pages.dev and *.projects-ui.pages.dev)
   allow do
     origins(%r{https?://.+\.editor-standalone-eyq\.pages\.dev$}, %r{https?://.+\.projects-ui\.pages\.dev$})
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,11 +8,7 @@ require Rails.root.join('lib/origin_parser')
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     # localhost and test domain origins
-    if Rails.env.development?
-      origins(%r{https?://localhost([:0-9]*)$})
-    elsif Rails.env.test?
-      origins(%r{https?://localhost([:0-9]*)$}, %r{https?://www\.example\.com$})
-    end
+    origins(%r{https?://localhost([:0-9]*)$}) if Rails.env.development? || Rails.env.test?
 
     standard_cors_options
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -2,23 +2,57 @@
 
 # Be sure to restart your server when you modify this file.
 
-origins_array = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+# Read more: https://github.com/cyu/rack-cors
+
+# Note the use of the $ at the end of the regexes below, this ensures
+# that the origins are matched exactly and not just a substring eg.
+# match: https://www.example.com
+# don't match: https://www.example.com.anotherdomain.com
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins origins_array
-    resource '*', headers: :any, methods: %i[get post patch put delete], expose: ['Link']
+    # localhost and test domain
+    if Rails.env.development?
+      origins(%r{https?://localhost([:0-9]*)$})
+    elsif Rails.env.test?
+      origins(%r{https?://localhost([:0-9]*)$}, %r{https?://www\.example\.com$})
+    end
+
+    standard_cors_options
+  end
+
+  # all raspberrypi.org subdomains
+  allow do
+    origins(%r{https?://.+\.raspberrypi\.org$})
+
+    standard_cors_options
+  end
+
+  # Cloudflare Pages static
+  allow do
+    origins('https://editor-standalone-eyq.pages.dev', 'https://block-to-text-alpha.pages.dev', 'https://projects-ui.pages.dev')
+
+    standard_cors_options
+  end
+
+  # Cloudflare Pages dynamic
+  allow do
+    origins(%r{https?://.+\.editor-standalone-eyq\.pages\.dev$}, %r{https?://.+\.projects-ui\.pages\.dev$})
+
+    standard_cors_options
+  end
+
+  # Oak
+  allow do
+    origins('https://preview.courses.edx.org', 'https://studio.edx.org')
+
+    standard_cors_options
   end
 end
-# Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+def standard_cors_options
+  resource '*', headers: :any, methods: %i[get post patch put delete], expose: ['Link']
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -3,6 +3,8 @@
 # Be sure to restart your server when you modify this file.
 # Read more: https://github.com/cyu/rack-cors
 
+require Rails.root.join('lib/origin_parser')
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     # localhost and test domains
@@ -16,23 +18,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   end
 
   allow do
-    origins allowed_origins
+    origins OriginParser.parse_origins
 
     standard_cors_options
   end
-end
-
-def allowed_origins
-  # fetch origins from the environment, these can be literal strings or regexes
-  # regexes must be wrapped in forward slashes eg. /https?:\/\/localhost(:[0-9]*)?$/
-  ENV['ALLOWED_ORIGINS']&.split(',')&.map do |origin|
-    stripped_origin = origin.strip
-    if stripped_origin.start_with?('/') && stripped_origin.end_with?('/')
-      Regexp.new(stripped_origin[1..-2])
-    else
-      stripped_origin
-    end
-  end || []
 end
 
 def standard_cors_options

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@ require Rails.root.join('lib/origin_parser')
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    # localhost and test domains
+    # localhost and test domain origins
     if Rails.env.development?
       origins(%r{https?://localhost([:0-9]*)$})
     elsif Rails.env.test?
@@ -18,6 +18,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   end
 
   allow do
+    # environment-specific origins set through ALLOWED_ORIGINS env var
+    # should only be necessary for staging / production environments (see above for local and test)
     origins OriginParser.parse_origins
 
     standard_cors_options

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,22 +1,7 @@
 # frozen_string_literal: true
 
 # Be sure to restart your server when you modify this file.
-
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
-
 # Read more: https://github.com/cyu/rack-cors
-
-# fetch origins from the environment, these can be literal strings or regexes
-origins_array = ENV['ALLOWED_ORIGINS']&.split(',')&.map do |origin|
-  stripped_origin = origin.strip
-  if stripped_origin.start_with?('/') && stripped_origin.end_with?('/')
-    # convert to Regexp if the origin is wrapped in forward slashes eg. /https?:\/\/localhost(:[0-9]*)?$/
-    Regexp.new(stripped_origin[1..-2])
-  else
-    stripped_origin
-  end
-end || []
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
@@ -31,11 +16,23 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   end
 
   allow do
-    # fetch allowed origins from the environment
-    origins origins_array
+    origins allowed_origins
 
     standard_cors_options
   end
+end
+
+def allowed_origins
+  # fetch origins from the environment, these can be literal strings or regexes
+  # regexes must be wrapped in forward slashes eg. /https?:\/\/localhost(:[0-9]*)?$/
+  ENV['ALLOWED_ORIGINS']&.split(',')&.map do |origin|
+    stripped_origin = origin.strip
+    if stripped_origin.start_with?('/') && stripped_origin.end_with?('/')
+      Regexp.new(stripped_origin[1..-2])
+    else
+      stripped_origin
+    end
+  end || []
 end
 
 def standard_cors_options

--- a/lib/corp_middleware.rb
+++ b/lib/corp_middleware.rb
@@ -8,7 +8,7 @@ class CorpMiddleware
   def call(env)
     status, headers, response = @app.call(env)
     request_origin = env['HTTP_HOST']
-    allowed_origins = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
+    allowed_origins = ['staging-editor-api.raspberrypi.org', 'editor-api.raspberrypi.org']
 
     if env['PATH_INFO'].start_with?('/rails/active_storage') && allowed_origins.include?(request_origin)
       headers['Cross-Origin-Resource-Policy'] = 'cross-origin'

--- a/lib/corp_middleware.rb
+++ b/lib/corp_middleware.rb
@@ -8,7 +8,7 @@ class CorpMiddleware
   def call(env)
     status, headers, response = @app.call(env)
     request_origin = env['HTTP_HOST']
-    allowed_origins = ['staging-editor-api.raspberrypi.org', 'editor-api.raspberrypi.org']
+    allowed_origins = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
 
     if env['PATH_INFO'].start_with?('/rails/active_storage') && allowed_origins.include?(request_origin)
       headers['Cross-Origin-Resource-Policy'] = 'cross-origin'

--- a/lib/corp_middleware.rb
+++ b/lib/corp_middleware.rb
@@ -8,12 +8,26 @@ class CorpMiddleware
   def call(env)
     status, headers, response = @app.call(env)
     request_origin = env['HTTP_HOST']
-    allowed_origins = ENV['ALLOWED_ORIGINS']&.split(',')&.map(&:strip) || []
 
-    if env['PATH_INFO'].start_with?('/rails/active_storage') && allowed_origins.include?(request_origin)
+    puts "Allowed origins: #{allowed_origins.to_json}"
+
+    if env['PATH_INFO'].start_with?('/rails/active_storage') && allowed_origins.any? do |origin|
+         origin.is_a?(Regexp) ? origin =~ request_origin : origin == request_origin
+       end
       headers['Cross-Origin-Resource-Policy'] = 'cross-origin'
     end
 
     [status, headers, response]
+  end
+
+  def allowed_origins
+    ENV['ALLOWED_ORIGINS']&.split(',')&.map do |origin|
+      stripped_origin = origin.strip
+      if stripped_origin.start_with?('/') && stripped_origin.end_with?('/')
+        Regexp.new(stripped_origin[1..-2])
+      else
+        stripped_origin
+      end
+    end || []
   end
 end

--- a/lib/origin_parser.rb
+++ b/lib/origin_parser.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# fetch origins from the environment, these can be literal strings or regexes
+# regexes must be wrapped in forward slashes eg. /https?:\/\/localhost(:[0-9]*)?$/
+module OriginParser
+  def self.parse_origins
+    ENV['ALLOWED_ORIGINS']&.split(',')&.map do |origin|
+      stripped_origin = origin.strip
+      if stripped_origin.start_with?('/') && stripped_origin.end_with?('/')
+        Regexp.new(stripped_origin[1..-2])
+      else
+        stripped_origin
+      end
+    end || []
+  end
+end

--- a/lib/tasks/classroom_management_helper.rb
+++ b/lib/tasks/classroom_management_helper.rb
@@ -91,6 +91,9 @@ module ClassroomManagementHelper
       project.school = school
       project.lesson = lesson
       project.locale = 'en'
+      project.project_type = 'python'
+      project.components << Component.new({ extension: 'py', name: 'main',
+                                            content: '' })
     end
   end
 end

--- a/spec/lib/corp_middleware_spec.rb
+++ b/spec/lib/corp_middleware_spec.rb
@@ -12,7 +12,15 @@ describe CorpMiddleware do
     allow(ENV).to receive(:[]).with('ALLOWED_ORIGINS').and_return('test.com')
   end
 
-  it 'sets the Cross-Origin-Resource-Policy header for allowed origins' do
+  it 'sets the Cross-Origin-Resource-Policy header for a literal origin' do
+    _status, headers, _response = middleware.call(env)
+
+    expect(headers['Cross-Origin-Resource-Policy']).to eq('cross-origin')
+  end
+
+  it 'sets the Cross-Origin-Resource-Policy header for regex origin' do
+    allow(ENV).to receive(:[]).with('ALLOWED_ORIGINS').and_return('/test\.com/')
+
     _status, headers, _response = middleware.call(env)
 
     expect(headers['Cross-Origin-Resource-Policy']).to eq('cross-origin')

--- a/spec/lib/origin_parser_spec.rb
+++ b/spec/lib/origin_parser_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OriginParser do
+  describe '.parse_origins' do
+    after { ENV['ALLOWED_ORIGINS'] = nil }
+
+    it 'returns an empty array if ALLOWED_ORIGINS is not set' do
+      ENV['ALLOWED_ORIGINS'] = nil
+      expect(described_class.parse_origins).to eq([])
+    end
+
+    it 'parses literal strings correctly' do
+      ENV['ALLOWED_ORIGINS'] = 'http://example.com, https://example.org'
+      expect(described_class.parse_origins).to eq(['http://example.com', 'https://example.org'])
+    end
+
+    it 'parses regexes correctly' do
+      ENV['ALLOWED_ORIGINS'] = '/https?:\/\/example\.com/'
+      expect(described_class.parse_origins).to eq([Regexp.new('https?:\/\/example\.com')])
+    end
+
+    it 'parses a mix of literals and regexes' do
+      ENV['ALLOWED_ORIGINS'] = 'http://example.com, /https?:\/\/localhost$/'
+      expect(described_class.parse_origins).to eq(['http://example.com', Regexp.new('https?:\/\/localhost$')])
+    end
+
+    it 'strips whitespace from origins' do
+      ENV['ALLOWED_ORIGINS'] = '  http://example.com  , /regex$/  '
+      expect(described_class.parse_origins).to eq(['http://example.com', Regexp.new('regex$')])
+    end
+
+    it 'returns an empty array if ALLOWED_ORIGINS is empty' do
+      ENV['ALLOWED_ORIGINS'] = ''
+      expect(described_class.parse_origins).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/editor-api/issues/405

## What's changed?

This extends the current origin-setting functionality (literal origins set via a comma-separated environment variable) and allows the env var string to also contain regular expressions. These allow the origins to match dynamic patterns (eg. `https://*.projects-ui.pages.dev`) and ensures that configuration still remains in the environment as we don't want to assume that anyone running this application will want the same allowed origins configured as us (other than for `localhost` for local and test environments only).

eg. instead of currently having to set the following in `ALLOWED_ORIGINS`:

```
https://foo.raspberrypi.org, https://bar.raspberrypi.org, https://foo.editor-standalone-eyq.pages.dev, https://bar.editor-standalone-eyq.pages.dev
```

The following can be set:

```
/https:\/\/(?:[a-z0-9-]+\.)?raspberrypi\.org$/, /https:\/\/.+\.editor-standalone-eyq\.pages\.dev$/
```

Associated updates in Terraform allow for the origins to match the spec in the [issue](https://github.com/RaspberryPiFoundation/editor-api/issues/405) (eg. the addition of wildcards / regex matching):

* https://github.com/RaspberryPiFoundation/terraform/pull/898