### PR TITLE
Add my classes filter to classes index endpoint

### DIFF
--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -8,9 +8,7 @@ module Api
 
     def index
       school_classes = @school.classes.accessible_by(current_ability)
-      if params[:my_classes]
-        school_classes = school_classes.where(teacher_id: current_user.id)
-      end
+      school_classes = school_classes.where(teacher_id: current_user.id) if params[:my_classes]
       @school_classes_with_teachers = school_classes.with_teachers
       render :index, formats: [:json], status: :ok
     end

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -7,7 +7,11 @@ module Api
     load_and_authorize_resource :school_class, through: :school, through_association: :classes
 
     def index
-      @school_classes_with_teachers = @school.classes.accessible_by(current_ability).with_teachers
+      school_classes = @school.classes.accessible_by(current_ability)
+      if params[:my_classes]
+        school_classes = school_classes.where(teacher_id: current_user.id)
+      end
+      @school_classes_with_teachers = school_classes.with_teachers
       render :index, formats: [:json], status: :ok
     end
 

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -8,7 +8,7 @@ module Api
 
     def index
       school_classes = @school.classes.accessible_by(current_ability)
-      school_classes = school_classes.where(teacher_id: current_user.id) if params[:my_classes]
+      school_classes = school_classes.where(teacher_id: current_user.id) if params[:my_classes] == 'true'
       @school_classes_with_teachers = school_classes.with_teachers
       render :index, formats: [:json], status: :ok
     end

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'Listing school classes', type: :request do
   let(:teacher) { create(:teacher, school:, name: 'School Teacher') }
   let(:owner) { create(:owner, school:) }
 
-  let!(:owner_teacher) { create(:teacher, school:, id: owner.id) }
-  let!(:owner_school_class) { create(:school_class, name: 'Owner School Class', teacher_id: owner.id, school:) }
+  let(:owner_teacher) { create(:teacher, school:, id: owner.id) }
+  let!(:owner_school_class) { create(:school_class, name: 'Owner School Class', teacher_id: owner_teacher.id, school:) }
 
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}/classes", headers:)
@@ -36,7 +36,7 @@ RSpec.describe 'Listing school classes', type: :request do
     get("/api/schools/#{school.id}/classes?my_classes=true", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data.first[:name]).to eq('Owner School Class')
+    expect(data.first[:name]).to eq(owner_school_class.name)
   end
 
   it 'responds with the teachers JSON' do

--- a/spec/features/school_class/listing_school_classes_spec.rb
+++ b/spec/features/school_class/listing_school_classes_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'Listing school classes', type: :request do
   let(:teacher) { create(:teacher, school:, name: 'School Teacher') }
   let(:owner) { create(:owner, school:) }
 
+  let!(:owner_teacher) { create(:teacher, school:, id: owner.id) }
+  let!(:owner_school_class) { create(:school_class, name: 'Owner School Class', teacher_id: owner.id, school:) }
+
   it 'responds 200 OK' do
     get("/api/schools/#{school.id}/classes", headers:)
     expect(response).to have_http_status(:ok)
@@ -27,6 +30,13 @@ RSpec.describe 'Listing school classes', type: :request do
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data.first[:name]).to eq('Test School Class')
+  end
+
+  it 'only responds with the user\'s classes if the my_classes param is present' do
+    get("/api/schools/#{school.id}/classes?my_classes=true", headers:)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.first[:name]).to eq('Owner School Class')
   end
 
   it 'responds with the teachers JSON' do


### PR DESCRIPTION
## What's changed?

- Only return the classes for which the user is the teacher if `my_classes` query param is set
