### PR TITLE
232: Add mark as finished endpoint

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -5,7 +5,7 @@ require 'project_loader'
 module Api
   class ProjectsController < ApiController
     before_action :authorize_user, only: %i[create update index destroy]
-    before_action :load_project, only: %i[show update destroy]
+    before_action :load_project, only: %i[show update toggle_finished destroy]
     before_action :load_projects, only: %i[index]
     load_and_authorize_resource
     before_action :verify_lesson_belongs_to_school, only: :create
@@ -31,6 +31,16 @@ module Api
       if result.success?
         @project = result[:project]
         render :show, formats: [:json], status: :created
+      else
+        render json: { error: result[:error] }, status: :unprocessable_entity
+      end
+    end
+
+    def toggle_finished
+      result = Project::ToggleFinished.call(project: @project)
+
+      if result.success?
+        head :ok
       else
         render json: { error: result[:error] }, status: :unprocessable_entity
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -78,7 +78,7 @@ class Ability
       school_teacher_can_manage_project?(user:, school:, project:)
     end
     can(%i[read], Project, school_id: school.id, lesson: { visibility: %w[teachers students] })
-    can(%i[read toggle_finished], Project,
+    can(%i[read], Project,
         remixed_from_id: Project.where(user_id: user.id, school_id: school.id, remixed_from_id: nil).pluck(:id))
   end
   # rubocop:enable Metrics/AbcSize
@@ -90,8 +90,18 @@ class Ability
     can(%i[read], Lesson, school_id: school.id, visibility: 'students', school_class: { members: { student_id: user.id } })
     can(%i[create], Project, school_id: school.id, user_id: user.id, lesson_id: nil)
     can(%i[read], Project, lesson: { school_id: school.id, school_class: { members: { student_id: user.id } } })
+    can(%i[toggle_finished], Project) do |project|
+      school_student_can_toggle_finished?(user: user, school: school, project: project)
+    end
   end
   # rubocop:enable Layout/LineLength
+
+  def school_student_can_toggle_finished?(user:, school:, project:)
+    is_my_project = project.user_id == user.id && project.school_id == school.id
+    is_a_remix = project.remixed_from_id.present?
+
+    is_my_project && is_a_remix
+  end
 
   def school_teacher_can_manage_lesson?(user:, school:, lesson:)
     is_my_lesson = lesson.school_id == school.id && lesson.user_id == user.id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,7 +91,7 @@ class Ability
     can(%i[create], Project, school_id: school.id, user_id: user.id, lesson_id: nil)
     can(%i[read], Project, lesson: { school_id: school.id, school_class: { members: { student_id: user.id } } })
     can(%i[toggle_finished], Project) do |project|
-      school_student_can_toggle_finished?(user: user, school: school, project: project)
+      school_student_can_toggle_finished?(user:, school:, project:)
     end
   end
   # rubocop:enable Layout/LineLength

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -78,7 +78,7 @@ class Ability
       school_teacher_can_manage_project?(user:, school:, project:)
     end
     can(%i[read], Project, school_id: school.id, lesson: { visibility: %w[teachers students] })
-    can(%i[read], Project,
+    can(%i[read toggle_finished], Project,
         remixed_from_id: Project.where(user_id: user.id, school_id: school.id, remixed_from_id: nil).pluck(:id))
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/views/api/lessons/index.json.jbuilder
+++ b/app/views/api/lessons/index.json.jbuilder
@@ -21,11 +21,9 @@ json.array!(@lessons_with_users) do |lesson, user|
     json.project(
       lesson.project,
       :identifier,
-      :project_type,
+      :project_type
     )
-    if lesson.project.remixed_from_id.present?
-      json.project.finished(lesson.project.finished)
-    end
+    json.project.finished(lesson.project.finished) if lesson.project.remixed_from_id.present?
   end
 
   json.user_name(user&.name)

--- a/app/views/api/lessons/index.json.jbuilder
+++ b/app/views/api/lessons/index.json.jbuilder
@@ -21,8 +21,11 @@ json.array!(@lessons_with_users) do |lesson, user|
     json.project(
       lesson.project,
       :identifier,
-      :project_type
+      :project_type,
     )
+    if lesson.project.remixed_from_id.present?
+      json.project.finished(lesson.project.finished)
+    end
   end
 
   json.user_name(user&.name)

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -32,4 +32,6 @@ end
 
 json.user_name(@user&.name) if @user.present? && @project.parent
 
-json.finished(@project.finished) if @project.school.present?
+if @project.school.present? && @project.remixed_from_id.present?
+  json.finished(@project.finished)
+end

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -32,6 +32,4 @@ end
 
 json.user_name(@user&.name) if @user.present? && @project.parent
 
-if @project.school.present? && @project.remixed_from_id.present?
-  json.finished(@project.finished)
-end
+json.finished(@project.finished) if @project.school.present? && @project.remixed_from_id.present?

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -31,3 +31,5 @@ json.image_list(@project.images) do |image|
 end
 
 json.user_name(@user&.name) if @user.present?
+
+json.finished(@project.finished) if @project.school.present?

--- a/app/views/api/projects/show.json.jbuilder
+++ b/app/views/api/projects/show.json.jbuilder
@@ -30,6 +30,6 @@ json.image_list(@project.images) do |image|
   json.url(rails_blob_url(image))
 end
 
-json.user_name(@user&.name) if @user.present?
+json.user_name(@user&.name) if @user.present? && @project.parent
 
 json.finished(@project.finished) if @project.school.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     end
 
     resources :projects, only: %i[index show update destroy create] do
+      put :toggle_finished, on: :member, to: 'projects#toggle_finished'
       resource :remix, only: %i[show create], controller: 'projects/remixes'
       resources :remixes, only: %i[index], controller: 'projects/remixes'
       resource :images, only: %i[show create], controller: 'projects/images'

--- a/db/migrate/20240902151414_add_finished_to_projects.rb
+++ b/db/migrate/20240902151414_add_finished_to_projects.rb
@@ -1,0 +1,5 @@
+class AddFinishedToProjects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :finished, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_28_122522) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_151414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_28_122522) do
     t.string "remix_origin"
     t.uuid "school_id"
     t.uuid "lesson_id"
+    t.boolean "finished"
     t.index ["identifier", "locale"], name: "index_projects_on_identifier_and_locale", unique: true
     t.index ["identifier"], name: "index_projects_on_identifier"
     t.index ["lesson_id"], name: "index_projects_on_lesson_id"

--- a/lib/concepts/project/operations/toggle_finished.rb
+++ b/lib/concepts/project/operations/toggle_finished.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Project
+  class ToggleFinished
+    class << self
+      def call(project:)
+        response = OperationResponse.new
+        response[:project] = project
+        response[:project].assign_attributes(finished: !project.finished)
+        response[:project].save!
+        response
+      rescue StandardError => e
+        Sentry.capture_exception(e)
+        response[:error] = response[:project]&.errors
+        response
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Ability do
 
         it { is_expected.to be_able_to(:read, school_project) }
         it { is_expected.not_to be_able_to(:update, school_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
       end
 
@@ -84,7 +85,16 @@ RSpec.describe Ability do
 
         it { is_expected.to be_able_to(:read, school_project) }
         it { is_expected.not_to be_able_to(:update, school_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
+
+        context 'with a remixed project belonging to one of their students' do
+          let(:student) { create(:student, school:) }
+          let(:original_project) { create(:project, user_id: user.id, school_id: school.id, lesson_id: lesson.id) }
+          let!(:remixed_project) { create(:project, user_id: student.id, school_id: school.id, remixed_from_id: original_project.id, lesson_id: nil) }
+
+          it { is_expected.to be_able_to(:toggle_finished, remixed_project) }
+        end
       end
 
       context 'when user is a school student and belongs to a class' do
@@ -95,6 +105,7 @@ RSpec.describe Ability do
 
         it { is_expected.to be_able_to(:read, school_project) }
         it { is_expected.not_to be_able_to(:update, school_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
       end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Ability do
       let(:teacher) { create(:teacher, school:) }
       let(:school_class) { build(:school_class, school:, teacher_id: teacher.id) }
       let(:lesson) { build(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'students') }
-      let(:school_project) { build(:project, school:, lesson:, user_id: teacher.id) }
+      let!(:school_project) { build(:project, school:, lesson:, user_id: teacher.id) }
 
       context 'when user is a school owner' do
         before do
@@ -87,16 +87,6 @@ RSpec.describe Ability do
         it { is_expected.not_to be_able_to(:update, school_project) }
         it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
-
-        # rubocop:disable RSpec/NestedGroups
-        context 'with a remixed project belonging to one of their students' do
-          let(:student) { create(:student, school:) }
-          let(:original_project) { create(:project, user_id: user.id, school_id: school.id, lesson_id: lesson.id) }
-          let!(:remixed_project) { create(:project, user_id: student.id, school_id: school.id, remixed_from_id: original_project.id, lesson_id: nil) }
-
-          it { is_expected.to be_able_to(:toggle_finished, remixed_project) }
-        end
-        # rubocop:enable RSpec/NestedGroups
       end
 
       context 'when user is a school student and belongs to a class' do
@@ -118,6 +108,7 @@ RSpec.describe Ability do
 
         it { is_expected.not_to be_able_to(:read, school_project) }
         it { is_expected.not_to be_able_to(:update, school_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
       end
     end
@@ -127,24 +118,33 @@ RSpec.describe Ability do
       let(:student) { create(:student, school:) }
       let(:teacher) { create(:teacher, school:) }
       let(:school_class) { create(:school_class, school:, teacher_id: teacher.id) }
+      let!(:class_member) { create(:class_member, school_class:, student_id: student.id) }
       let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'students') }
       let(:original_project) { create(:project, school:, lesson:, user_id: teacher.id) }
-      let!(:school_project) { create(:project, school:, user_id: student.id, remixed_from_id: original_project.id) }
+      let!(:remixed_project) { create(:project, school:, user_id: student.id, remixed_from_id: original_project.id) }
+
+      context 'when user is the student' do
+        let(:user) { student }
+
+        it { is_expected.to be_able_to(:toggle_finished, remixed_project) }
+      end
 
       context 'when user is teacher that does not own the orginal project' do
         let(:user) { create(:teacher, school:) }
 
-        it { is_expected.not_to be_able_to(:read, school_project) }
-        it { is_expected.not_to be_able_to(:update, school_project) }
-        it { is_expected.not_to be_able_to(:destroy, school_project) }
+        it { is_expected.not_to be_able_to(:read, remixed_project) }
+        it { is_expected.not_to be_able_to(:update, remixed_project) }
+        it { is_expected.not_to be_able_to(:destroy, remixed_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, remixed_project) }
       end
 
       context 'when user is teacher that owns the orginal project' do
         let(:user) { teacher }
 
-        it { is_expected.to be_able_to(:read, school_project) }
-        it { is_expected.not_to be_able_to(:update, school_project) }
-        it { is_expected.not_to be_able_to(:destroy, school_project) }
+        it { is_expected.to be_able_to(:read, remixed_project) }
+        it { is_expected.not_to be_able_to(:update, remixed_project) }
+        it { is_expected.not_to be_able_to(:destroy, remixed_project) }
+        it { is_expected.not_to be_able_to(:toggle_finished, remixed_project) }
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Ability do
       let(:student) { create(:student, school:) }
       let(:teacher) { create(:teacher, school:) }
       let(:school_class) { create(:school_class, school:, teacher_id: teacher.id) }
-      let!(:class_member) { create(:class_member, school_class:, student_id: student.id) }
+      let(:class_member) { create(:class_member, school_class:, student_id: student.id) }
       let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'students') }
       let(:original_project) { create(:project, school:, lesson:, user_id: teacher.id) }
       let!(:remixed_project) { create(:project, school:, user_id: student.id, remixed_from_id: original_project.id) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Ability do
         it { is_expected.not_to be_able_to(:toggle_finished, school_project) }
         it { is_expected.not_to be_able_to(:destroy, school_project) }
 
+        # rubocop:disable RSpec/NestedGroups
         context 'with a remixed project belonging to one of their students' do
           let(:student) { create(:student, school:) }
           let(:original_project) { create(:project, user_id: user.id, school_id: school.id, lesson_id: lesson.id) }
@@ -95,6 +96,7 @@ RSpec.describe Ability do
 
           it { is_expected.to be_able_to(:toggle_finished, remixed_project) }
         end
+        # rubocop:enable RSpec/NestedGroups
       end
 
       context 'when user is a school student and belongs to a class' do

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Project show requests' do
 
       it 'does not include the finished boolean in the project json' do
         get("/api/projects/#{project.identifier}", headers:)
-        expect(JSON.parse(response.body)).not_to have_key('finished')
+        expect(response.parsed_body).not_to have_key('finished')
       end
     end
 
@@ -73,7 +73,6 @@ RSpec.describe 'Project show requests' do
           finished: student_project.finished
         }.to_json
       end
-
 
       it 'returns success response' do
         get("/api/projects/#{student_project.identifier}", headers:)

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -44,13 +44,18 @@ RSpec.describe 'Project show requests' do
         get("/api/projects/#{project.identifier}", headers:)
         expect(response.body).to eq(project_json)
       end
+
+      it 'does not include the finished boolean in the project json' do
+        get("/api/projects/#{project.identifier}", headers:)
+        expect(JSON.parse(response.body)).not_to have_key('finished')
+      end
     end
 
     context 'when loading a student\'s project' do
       let(:student) { create(:student, school:) }
       let(:lesson) { build(:lesson, school:, user_id: teacher.id, visibility: 'students') }
       let(:teacher_project) { create(:project, school_id: school.id, lesson_id: lesson.id, user_id: teacher.id, locale: nil) }
-      let!(:student_project) { create(:project, school_id: school.id, lesson_id: nil, user_id: student.id, remixed_from_id: teacher_project.id, locale: nil) }
+      let(:student_project) { create(:project, school_id: school.id, lesson_id: nil, user_id: student.id, remixed_from_id: teacher_project.id, locale: nil, finished: true) }
       let(:student_project_json) do
         {
           identifier: student_project.identifier,
@@ -64,16 +69,18 @@ RSpec.describe 'Project show requests' do
           },
           components: [],
           image_list: [],
-          user_name: 'Joe Bloggs'
+          user_name: 'Joe Bloggs',
+          finished: student_project.finished
         }.to_json
       end
+
 
       it 'returns success response' do
         get("/api/projects/#{student_project.identifier}", headers:)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'includes the student\'s name in the project json' do
+      it 'includes the expected parameters in the project json' do
         get("/api/projects/#{student_project.identifier}", headers:)
         expect(response.body).to eq(student_project_json)
       end

--- a/spec/requests/projects/toggle_finished_spec.rb
+++ b/spec/requests/projects/toggle_finished_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Project toggle_finished requests' do
   let(:teacher_project) { create(:project, school_id: school.id, lesson_id: lesson.id, user_id: teacher.id, locale: nil) }
 
   before do
-    authenticated_in_hydra_as(teacher)
+    authenticated_in_hydra_as(student)
     stub_profile_api_list_school_students(school:, student_attributes: [{ name: 'Joe Bloggs' }])
   end
 

--- a/spec/requests/projects/toggle_finished_spec.rb
+++ b/spec/requests/projects/toggle_finished_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Project toggle_finished requests' do
+  let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:school) { create(:school) }
+  let(:teacher) { create(:teacher, school:) }
+  let(:student) { create(:student, school:) }
+  let(:lesson) { build(:lesson, school:, user_id: teacher.id, visibility: 'students') }
+  let(:teacher_project) { create(:project, school_id: school.id, lesson_id: lesson.id, user_id: teacher.id, locale: nil) }
+
+  before do
+    authenticated_in_hydra_as(teacher)
+    stub_profile_api_list_school_students(school:, student_attributes: [{ name: 'Joe Bloggs' }])
+  end
+
+  context 'when the finished flag is initially false' do
+    let!(:student_project) { create(:project, school_id: school.id, lesson_id: nil, user_id: student.id, remixed_from_id: teacher_project.id, locale: nil, finished: false) }
+
+    before do
+      put("/api/projects/#{student_project.identifier}/toggle_finished", headers:)
+      student_project.reload
+    end
+
+    it 'returns success response' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'sets the completed flag to true' do
+      expect(student_project.finished).to be_truthy
+    end
+  end
+
+  context 'when the finished flag is initially true' do
+    let!(:student_project) { create(:project, school_id: school.id, lesson_id: nil, user_id: student.id, remixed_from_id: teacher_project.id, locale: nil, finished: true) }
+
+    before do
+      put("/api/projects/#{student_project.identifier}/toggle_finished", headers:)
+      student_project.reload
+    end
+
+    it 'returns success response' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'sets the completed flag to false' do
+      expect(student_project.finished).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/232

## What's changed?

- Adds a boolean `finished` to projects
- Adds a new endpoint  `/api/projects/front-chow-empty/toggle_finished` that toggles `finished`
- Restricted to students, on a remix of one of their projects only
- Returns the flag on a standard show, if the project is a remix associated with a school

## Steps to perform after deploying to production

- Run `db:migrate`
