### PR TITLE
Add seed projects for 2 experience cs Scratch projects

### DIFF
--- a/lib/tasks/project_components/experience_cs_debugging/project_config.yml
+++ b/lib/tasks/project_components/experience_cs_debugging/project_config.yml
@@ -1,0 +1,3 @@
+NAME: 'L5 Debugging Activity'
+IDENTIFIER: 'experience-cs-debugging'
+TYPE: 'scratch'

--- a/lib/tasks/project_components/experience_cs_parsons_problem/project_config.yml
+++ b/lib/tasks/project_components/experience_cs_parsons_problem/project_config.yml
@@ -1,0 +1,3 @@
+NAME: 'L4 Parsons Problem'
+IDENTIFIER: 'experience-cs-parsons-problem'
+TYPE: 'scratch'


### PR DESCRIPTION
The names correspond to the names we currently use in the seed data in experience-cs[1].

[1]: https://github.com/RaspberryPiFoundation/experience-cs/blob/7024e60adc8ee9c01ebdd833228576b8babfa8b1/db/seeds.rb#L11

## Status

- Closes _add issue numbers or delete_
- Related to _add issue numbers or delete_

## Points for consideration:

- Security
- Performance

## What's changed?

_Description of what's been done - bullets are often best_

## Steps to perform after deploying to production

_If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, a migration, or upgrading a Gem. That kind of thing._
