### PR TITLE
Restrict instructions to school projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,7 @@ class Project < ApplicationRecord
   validates :locale, presence: true, unless: :user_id
   validate :user_has_a_role_within_the_school
   validate :user_is_a_member_or_the_owner_of_the_lesson
+  validate :project_with_instructions_must_belong_to_school
 
   scope :internal_projects, -> { where(user_id: nil) }
 
@@ -84,5 +85,11 @@ class Project < ApplicationRecord
     return if !lesson || user_id == lesson.user_id || !lesson.school_class || lesson.school_class&.members&.exists?(student_id: user_id)
 
     errors.add(:user, "'#{user_id}' is not the owner or a member of the lesson '#{lesson_id}'")
+  end
+
+  def project_with_instructions_must_belong_to_school
+    return unless instructions && !school_id
+
+    errors.add(:instructions, "Projects with instructions must belong to a school")
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,6 +90,6 @@ class Project < ApplicationRecord
   def project_with_instructions_must_belong_to_school
     return unless instructions && !school_id
 
-    errors.add(:instructions, "Projects with instructions must belong to a school")
+    errors.add(:instructions, 'Projects with instructions must belong to a school')
   end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
 
     trait :with_instructions do
       instructions { Faker::Lorem.paragraph }
+      school { create(:school) }
     end
   end
 end

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Project show requests' do
     end
 
     context 'when loading own project' do
-      let!(:project) { create(:project, :with_instructions, user_id: teacher.id, locale: nil) }
+      let!(:project) { create(:project, :with_instructions, school:, user_id: teacher.id, locale: nil) }
       let(:project_json) do
         {
           identifier: project.identifier,
@@ -116,7 +116,7 @@ RSpec.describe 'Project show requests' do
 
   context 'when user is not logged in' do
     context 'when loading a starter project' do
-      let!(:starter_project) { create(:project, :with_instructions, user_id: nil, locale: 'ja-JP') }
+      let!(:starter_project) { create(:project, user_id: nil, locale: 'ja-JP') }
       let(:starter_project_json) do
         {
           identifier: starter_project.identifier,
@@ -124,7 +124,7 @@ RSpec.describe 'Project show requests' do
           locale: starter_project.locale,
           name: starter_project.name,
           user_id: starter_project.user_id,
-          instructions: starter_project.instructions,
+          instructions: nil,
           components: [],
           image_list: []
         }.to_json

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Project update requests' do
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
   context 'when authed user is project creator' do
-    let(:project) { create(:project, :with_default_component, :with_instructions, user_id: owner.id, locale: nil) }
+    let!(:project) { create(:project, :with_default_component, :with_instructions, school:, user_id: owner.id, locale: nil) }
     let!(:component) { create(:component, project:) }
     let(:default_component_params) do
       project.components.first.attributes.symbolize_keys.slice(


### PR DESCRIPTION
## What's changed?

- Added extra validation to the `project` model to stop instructions being added to non-school projects

closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/393