### PR TITLE
Copy all media when project remixed

### DIFF
--- a/lib/concepts/project/operations/create_remix.rb
+++ b/lib/concepts/project/operations/create_remix.rb
@@ -35,6 +35,14 @@ class Project
           remix.images.attach(image.blob)
         end
 
+        original_project.videos.each do |video|
+          remix.videos.attach(video.blob)
+        end
+
+        original_project.audio.each do |audio_file|
+          remix.audio.attach(audio_file.blob)
+        end
+
         params[:components].each do |x|
           remix.components.build(x.slice(:name, :extension, :content))
         end

--- a/spec/concepts/project/create_remix_spec.rb
+++ b/spec/concepts/project/create_remix_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Project::CreateRemix, type: :unit do
 
   let(:remix_origin) { 'editor.com' }
   let(:user_id) { 'e0675b6c-dc48-4cd6-8c04-0f7ac05af51a' }
-  let!(:original_project) { create(:project, :with_components, :with_attached_image) }
+  let!(:original_project) { create(:project, :with_components, :with_attached_image, :with_attached_video, :with_attached_audio) }
   let(:remix_params) do
     component = original_project.components.first
     {
@@ -79,11 +79,21 @@ RSpec.describe Project::CreateRemix, type: :unit do
       expect(remixed_project.images.length).to eq(original_project.images.length)
     end
 
-    it 'creates a new attachment' do
-      expect { create_remix }.to change(ActiveStorage::Attachment, :count).by(1)
+    it 'links remix to attached videos' do
+      remixed_project = create_remix[:project]
+      expect(remixed_project.videos.length).to eq(original_project.videos.length)
     end
 
-    it 'does not create a new image' do
+    it 'links remix to attached audio' do
+      remixed_project = create_remix[:project]
+      expect(remixed_project.audio.length).to eq(original_project.audio.length)
+    end
+
+    it 'creates new attachments' do
+      expect { create_remix }.to change(ActiveStorage::Attachment, :count).by(3)
+    end
+
+    it 'does not create new media' do
       expect { create_remix }.not_to change(ActiveStorage::Blob, :count)
     end
 


### PR DESCRIPTION
## Status

closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/386

## What's changed?

- Remixes copy audio and video files as well as images
