### PR TITLE
Add example Scratch project for Experience CS 

### DIFF
--- a/lib/tasks/project_components/experience_cs_example/project_config.yml
+++ b/lib/tasks/project_components/experience_cs_example/project_config.yml
@@ -1,0 +1,4 @@
+NAME: "Example"
+IDENTIFIER: "experience-cs-example"
+TYPE: "scratch"
+COMPONENTS: []


### PR DESCRIPTION
## Points for consideration:

Do not merge until #513 has been merged and deployed. This will ensure that existing clients of the API are unable to "see" this example Scratch project.

## What's changed?

This adds a simple example project of type "scratch". For the moment we're only planning to store metadata for Scratch projects in the `editor-api` database, so no components are included.

## Steps to perform after deploying to production

The seed data in production-like environments will need to be updated so this new project is added.