### PR TITLE
Fix for attaching media in editor builds

### DIFF
--- a/lib/project_importer.rb
+++ b/lib/project_importer.rb
@@ -71,16 +71,28 @@ class ProjectImporter
 
         existing_media_file.purge
       end
+
       if images.include?(media_file)
-        project.images.attach(**media_file)
+        blob = create_blob(media_file)
+        project.images.attach(blob)
       elsif videos.include?(media_file)
-        project.videos.attach(**media_file)
+        blob = create_blob(media_file)
+        project.videos.attach(blob)
       elsif audio.include?(media_file)
-        project.audio.attach(**media_file)
+        blob = create_blob(media_file)
+        project.audio.attach(blob)
       else
         raise "Unsupported media file: #{media_file[:filename]}"
       end
     end
+  end
+
+  def create_blob(media_file)
+    ActiveStorage::Blob.create_and_upload!(
+      io: media_file[:io],
+      filename: media_file[:filename],
+      content_type: media_file[:content_type]
+    )
   end
 
   def find_existing_media_file(filename)


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/438

## What's changed?

In some scenarios the blob is not being created properly on attach, which is causing a foreign key constraint, this change explicitly creates the blob prior to attaching it.

## Steps to perform after deploying to production

- Try re-running one of the failed jobs
