### PR TITLE
Fix ruby lsp

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,9 +28,8 @@
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [
-    3009
-  ],
+  // "forwardPorts": [
+  // ],
 
   // Uncomment the next line if you want start specific services in your Docker Compose config.
   // "runServices": [],
@@ -76,6 +75,11 @@
         },
         "rubyLsp.enabledFeatures": {
           "diagnostics": true
+        },
+        "terminal.integrated.profiles.linux": {
+          "sh": {
+            "path": "/bin/zsh"
+          }
         },
         "rubyLsp.rubyVersionManager": {
           "identifier": "none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,6 +76,13 @@
         },
         "rubyLsp.enabledFeatures": {
           "diagnostics": true
+        },
+        "rubyLsp.rubyVersionManager": {
+          "identifier": "none"
+        },
+        "rubyLsp.rubyExecutablePath": "/usr/local/bin/ruby",
+        "rubyLsp.featureFlags": {
+          "launcher": false // ruby-lsp v0.17 will fail with this flag enabled
         }
       }
     }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - bundle:/usr/local/bundle
 
 volumes:
-  node_modules: null
+  node_modules:
   postgres_data:
-  bundle: null
+  bundle:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - ${HOME}/.ssh:/root/.ssh:ro # To share any ssh keys with the container
       - /var/run/docker.sock:/var/run/docker.sock
       - node_modules:/app/node_modules
+      - bundle:/usr/local/bundle
 
 volumes:
   node_modules: null
+  postgres_data:
+  bundle: null

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ AWS_SECRET_ACCESS_KEY=changeme
 
 GITHUB_WEBHOOK_SECRET=test_token
 GITHUB_WEBHOOK_REF="refs/heads/draft"
+# GITHUB_AUTH_TOKEN="" # Only needed if testing editor builds with Github Api
 
 POSTGRES_HOST=db
 POSTGRES_PASSWORD=password

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,11 @@ FROM builder AS dev-container
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends sudo git vim zsh ssh curl less
 RUN sh -c "$(curl -L https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
-    -t robbyrussell \
-    -p git -p docker-compose -p yarn \
-    -p https://github.com/zsh-users/zsh-autosuggestions \
-    # -p https://github.com/marlonrichert/zsh-autocomplete \
-    -p https://github.com/unixorn/fzf-zsh-plugin
+  -t robbyrussell \
+  -p git -p docker-compose -p yarn \
+  -p https://github.com/zsh-users/zsh-autosuggestions \
+  -p https://github.com/marlonrichert/zsh-autocomplete \
+  -p https://github.com/unixorn/fzf-zsh-plugin
 RUN chsh -s $(which zsh) ${USER}
 
 # Slim application image without development dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ end
 group :development do
   gem 'awesome_print'
   gem 'rails-erd'
-  gem 'ruby-lsp', '~> 0.17.7'
   gem 'ruby-lsp-rails'
   gem 'ruby-lsp-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -565,7 +565,6 @@ DEPENDENCIES
   rubocop-graphql
   rubocop-rails
   rubocop-rspec
-  ruby-lsp (~> 0.17.7)
   ruby-lsp-rails
   ruby-lsp-rspec
   scout_apm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: deltaprojects/smee-client
     platform: linux/amd64
     command: -u $SMEE_TUNNEL -t http://api:3009/github_webhooks
+    environment:
+      - SMEE_TUNNEL
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Status

Ready for review

## What's changed?

- Fix ruby-lsp inside dev-container, previously wasn't working as asdf (or any verison manager) wasn't on the image. 
- Defines zsh as default terminal (previous cmd was deprecated apparently)
- Puts the bundle on a volume for the dev-container
- Make the smee tunnel an overwritable value

## Steps to perform after deploying to production

- Rebuild your dev containers with `Dev Containers: Rebuild Container` cmd in vscode
