### PR TITLE
Remove projects:create_all from release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rails db:migrate && bundle exec rake projects:create_all
+release: bundle exec rails db:migrate
 worker: bundle exec good_job start --max-threads=8


### PR DESCRIPTION
## Status

Ready for review

## What's changed?

Removes projects:create_all from release process, which could be resetting default projects

## Steps to perform after deploying to production

N/A
