### PR TITLE
Create and show remixes for scratch projects

### DIFF
--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -36,12 +36,16 @@ module Api
       private
 
       def project
-        @project ||= Project.find_by!(identifier: params[:project_id])
+        @project ||= project_scope.find_by!(identifier: params[:project_id])
       end
 
       def load_and_authorize_remix
-        @project = Project.find_by!(remixed_from_id: project.id, user_id: current_user&.id)
+        @project = project_scope.find_by!(remixed_from_id: project.id, user_id: current_user&.id)
         authorize! :show, @project
+      end
+
+      def project_scope
+        Project.only_scratch(params[:project_type] == Project::Types::SCRATCH)
       end
 
       def remix_params

--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -36,16 +36,12 @@ module Api
       private
 
       def project
-        @project ||= project_scope.find_by!(identifier: params[:project_id])
+        @project ||= Current.project_scope.find_by!(identifier: params[:project_id])
       end
 
       def load_and_authorize_remix
-        @project = project_scope.find_by!(remixed_from_id: project.id, user_id: current_user&.id)
+        @project = Current.project_scope.find_by!(remixed_from_id: project.id, user_id: current_user&.id)
         authorize! :show, @project
-      end
-
-      def project_scope
-        Project.only_scratch(params[:project_type] == Project::Types::SCRATCH)
       end
 
       def remix_params

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -69,7 +69,7 @@ module Api
     def load_project
       project_loader = ProjectLoader.new(params[:id], [params[:locale]])
       @project = if action_name == 'show'
-                   project_loader.load(include_images: true, only_scratch: params[:project_type] == Project::Types::SCRATCH)
+                   project_loader.load(include_images: true)
                  else
                    project_loader.load
                  end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,6 +4,7 @@ class ApiController < ActionController::API
   class ::ParameterError < StandardError; end
 
   include Identifiable
+  include ProjectScoping
 
   rescue_from ActionController::ParameterMissing, with: -> { bad_request }
   rescue_from ActiveRecord::RecordNotFound, with: -> { not_found }

--- a/app/controllers/concerns/project_scoping.rb
+++ b/app/controllers/concerns/project_scoping.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ProjectScoping
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_project_scope
+  end
+
+  private
+
+  def set_project_scope
+    only_scratch = params[:project_type] == Project::Types::SCRATCH
+    Current.project_scope = Project.only_scratch(only_scratch)
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :project_scope
+
+  def project_scope
+    super || Project
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,6 +35,9 @@ class Project < ApplicationRecord
   default_scope -> { where.not(project_type: Types::SCRATCH) }
 
   scope :internal_projects, -> { where(user_id: nil) }
+  scope :only_scratch, lambda { |only_scratch|
+    only_scratch ? unscoped.where(project_type: Project::Types::SCRATCH) : self
+  }
 
   has_paper_trail(
     if: ->(p) { p&.school_id },

--- a/lib/project_loader.rb
+++ b/lib/project_loader.rb
@@ -9,7 +9,7 @@ class ProjectLoader
   end
 
   def load(include_images: false, only_scratch: false)
-    query = only_scratch ? Project.unscoped.where(project_type: Project::Types::SCRATCH) : Project
+    query = Project.only_scratch(only_scratch)
     query = query.where(identifier:, locale: @locales)
     query = query.includes(images_attachments: :blob) if include_images
     query.min_by { |project| @locales.find_index(project.locale) }

--- a/lib/project_loader.rb
+++ b/lib/project_loader.rb
@@ -8,8 +8,8 @@ class ProjectLoader
     @locales = [*locales, 'en', nil]
   end
 
-  def load(include_images: false, only_scratch: false)
-    query = Project.only_scratch(only_scratch)
+  def load(include_images: false)
+    query = Current.project_scope
     query = query.where(identifier:, locale: @locales)
     query = query.includes(images_attachments: :blob) if include_images
     query.min_by { |project| @locales.find_index(project.locale) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -342,4 +342,53 @@ RSpec.describe Project, versioning: true do
       expect(described_class.all).not_to include(scratch_project)
     end
   end
+
+  describe 'only_scratch scope' do
+    let!(:python_project) { create(:project, project_type: Project::Types::PYTHON) }
+    let!(:html_project) { create(:project, project_type: Project::Types::HTML) }
+    let!(:project_with_unknown_type) { create(:project, project_type: 'unknown') }
+    let!(:scratch_project) { create(:project, project_type: Project::Types::SCRATCH) }
+
+    let(:projects_in_scope) { described_class.only_scratch(only_scratch) }
+
+    context 'when only_scratch is false' do
+      let(:only_scratch) { false }
+
+      it 'includes python projects' do
+        expect(projects_in_scope).to include(python_project)
+      end
+
+      it 'includes html projects' do
+        expect(projects_in_scope).to include(html_project)
+      end
+
+      it 'includes projects with unknown type' do
+        expect(projects_in_scope).to include(project_with_unknown_type)
+      end
+
+      it 'does not include scratch projects' do
+        expect(projects_in_scope).not_to include(scratch_project)
+      end
+    end
+
+    context 'when only_scratch is true' do
+      let(:only_scratch) { true }
+
+      it 'does not include python projects' do
+        expect(projects_in_scope).not_to include(python_project)
+      end
+
+      it 'does not include html projects' do
+        expect(projects_in_scope).not_to include(html_project)
+      end
+
+      it 'does not include projects with unknown type' do
+        expect(projects_in_scope).not_to include(project_with_unknown_type)
+      end
+
+      it 'includes scratch projects' do
+        expect(projects_in_scope).to include(scratch_project)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This extends the `project_type` param mechanism introduced in https://github.com/RaspberryPiFoundation/editor-api/pull/513 [into the `Api::Projects::RemixesController`](https://github.com/RaspberryPiFoundation/editor-api/commit/58875819cfebbfbd0f3a999271d78ae7544e1f3d) so that [the `experience-cs` app][1] can create a remix of a Scratch project and then show the remix. See [this pull request][2] for more details.

It also includes some preparatory refactoring [to extract a `Project.only_scratch` scope](https://github.com/RaspberryPiFoundation/editor-api/commit/00304473f251caca176e0de0977b9467ed4cf381) to reduce duplication. And then some subsequent refactoring [to extract a `ProjectScoping` controller concern and `Current.project_scope`](https://github.com/RaspberryPiFoundation/editor-api/commit/7711490ebe4962e88617081af3286769fee799d5) to further reduce duplication and simplify the code. The latter should make it easier to make similar changes to other controller actions in the future as we add functionality to `experience-cs`. It should also make it easier to change the mechanism we use for this, e.g. using an HTTP header instead of the `project_type` param.

Supersedes #534.

[1]: https://github.com/RaspberryPiFoundation/experience-cs
[2]: https://github.com/RaspberryPiFoundation/experience-cs/pull/290