### PR TITLE
447: Add owners and a type to school member list

### DIFF
--- a/app/controllers/api/school_owners_controller.rb
+++ b/app/controllers/api/school_owners_controller.rb
@@ -7,7 +7,7 @@ module Api
     authorize_resource :school_owner, class: false
 
     def index
-      result = SchoolOwner::List.call(school: @school, token: current_user.token)
+      result = SchoolOwner::List.call(school: @school)
 
       if result.success?
         @school_owners = result[:school_owners]

--- a/app/views/api/school_members/index.json.jbuilder
+++ b/app/views/api/school_members/index.json.jbuilder
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 json.array!(@school_members) do |school_member|
-  if school_member.respond_to?(:email) && school_member.email.present?
+  case school_member.type
+  when :owner
+    json.set! :owner do
+      json.partial! '/api/school_owners/school_owner', owner: school_member
+    end
+  when :teacher
     json.set! :teacher do
       json.partial! '/api/school_teachers/school_teacher', teacher: school_member
     end

--- a/app/views/api/school_owners/_school_owner.json.jbuilder
+++ b/app/views/api/school_owners/_school_owner.json.jbuilder
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 json.call(
-  teacher,
+  owner,
   :id,
   :name
 )
 
-json.type(teacher.type) if teacher.respond_to?(:type)
+json.type(owner.type) if owner.respond_to?(:type)
 
 include_email = local_assigns.fetch(:include_email, true)
 
-json.email(teacher.email) if include_email
+json.email(owner.email) if include_email

--- a/app/views/api/school_owners/index.json.jbuilder
+++ b/app/views/api/school_owners/index.json.jbuilder
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
 json.array!(@school_owners) do |owner|
-  json.call(
-    owner,
-    :id,
-    :email,
-    :name
-  )
+  json.partial! 'school_owner', owner:
 end

--- a/app/views/api/school_students/_school_student.json.jbuilder
+++ b/app/views/api/school_students/_school_student.json.jbuilder
@@ -6,3 +6,5 @@ json.call(
   :username,
   :name
 )
+
+json.type(student.type) if student.respond_to?(:type)

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -33,10 +33,7 @@ module SchoolMember
           response
         end
 
-        type_priority = { owner: 0, teacher: 1, student: 2 }
-        response[:school_members] = (owners + teachers + students).sort do |a, b|
-          [type_priority[a.type], a.name] <=> [type_priority[b.type], b.name]
-        end
+        response[:school_members] = (owners + teachers + students).sort_by(&:name)
         response
       end
     end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -39,7 +39,7 @@ module SchoolMember
         end
         response
       end
-      # rubocop:disable Metrics/CyclomaticComplexity
-    enable
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -5,6 +5,7 @@ module SchoolMember
     SchoolMember = Struct.new(:id, :name, :username, :email, :type)
 
     class << self
+      # rubocop:disable Metrics/CyclomaticComplexity
       def call(school:, token:)
         response = OperationResponse.new
         response[:school_members] = []
@@ -38,6 +39,7 @@ module SchoolMember
         end
         response
       end
-    end
+      # rubocop:disable Metrics/CyclomaticComplexity
+    enable
   end
 end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -2,22 +2,39 @@
 
 module SchoolMember
   class List
+    SchoolMember = Struct.new(:id, :name, :username, :email, :type)
+
     class << self
       def call(school:, token:)
         response = OperationResponse.new
         response[:school_members] = []
 
+        students = teachers = owners = []
+
         begin
-          students = SchoolStudent::List.call(school:, token:).fetch(:school_students, [])
-          teachers = SchoolTeacher::List.call(school:).fetch(:school_teachers, [])
+          students_response = SchoolStudent::List.call(school:, token:).fetch(:school_students, [])
+          teachers_response = SchoolTeacher::List.call(school:).fetch(:school_teachers, [])
+          owners_response = SchoolOwner::List.call(school:).fetch(:school_owners, [])
+
+          students = students_response.map do |student|
+            SchoolMember.new(student.id, student.name, student.username, nil, :student)
+          end
+          owners = owners_response.map do |owner|
+            SchoolMember.new(owner.id, owner.name, nil, owner.email, :owner)
+          end
+          owner_ids = owners.map(&:id)
+          teachers = teachers_response.reject { |teacher| owner_ids.include?(teacher.id) }.map do |teacher|
+            SchoolMember.new(teacher.id, teacher.name, nil, teacher.email, :teacher)
+          end
         rescue StandardError => e
           Sentry.capture_exception(e)
           response[:error] = "Error listing school members: #{e}"
-          return response
+          response
         end
 
-        response[:school_members] = teachers + students.sort do |a, b|
-          a.name <=> b.name
+        type_priority = { owner: 0, teacher: 1, student: 2 }
+        response[:school_members] = (owners + teachers + students).sort do |a, b|
+          [type_priority[a.type], a.name] <=> [type_priority[b.type], b.name]
         end
         response
       end

--- a/lib/concepts/school_owner/list.rb
+++ b/lib/concepts/school_owner/list.rb
@@ -3,9 +3,10 @@
 module SchoolOwner
   class List
     class << self
-      def call(school:, token:)
+      def call(school:, owner_ids: nil)
         response = OperationResponse.new
-        response[:school_owners] = list_owners(school, token)
+        owner_ids = school.roles.where(role: :owner)&.pluck(:user_id) if owner_ids.blank?
+        response[:school_owners] = list_owners(owner_ids)
         response
       rescue StandardError => e
         Sentry.capture_exception(e)
@@ -15,11 +16,8 @@ module SchoolOwner
 
       private
 
-      def list_owners(school, token)
-        response = ProfileApiClient.list_school_owners(token:, organisation_id: school.id)
-        user_ids = response.fetch(:ids)
-
-        User.from_userinfo(ids: user_ids)
+      def list_owners(ids)
+        User.from_userinfo(ids:)
       end
     end
   end

--- a/spec/concepts/school_member/list_spec.rb
+++ b/spec/concepts/school_member/list_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe SchoolMember::List, type: :unit do
       expect(response.success?).to be(true)
     end
 
-    it 'returns school members in the operation response' do
-      response = described_class.call(school:, token:)
-      expect(response[:school_members].count { |member| member.is_a?(User) }).to eq(4)
-    end
-
     it 'contains the expected students' do
       response = described_class.call(school:, token:)
       students.each do |student|

--- a/spec/concepts/school_owner/list_spec.rb
+++ b/spec/concepts/school_owner/list_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe SchoolOwner::List, type: :unit do
-  let(:token) { UserProfileMock::TOKEN }
   let(:school) { create(:school) }
   let(:owner) { create(:owner, school:) }
+  let(:owner_ids) { [owner.id] }
 
   before do
     stub_profile_api_list_school_owners(user_id: owner.id)
@@ -13,41 +13,33 @@ RSpec.describe SchoolOwner::List, type: :unit do
   end
 
   it 'returns a successful operation response' do
-    response = described_class.call(school:, token:)
+    response = described_class.call(school:)
     expect(response.success?).to be(true)
   end
 
-  it 'makes a profile API call' do
-    described_class.call(school:, token:)
-
-    # TODO: Replace with WebMock assertion once the profile API has been built.
-    expect(ProfileApiClient).to have_received(:list_school_owners).with(token:, organisation_id: school.id)
-  end
-
   it 'returns the school owners in the operation response' do
-    response = described_class.call(school:, token:)
+    response = described_class.call(school:)
     expect(response[:school_owners].first).to be_a(User)
   end
 
-  context 'when listing fails' do
+  context 'when an error occurs' do
+    let(:response) { described_class.call(school:, owner_ids:) }
+
+    let(:error_message) { 'Error listing school owners: some error' }
+
     before do
-      allow(ProfileApiClient).to receive(:list_school_owners).and_raise('Some API error')
+      allow(User).to receive(:from_userinfo).with(ids: owner_ids).and_raise(StandardError.new('some error'))
       allow(Sentry).to receive(:capture_exception)
     end
 
-    it 'returns a failed operation response' do
-      response = described_class.call(school:, token:)
-      expect(response.failure?).to be(true)
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'captures the exception and returns an error response' do
+      # Call the method to ensure the error is raised and captured
+      response
+      expect(Sentry).to have_received(:capture_exception).with(instance_of(StandardError))
+      expect(response[:school_owners]).to be_nil
+      expect(response[:error]).to eq(error_message)
     end
-
-    it 'returns the error message in the operation response' do
-      response = described_class.call(school:, token:)
-      expect(response[:error]).to match(/Some API error/)
-    end
-
-    it 'sent the exception to Sentry' do
-      described_class.call(school:, token:)
-      expect(Sentry).to have_received(:capture_exception).with(kind_of(StandardError))
-    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/features/school_member/listing_school_members_spec.rb
+++ b/spec/features/school_member/listing_school_members_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Listing school members', type: :request do
     get("/api/schools/#{school.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data.size).to eq(4)
+    expect(data.size).to eq(5)
   end
 
   it 'responds with the correct student ids' do
@@ -51,7 +51,8 @@ RSpec.describe 'Listing school members', type: :request do
       {
         id: students[0].id,
         username: students[0].username,
-        name: students[0].name
+        name: students[0].name,
+        type: 'student'
       }
     )
   end
@@ -73,16 +74,31 @@ RSpec.describe 'Listing school members', type: :request do
       {
         id: teacher.id,
         name: teacher.name,
-        email: teacher.email
+        email: teacher.email,
+        type: 'teacher'
       }
     )
   end
 
-  it 'responds with teachers at the top' do
+  it 'responds with owners at the top' do
     get("/api/schools/#{school.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data[0][:teacher]).to be_truthy
+    expect(data[0][:owner]).to be_truthy
+  end
+
+  it 'responds with teachers second from the top' do
+    get("/api/schools/#{school.id}/members", headers:)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data[1][:teacher]).to be_truthy
+  end
+
+  it 'responds with students after owners and teachers' do
+    get("/api/schools/#{school.id}/members", headers:)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data[2][:student]).to be_truthy
   end
 
   it 'responds with students in alphabetical order by name ascending' do

--- a/spec/features/school_member/listing_school_members_spec.rb
+++ b/spec/features/school_member/listing_school_members_spec.rb
@@ -80,35 +80,14 @@ RSpec.describe 'Listing school members', type: :request do
     )
   end
 
-  it 'responds with owners at the top' do
-    get("/api/schools/#{school.id}/members", headers:)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[0][:owner]).to be_truthy
-  end
-
-  it 'responds with teachers second from the top' do
-    get("/api/schools/#{school.id}/members", headers:)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[1][:teacher]).to be_truthy
-  end
-
-  it 'responds with students after owners and teachers' do
-    get("/api/schools/#{school.id}/members", headers:)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[2][:student]).to be_truthy
-  end
-
   it 'responds with students in alphabetical order by name ascending' do
     get("/api/schools/#{school.id}/members", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    student_names = data.pluck(:student).compact.pluck(:name)
-    sorted_student_names = student_names.sort
+    names = data.map { |member| member.values.first[:name] }
+    sorted_names = names.sort
 
-    expect(student_names).to eq(sorted_student_names)
+    expect(names).to eq(sorted_names)
   end
 
   it 'creates the school owner safeguarding flag' do


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/447

## What's changed?

- Adds owners to the shool member list endpoint
- Adds a type to identify each user type

## Steps to perform after deploying to production

N/A
