### PR TITLE
455: Fix api errors

### DIFF
--- a/lib/concepts/school_student/create_batch.rb
+++ b/lib/concepts/school_student/create_batch.rb
@@ -2,7 +2,6 @@
 
 module SchoolStudent
   class Error < StandardError; end
-
   class ValidationError < StandardError
     attr_reader :errors
 
@@ -11,6 +10,7 @@ module SchoolStudent
       super()
     end
   end
+  class ConcurrencyExceededForSchool < StandardError; end
 
   class CreateBatch
     class << self

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -122,8 +122,15 @@ class ProfileApiClient
 
       response.body.deep_symbolize_keys
     rescue Faraday::BadRequestError => e
-      errors = JSON.parse(e.response_body)['errors']
-      raise Student422Error, errors
+      rawError = JSON.parse(e.response_body)
+      # Profile returns an array for standard errors, and json for bulk validations
+      if rawError.is_a?(Array)
+        raise Error, rawError.first['message']
+      elsif rawError['errors']
+        raise Student422Error, rawError['errors']
+      else
+        raise Student422Error, 'An unknown error occurred'
+      end
     end
 
     def update_school_student(token:, school_id:, student_id:, name: nil, username: nil, password: nil) # rubocop:disable Metrics/ParameterLists


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/editor-standalone/issues/455

## What's changed?

- Fixes error handling, to switch between a json validation response and a standard error

## Steps to perform after deploying to production

N/A
