### PR TITLE
Add more Scratch projects for Experience CS

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rails db:migrate && bundle exec rake projects:create_experience_cs_example
+release: bundle exec rails db:migrate && bundle exec rake projects:create_experience_cs_examples
 worker: bundle exec good_job start --max-threads=8

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -6,21 +6,25 @@ namespace :projects do
     FilesystemProject.import_all!
   end
 
-  desc "Create example Scratch project for Experience CS (if it doesn't already exist)"
-  task create_experience_cs_example: :environment do
-    attributes = {
-      identifier: 'experience-cs-example',
-      locale: 'en',
-      project_type: Project::Types::SCRATCH,
-      name: 'Experience CS Example',
-      user_id: nil
-    }
-    if Project.unscoped.exists?(attributes.slice(:identifier, :locale))
-      puts 'Scratch project already exists'
-    elsif Project.create(attributes)
-      puts 'Scratch project created successfully'
-    else
-      puts 'Scratch project creation failed'
+  desc "Create example Scratch projects for Experience CS (if they don't already exist)"
+  task create_experience_cs_examples: :environment do
+    projects = [
+      {
+        identifier: 'experience-cs-example',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: 'Experience CS Example',
+        user_id: nil
+      }
+    ]
+    projects.each do |attributes|
+      if Project.unscoped.exists?(attributes.slice(:identifier, :locale))
+        puts 'Scratch project already exists'
+      elsif Project.create(attributes)
+        puts 'Scratch project created successfully'
+      else
+        puts 'Scratch project creation failed'
+      end
     end
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -29,6 +29,13 @@ namespace :projects do
         project_type: Project::Types::SCRATCH,
         name: '10 Block Mission',
         user_id: nil
+      },
+      {
+        identifier: 'blank-scratch-starter',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: 'Blank Scratch Starter',
+        user_id: nil
       }
     ]
     projects.each do |attributes|

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -25,12 +25,13 @@ namespace :projects do
       }
     ]
     projects.each do |attributes|
+      identifier = attributes[:identifier]
       if Project.unscoped.exists?(attributes.slice(:identifier, :locale))
-        puts 'Scratch project already exists'
+        puts "Scratch project with identifier '#{identifier}' already exists"
       elsif Project.create(attributes)
-        puts 'Scratch project created successfully'
+        puts "Scratch project with identifier '#{identifier}' created successfully"
       else
-        puts 'Scratch project creation failed'
+        puts "Scratch project with identifier '#{identifier}' creation failed"
       end
     end
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -17,6 +17,13 @@ namespace :projects do
         user_id: nil
       },
       {
+        identifier: 'dialogue-in-scratch',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: 'Dialogue in Scratch',
+        user_id: nil
+      },
+      {
         identifier: 'ten-block-mission',
         locale: 'en',
         project_type: Project::Types::SCRATCH,

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -15,6 +15,13 @@ namespace :projects do
         project_type: Project::Types::SCRATCH,
         name: 'Experience CS Example',
         user_id: nil
+      },
+      {
+        identifier: 'ten-block-mission',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: '10 Block Mission',
+        user_id: nil
       }
     ]
     projects.each do |attributes|


### PR DESCRIPTION
- Renames the `projects:create_experience_cs_example` rake task to `projects:create_experience_cs_examples` and changes the release process in the `Procfile` to call the renamed version.
- Adds three new Scratch projects for Experience CS which are needed for demos/user-teting in the near future.