### PR TITLE
Add projects:create_experience_cs_example rake task & run as part of Heroku release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rails db:migrate
+release: bundle exec rails db:migrate && bundle exec rake projects:create_experience_cs_example
 worker: bundle exec good_job start --max-threads=8

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -5,4 +5,22 @@ namespace :projects do
   task create_all: :environment do
     FilesystemProject.import_all!
   end
+
+  desc "Create example Scratch project for Experience CS (if it doesn't already exist)"
+  task create_experience_cs_example: :environment do
+    attributes = {
+      identifier: 'experience-cs-example',
+      locale: 'en',
+      project_type: Project::Types::SCRATCH,
+      name: 'Experience CS Example',
+      user_id: nil
+    }
+    if Project.unscoped.exists?(attributes.slice(:identifier, :locale))
+      puts 'Scratch project already exists'
+    elsif Project.create(attributes)
+      puts 'Scratch project created successfully'
+    else
+      puts 'Scratch project creation failed'
+    end
+  end
 end


### PR DESCRIPTION
This new rake task creates a single example project for the Experience CS app. If the project with the same `identifier` & `locale` already exists, the task is a no-op, i.e. the task is idempotent and can be safely run multiple times.

We look for the project based on just the `identifier` & `locale`, because there is validation and a database constraint that requires the combination of these two attributes to be unique. Thus if we don't find a project, we should be able to create one without an exception being raised.

We've used a separate rake task rather than incorporating it into the existing `projects:create_all` rake task for now, because there's some uncertainty about how that decides whether to overwrite a project. By keeping it completely separate we avoid iterating over all the projects and potentially unintentionally changing other projects that already exist in the editor-api database.

We haven't included this new rake task in `db/seeds.rb`, because it's only needed in development by the Experience CS team; not by the Code Editor for Education team.

The projects represented by the data in the sub-directories under [`lib/tasks/project_components`][1] in this repo are the ones imported by the existing `projects:create_all` rake task via [`ProjectImporter#import!`][2]. We've confirmed that the selected identifier, 'experience-cs-example' does *not* exist in those sub-directories, which means we can be confident the new rake task won't accidentally overwrite one of these projects in the editor-api database.

The projects represented by the repos under [the `raspberrypilearning` GitHub organisation][3] are the ones whose import is triggered by GitHub webhook requests to [`GitHubWebhooksController#github_push`][4] via
[`UploadJob#perform`][5] and thence the same `ProjectImporter#import!` method as before. We've confirmed that the selected identifier, 'experience-cs-example' [does *not* exist][5] in any repos in the `raspberrypilearning` GitHub organisation, which means we can be confident that the new rake task won't accidentally overwrite one of these projects in the editor-api database.

We have to use `Project.unscoped` in the new rake task in order to determine whether the example project already exists, because of the default scope on `Project` that we added in https://github.com/RaspberryPiFoundation/editor-api/pull/513.

We explicitly set the `project_type` to `Project::Types::SCRATCH`, i.e. 'scratch', so that it will only be found when a request is made to [the `Api::ProjectsController#show` action][7] with [the 'project_type` param set to 'scratch'][8]. This means that the Code Editor for Education should never "see" Scratch projects like this example one.

We explicitly set the `locale` to 'en' which seems to be the default [set in `FilesystemProject.import_all!`][9] and one of [the defaults specified in `ProjectLoader`][10]. This seems to match up with the projects defined in `lib/tasks/project_components` none of which set a value for the 'LOCALE' key in their `project_config.yml` file.

We explicitly set the `user_id` to `nil`, even though this is the default, because we want to make it clear that this example project to should be visible to users that are *not* signed in.

In https://github.com/RaspberryPiFoundation/editor-api/pull/527, the `projects:create_all` rake task invocation was removed from the Heroku release, because of concerns it might reset/overwrite existing projects in the database.

Now that we have a separate & idempotent `projects:create_experience_cs_example` rake task with much more limited scope, we're confident that it's safe to invoke this new rake task as part of the Heroku release.

Closely related to https://github.com/RaspberryPiFoundation/experience-cs/pull/55.

[1]: https://github.com/RaspberryPiFoundation/editor-api/tree/491c72859f66b49d249d6b0186f002e70673cd2a/lib/tasks/project_components
[2]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/lib/project_importer.rb#L18-L28
[3]: https://github.com/raspberrypilearning
[4]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/app/controllers/github_webhooks_controller.rb#L6-L8
[5]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/app/jobs/upload_job.rb#L57-L75
[6]: https://github.com/search?q=org%3Araspberrypilearning+experience-cs-example&type=code
[7]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/app/controllers/api/projects_controller.rb#L19-L27
[8]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/app/controllers/api/projects_controller.rb#L72
[9]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/app/models/filesystem_project.rb#L19
[10]: https://github.com/RaspberryPiFoundation/editor-api/blob/491c72859f66b49d249d6b0186f002e70673cd2a/lib/project_loader.rb#L8