### PR TITLE
feat(SchoolDashboard): add postal_code to school form page for admin edits

### DIFF
--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -80,6 +80,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     address_line_1
     address_line_2
     municipality
+    postal_code
     administrative_area
     country_code
   ].freeze


### PR DESCRIPTION
## Status

We're regularly getting support requests (e.g. [this](https://raspberrypifoundation.slack.com/archives/C072CFJLC66/p1729673173120939)) relating to editing school postcodes. Adding this to the dashboard enables self serve for admins