### PR TITLE
Revert "Add example Scratch project for Experience CS"

### DIFF
--- a/lib/tasks/project_components/experience_cs_example/project_config.yml
+++ b/lib/tasks/project_components/experience_cs_example/project_config.yml
@@ -1,4 +1,0 @@
-NAME: "Example"
-IDENTIFIER: "experience-cs-example"
-TYPE: "scratch"
-COMPONENTS: []


### PR DESCRIPTION
This reverts commit 4d4a1234d94421febea21d834e3d252175d46f2f.

The `ProjectImporter` doesn't currently play nicely with the `default_scope` we've added to `Project`. It correctly created the experience-cs-example project the first time the `rake projects:create_all` task ran on the deployment to staging but it fails on subsequent invocations because the `default_scope` prevents the importer from finding the existing Scratch project and it therefore attempts to create it again, resulting in:

> ActiveRecord::RecordInvalid: Validation failed: Identifier has already been taken (ActiveRecord::RecordInvalid)

