### PR TITLE
Add libyaml-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM base AS builder
 WORKDIR /app
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
-  build-essential libpq-dev libxml2-dev libxslt1-dev git \
+  build-essential libpq-dev libxml2-dev libxslt1-dev git libyaml-dev \
   firefox-esr python2-dev \
   && rm -rf /var/lib/apt/lists/* /var/lib/apt/archives/*.deb
 COPY Gemfile Gemfile.lock /app/


### PR DESCRIPTION
This is required to build the psych Gem. Prior to this commit, running `docker compose build` would fail with:

```
65.20 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
65.20
65.20     current directory: /usr/local/bundle/gems/psych-5.1.2/ext/psych
65.20 /usr/local/bin/ruby extconf.rb
65.20 checking for yaml.h... no
65.20 yaml.h not found
65.20 *** extconf.rb failed ***
```

I don't understand why I'm seeing this error now because there don't appear to be any changes in the Dockerfile or docker-compose.yml files that could've caused it.
