### PR TITLE
Distinguish owners in class members list

### DIFF
--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -9,9 +9,11 @@ module Api
 
     def index
       @class_students = @school_class.students.accessible_by(current_ability)
+      owners = SchoolOwner::List.call(school: @school).fetch(:school_owners, [])
       result = ClassMember::List.call(school_class: @school_class, class_students: @class_students, token: current_user.token)
 
       if result.success?
+        @school_owner_ids = owners.map(&:id)
         @class_members = result[:class_members]
         render :index, formats: [:json], status: :ok
       else

--- a/app/views/api/class_members/index.json.jbuilder
+++ b/app/views/api/class_members/index.json.jbuilder
@@ -3,6 +3,10 @@
 json.array!(@class_members) do |class_member|
   if class_member.respond_to?(:student_id)
     json.partial! 'class_member', class_member:
+  elsif @school_owner_ids.include?(class_member.id)
+    json.set! :owner do
+      json.partial! '/api/school_owners/school_owner', owner: class_member
+    end
   else
     json.set! :teacher do
       json.partial! '/api/school_teachers/school_teacher', teacher: class_member


### PR DESCRIPTION
## Status

closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/485

## What's changed?

- Class teachers that are also a school owner are not returned in the format `owner: {class_member}` rather than `teacher: {class_member}` when listing class members. This allows the owner icon to be displayed next to them on the frontend.

