### PR TITLE
Add example to `SchoolTeacher::Invite` spec to diagnose flakey example

### DIFF
--- a/spec/concepts/school_teacher/invite_spec.rb
+++ b/spec/concepts/school_teacher/invite_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe SchoolTeacher::Invite, type: :unit do
     expect(response.success?).to be(true)
   end
 
+  it 'does not return an error in operation response' do
+    response = described_class.call(school:, school_teacher_params:, token:)
+    expect(response[:error]).to be_blank
+  end
+
   it 'creates a TeacherInvitation' do
     expect { described_class.call(school:, school_teacher_params:, token:) }.to change(TeacherInvitation, :count)
   end


### PR DESCRIPTION
The example just before this one keeps failing in the CircleCI build, but I haven't been able to replicate it locally. It's hard to work out what's going on, because `SchoolTeacher::Invite#call` swallows any exception. I'm hoping that this new assertion _might_ fail for the same reason, but then display the exception message to give us more clues.
