### PR TITLE
Add support for Scratch projects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ GraphQL/ObjectDescription:
     - app/graphql/types/query_type.rb
 
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/api/default_projects_controller.rb
+++ b/app/controllers/api/default_projects_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :authorize_user, only: %i[create]
 
     def show
-      data = if params[:type] == 'html'
+      data = if params[:type] == Project::Types::HTML
                html_project
              else
                python_project
@@ -23,7 +23,7 @@ module Api
 
     def create
       identifier = PhraseIdentifier.generate
-      @project = Project.new(identifier:, project_type: 'python')
+      @project = Project.new(identifier:, project_type: Project::Types::PYTHON)
       @project.components << Component.new(python_component)
       @project.save
 
@@ -38,7 +38,7 @@ module Api
 
     def python_project
       {
-        type: 'python',
+        type: Project::Types::PYTHON,
         components: [
           { lang: 'py', name: 'main',
             content: "import turtle\nt = turtle.Turtle()\nt.forward(100)\nprint(\"Oh yeah!\")" }
@@ -53,7 +53,7 @@ module Api
       CON
 
       {
-        type: 'html',
+        type: Project::Types::HTML,
         components: [
           { lang: 'html', name: 'index', content: },
           { lang: 'css', name: 'style', content: "h1 {\n  color: blue;\n}" },

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -64,7 +64,7 @@ module Api
     def load_project
       project_loader = ProjectLoader.new(params[:id], [params[:locale]])
       @project = if action_name == 'show'
-                   project_loader.load(include_images: true)
+                   project_loader.load(include_images: true, only_scratch: params[:project_type] == 'scratch')
                  else
                    project_loader.load
                  end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -64,7 +64,7 @@ module Api
     def load_project
       project_loader = ProjectLoader.new(params[:id], [params[:locale]])
       @project = if action_name == 'show'
-                   project_loader.load(include_images: true, only_scratch: params[:project_type] == 'scratch')
+                   project_loader.load(include_images: true, only_scratch: params[:project_type] == Project::Types::SCRATCH)
                  else
                    project_loader.load
                  end

--- a/app/models/filesystem_project.rb
+++ b/app/models/filesystem_project.rb
@@ -15,7 +15,7 @@ class FilesystemProject
       categorized_files = categorize_files(files, dir)
 
       project_importer = ProjectImporter.new(name: proj_config['NAME'], identifier: proj_config['IDENTIFIER'],
-                                             type: proj_config['TYPE'] || 'python',
+                                             type: proj_config['TYPE'] || Project::Types::PYTHON,
                                              locale: proj_config['LOCALE'] || 'en', **categorized_files)
       project_importer.import!
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
+  module Types
+    PYTHON = 'python'
+    HTML = 'html'
+    SCRATCH = 'scratch'
+  end
+
   belongs_to :school, optional: true
   belongs_to :lesson, optional: true
   belongs_to :parent, optional: true, class_name: :Project, foreign_key: :remixed_from_id, inverse_of: :remixes
@@ -26,7 +32,7 @@ class Project < ApplicationRecord
   validate :project_with_school_id_has_school_project
   validate :school_project_school_matches_project_school
 
-  default_scope -> { where.not(project_type: 'scratch') }
+  default_scope -> { where.not(project_type: Types::SCRATCH) }
 
   scope :internal_projects, -> { where(user_id: nil) }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,8 @@ class Project < ApplicationRecord
   validate :project_with_school_id_has_school_project
   validate :school_project_school_matches_project_school
 
+  default_scope -> { where.not(project_type: 'scratch') }
+
   scope :internal_projects, -> { where(user_id: nil) }
 
   has_paper_trail(

--- a/lib/project_loader.rb
+++ b/lib/project_loader.rb
@@ -8,8 +8,9 @@ class ProjectLoader
     @locales = [*locales, 'en', nil]
   end
 
-  def load(include_images: false)
-    query = Project.where(identifier:, locale: @locales)
+  def load(include_images: false, only_scratch: false)
+    query = only_scratch ? Project.unscoped.where(project_type: 'scratch') : Project
+    query = query.where(identifier:, locale: @locales)
     query = query.includes(images_attachments: :blob) if include_images
     query.min_by { |project| @locales.find_index(project.locale) }
   end

--- a/lib/project_loader.rb
+++ b/lib/project_loader.rb
@@ -9,7 +9,7 @@ class ProjectLoader
   end
 
   def load(include_images: false, only_scratch: false)
-    query = only_scratch ? Project.unscoped.where(project_type: 'scratch') : Project
+    query = only_scratch ? Project.unscoped.where(project_type: Project::Types::SCRATCH) : Project
     query = query.where(identifier:, locale: @locales)
     query = query.includes(images_attachments: :blob) if include_images
     query.min_by { |project| @locales.find_index(project.locale) }

--- a/lib/tasks/seeds_helper.rb
+++ b/lib/tasks/seeds_helper.rb
@@ -98,7 +98,7 @@ module SeedsHelper
       project.school = school
       project.lesson = lesson
       project.locale = 'en'
-      project.project_type = 'python'
+      project.project_type = Project::Types::PYTHON
       project.components << Component.new({ extension: 'py', name: 'main',
                                             content: code })
     end

--- a/spec/concepts/lesson/create_spec.rb
+++ b/spec/concepts/lesson/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Lesson::Create, type: :unit do
       school_id: school.id,
       project_attributes: {
         name: 'Hello world project',
-        project_type: 'python',
+        project_type: Project::Types::PYTHON,
         components: [
           { name: 'main.py', extension: 'py', content: 'print("Hello, world!")' }
         ]
@@ -86,7 +86,7 @@ RSpec.describe Lesson::Create, type: :unit do
       {
         project_attributes: {
           name: 'Hello world project',
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           components: [
             { name: 'main.py', extension: 'py', content: 'print("Hello, world!")' }
           ]

--- a/spec/concepts/project/create_spec.rb
+++ b/spec/concepts/project/create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Project::Create, type: :unit do
 
       let(:project_hash) do
         {
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           components: [{
             name: 'main',
             extension: 'py',

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     user_id { SecureRandom.uuid }
     name { Faker::Book.title }
     identifier { "#{Faker::Verb.base}-#{Faker::Verb.base}-#{Faker::Verb.base}" }
-    project_type { 'python' }
+    project_type { Project::Types::PYTHON }
     locale { %w[en es-LA fr-FR].sample }
 
     transient do

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Creating a lesson', type: :request do
         name: 'Test Lesson',
         project_attributes: {
           name: 'Hello world project',
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           components: [
             { name: 'main.py', extension: 'py', content: 'print("Hello, world!")' }
           ]
@@ -68,7 +68,7 @@ RSpec.describe 'Creating a lesson', type: :request do
           school_id: school.id,
           project_attributes: {
             name: 'Hello world project',
-            project_type: 'python',
+            project_type: Project::Types::PYTHON,
             components: [
               { name: 'main.py', extension: 'py', content: 'print("Hello, world!")' }
             ]
@@ -130,7 +130,7 @@ RSpec.describe 'Creating a lesson', type: :request do
           school_class_id: school_class.id,
           project_attributes: {
             name: 'Hello world project',
-            project_type: 'python',
+            project_type: Project::Types::PYTHON,
             components: [
               { name: 'main.py', extension: 'py', content: 'print("Hello, world!")' }
             ]

--- a/spec/graphql/mutations/create_project_mutation_spec.rb
+++ b/spec/graphql/mutations/create_project_mutation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'mutation CreateProject() { ... }' do
     {
       project: {
         name: 'Untitled project',
-        projectType: 'python',
+        projectType: Project::Types::PYTHON,
         components: [{
           content: 'Insert Python Here',
           default: true,

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
   it { expect(mutation).to be_a_valid_graphql_query }
 
   context 'with an existing project' do
-    let(:project) { create(:project, user_id: authenticated_user.id, project_type: :python) }
+    let(:project) { create(:project, user_id: authenticated_user.id, project_type: 'python') }
     let(:project_id) { project.to_gid_param }
     let(:school) { create(:school) }
 

--- a/spec/graphql/mutations/update_project_mutation_spec.rb
+++ b/spec/graphql/mutations/update_project_mutation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
       project: {
         id: project_id,
         name: 'Untitled project again',
-        projectType: 'html'
+        projectType: Project::Types::HTML
       }
     }
   end
@@ -26,7 +26,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
   it { expect(mutation).to be_a_valid_graphql_query }
 
   context 'with an existing project' do
-    let(:project) { create(:project, user_id: authenticated_user.id, project_type: 'python') }
+    let(:project) { create(:project, user_id: authenticated_user.id, project_type: Project::Types::PYTHON) }
     let(:project_id) { project.to_gid_param }
     let(:school) { create(:school) }
 
@@ -62,7 +62,7 @@ RSpec.describe 'mutation UpdateProject() { ... }' do
       end
 
       it 'updates the project type' do
-        expect { result }.to change { project.reload.project_type }.from(project.project_type).to('html')
+        expect { result }.to change { project.reload.project_type }.from(project.project_type).to(Project::Types::HTML)
       end
 
       context 'when the project cannot be found' do

--- a/spec/jobs/upload_job_spec.rb
+++ b/spec/jobs/upload_job_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe UploadJob do
     {
       name: "Don't Collide!",
       identifier: 'dont-collide-starter',
-      type: 'python',
+      type: Project::Types::PYTHON,
       locale: 'ja-JP',
       components: [
         {

--- a/spec/lib/project_importer_spec.rb
+++ b/spec/lib/project_importer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProjectImporter do
     described_class.new(
       name: 'My amazing project',
       identifier: 'my-amazing-project',
-      type: 'python',
+      type: Project::Types::PYTHON,
       locale: 'ja-JP',
       components: [
         { name: 'main', extension: 'py', content: 'print(\'hello\')', default: true },

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -321,10 +321,10 @@ RSpec.describe Project, versioning: true do
   end
 
   describe 'default scope' do
-    let!(:python_project) { create(:project, project_type: 'python') }
-    let!(:html_project) { create(:project, project_type: 'html') }
+    let!(:python_project) { create(:project, project_type: Project::Types::PYTHON) }
+    let!(:html_project) { create(:project, project_type: Project::Types::HTML) }
     let!(:project_with_unknown_type) { create(:project, project_type: 'unknown') }
-    let!(:scratch_project) { create(:project, project_type: 'scratch') }
+    let!(:scratch_project) { create(:project, project_type: Project::Types::SCRATCH) }
 
     it 'includes python projects' do
       expect(described_class.all).to include(python_project)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -319,4 +319,27 @@ RSpec.describe Project, versioning: true do
       expect(project_without_school.versions.length).to(eq(0))
     end
   end
+
+  describe 'default scope' do
+    let!(:python_project) { create(:project, project_type: 'python') }
+    let!(:html_project) { create(:project, project_type: 'html') }
+    let!(:project_with_unknown_type) { create(:project, project_type: 'unknown') }
+    let!(:scratch_project) { create(:project, project_type: 'scratch') }
+
+    it 'includes python projects' do
+      expect(described_class.all).to include(python_project)
+    end
+
+    it 'includes html projects' do
+      expect(described_class.all).to include(html_project)
+    end
+
+    it 'includes projects with unknown type' do
+      expect(described_class.all).to include(project_with_unknown_type)
+    end
+
+    it 'does not include scratch projects' do
+      expect(described_class.all).not_to include(scratch_project)
+    end
+  end
 end

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -156,11 +156,12 @@ RSpec.describe 'Project show requests' do
 
   context 'when user is not logged in' do
     context 'when loading a starter project' do
-      let!(:starter_project) { create(:project, user_id: nil, locale: 'ja-JP') }
+      let(:project_type) { 'python' }
+      let!(:starter_project) { create(:project, user_id: nil, locale: 'ja-JP', project_type:) }
       let(:starter_project_json) do
         {
           identifier: starter_project.identifier,
-          project_type: 'python',
+          project_type:,
           locale: starter_project.locale,
           name: starter_project.name,
           user_id: starter_project.user_id,
@@ -190,6 +191,15 @@ RSpec.describe 'Project show requests' do
       it 'returns 404 response if invalid project' do
         get('/api/projects/no-such-project', headers:)
         expect(response).to have_http_status(:not_found)
+      end
+
+      context 'when project is a scratch project' do
+        let(:project_type) { 'scratch' }
+
+        it 'returns 404 response if scratch project' do
+          get("/api/projects/#{starter_project.identifier}?locale=#{starter_project.locale}", headers:)
+          expect(response).to have_http_status(:not_found)
+        end
       end
 
       it 'creates a new ProjectLoader with the correct parameters' do

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Project show requests' do
       let(:project_json) do
         {
           identifier: project.identifier,
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           locale: project.locale,
           name: project.name,
           user_id: project.user_id,
@@ -62,7 +62,7 @@ RSpec.describe 'Project show requests' do
       let(:student_project_json) do
         {
           identifier: student_project.identifier,
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           locale: student_project.locale,
           name: student_project.name,
           user_id: student_project.user_id,
@@ -102,7 +102,7 @@ RSpec.describe 'Project show requests' do
       let(:another_teacher_project_json) do
         {
           identifier: another_teacher_project.identifier,
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           locale: another_teacher_project.locale,
           name: another_teacher_project.name,
           user_id: teacher.id,
@@ -130,7 +130,7 @@ RSpec.describe 'Project show requests' do
       let(:another_project_json) do
         {
           identifier: another_project.identifier,
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           name: another_project.name,
           locale: another_project.locale,
           user_id: another_project.user_id,
@@ -156,7 +156,7 @@ RSpec.describe 'Project show requests' do
 
   context 'when user is not logged in' do
     context 'when loading a starter project' do
-      let(:project_type) { 'python' }
+      let(:project_type) { Project::Types::PYTHON }
       let!(:starter_project) { create(:project, user_id: nil, locale: 'ja-JP', project_type:) }
       let(:starter_project_json) do
         {
@@ -194,7 +194,7 @@ RSpec.describe 'Project show requests' do
       end
 
       context 'when project is a scratch project' do
-        let(:project_type) { 'scratch' }
+        let(:project_type) { Project::Types::SCRATCH }
 
         context 'when project_type is set to scratch in query params' do
           before do
@@ -233,7 +233,7 @@ RSpec.describe 'Project show requests' do
       let(:project_json) do
         {
           identifier: project.identifier,
-          project_type: 'python',
+          project_type: Project::Types::PYTHON,
           locale: project.locale,
           name: project.name,
           user_id: project.user_id,

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -196,6 +196,24 @@ RSpec.describe 'Project show requests' do
       context 'when project is a scratch project' do
         let(:project_type) { 'scratch' }
 
+        context 'when project_type is set to scratch in query params' do
+          before do
+            get("/api/projects/#{starter_project.identifier}?locale=#{starter_project.locale}&project_type=scratch", headers:)
+          end
+
+          it 'returns success response' do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'returns json' do
+            expect(response.content_type).to eq('application/json; charset=utf-8')
+          end
+
+          it 'returns the project json' do
+            expect(response.body).to eq(starter_project_json)
+          end
+        end
+
         it 'returns 404 response if scratch project' do
           get("/api/projects/#{starter_project.identifier}?locale=#{starter_project.locale}", headers:)
           expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
This introduces the concept of projects of type "scratch" which we're going to need for the [Experience CS project](https://github.com/RaspberryPiFoundation/experience-cs). However, it goes to some pains to ensure that any existing clients of the API  (e.g. `editor-standalone`, `editor-ui`, the admin dashboard in `editor-api`, etc) will not see a scratch project for now unless they specifically choose to by adding a `project_type=scratch` query string parameter.

* [Add default scope to hide scratch projects](https://github.com/RaspberryPiFoundation/editor-api/pull/513/commits/bdf8cccf0c9c024aab81f469870802cbab6a8237)
* [Add scratch-only option for project show endpoint](https://github.com/RaspberryPiFoundation/editor-api/pull/513/commits/91e8466a8be86764b23c72024ceeac559e4fd642)
* [Consistently use strings for Project#project_type](https://github.com/RaspberryPiFoundation/editor-api/pull/513/commits/f4429655a56dd663d54e6b076625d0dfe8d77ca5)
* [Extract string literals -> Project::Types constants](https://github.com/RaspberryPiFoundation/editor-api/pull/513/commits/dfade60e7d3a9b89e371e24703c3c15cfc8780d1)
