### PR TITLE
Add host.docker.internal to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - POSTGRES_DB
       - POSTGRES_PASSWORD
       - POSTGRES_USER
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   smee:
     image: deltaprojects/smee-client
     platform: linux/amd64


### PR DESCRIPTION
This should ensure that we can use host.docker.internal to connect to the host machine from within a container irrespective of the OS on the host machine.

The `host.docker.internal` address is [automatically available to Docker Desktop][1] on Windows and Mac, but [not on Linux without this additional configuration][2].

[1]: https://docs.docker.com/desktop/features/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
[2]: https://github.com/docker/for-linux/issues/264#issuecomment-964620100
