### PR TITLE
Add two more Scratch projects for Experience CS

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -36,6 +36,20 @@ namespace :projects do
         project_type: Project::Types::SCRATCH,
         name: 'Blank Scratch Starter',
         user_id: nil
+      },
+      {
+        identifier: 'lets-explore-scratch',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: "Let's Explore Scratch",
+        user_id: nil
+      },
+      {
+        identifier: 'transforming-sprites',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        name: 'Transforming Sprites',
+        user_id: nil
       }
     ]
     projects.each do |attributes|


### PR DESCRIPTION
See: https://github.com/RaspberryPiFoundation/experience-cs/issues/404

The Learning Team are planning to do some user testing at the end of this week and they want to use a couple more Scratch projects:

* Let's Explore Scratch
* Transforming Sprites

As before (e.g. in #538), these projects will be automatically added to all production-like environments as part of the release phase of the Heroku deployment.