### PR TITLE
843: Ensure a fallback for a missing remix origin (mainly for cypress test failures)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -516,6 +516,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -19,10 +19,12 @@ module Api
       end
 
       def create
+        # Ensure we have a fallback value to prevent bad requests
+        remix_origin = request.origin || request.referer
         result = Project::CreateRemix.call(params: remix_params,
                                            user_id: current_user&.id,
                                            original_project: project,
-                                           remix_origin: request.origin)
+                                           remix_origin:)
 
         if result.success?
           @project = result[:project]
@@ -42,7 +44,10 @@ module Api
         params.require(:project)
               .permit(:name,
                       :identifier,
+                      :project_type,
                       :locale,
+                      :user_id,
+                      image_list: [],
                       components: %i[id name extension content index])
       end
     end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -104,7 +104,9 @@ module Api
         :locale,
         {
           components: %i[id name extension content index default]
-        }
+        },
+        parent: {},
+        image_list: []
       )
     end
 


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/editor-ui/issues/843

## What's changed?

Fixes a bad request when no remix_origin is defined, this was leading to cypress integration tests failing.

## Steps to perform after deploying to production

N/A
