### PR TITLE
Experience CS: Update name of ten-block-mission project and consistently use sentence case for project names

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -13,7 +13,7 @@ namespace :projects do
         identifier: 'experience-cs-example',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: 'Experience CS Example',
+        name: 'Experience CS example',
         user_id: nil
       },
       {
@@ -27,28 +27,28 @@ namespace :projects do
         identifier: 'ten-block-mission',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: 'Ten Block Mission',
+        name: 'Ten block mission',
         user_id: nil
       },
       {
         identifier: 'blank-scratch-starter',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: 'Blank Scratch Starter',
+        name: 'Blank Scratch starter',
         user_id: nil
       },
       {
         identifier: 'lets-explore-scratch',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: "Let's Explore Scratch",
+        name: "Let's explore Scratch",
         user_id: nil
       },
       {
         identifier: 'transforming-sprites',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: 'Transforming Sprites',
+        name: 'Transforming sprites',
         user_id: nil
       }
     ]

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -54,7 +54,7 @@ namespace :projects do
     ]
     projects.each do |attributes|
       identifier = attributes[:identifier]
-      if Project.unscoped.exists?(attributes.slice(:identifier, :locale))
+      if Project.only_scratch(true).exists?(attributes.slice(:identifier, :locale))
         puts "Scratch project with identifier '#{identifier}' already exists"
       elsif Project.create(attributes)
         puts "Scratch project with identifier '#{identifier}' created successfully"

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -54,8 +54,19 @@ namespace :projects do
     ]
     projects.each do |attributes|
       identifier = attributes[:identifier]
-      if Project.only_scratch(true).exists?(attributes.slice(:identifier, :locale))
+      project = Project.only_scratch(true).find_by(attributes.slice(:identifier, :locale))
+      if project.present?
         puts "Scratch project with identifier '#{identifier}' already exists"
+        project.assign_attributes(attributes.except(:identifier, :locale))
+        if project.changed?
+          if project.save
+            puts "Scratch project with identifier '#{identifier}' updated successfully"
+          else
+            puts "Scratch project with identifier '#{identifier}' update failed"
+          end
+        else
+          puts "Scratch project with identifier '#{identifier}' has not changed"
+        end
       elsif Project.create(attributes)
         puts "Scratch project with identifier '#{identifier}' created successfully"
       else

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -27,7 +27,7 @@ namespace :projects do
         identifier: 'ten-block-mission',
         locale: 'en',
         project_type: Project::Types::SCRATCH,
-        name: '10 Block Mission',
+        name: 'Ten Block Mission',
         user_id: nil
       },
       {


### PR DESCRIPTION
See https://github.com/RaspberryPiFoundation/experience-cs/issues/451 & https://github.com/RaspberryPiFoundation/experience-cs/issues/454.

This renames a bunch of the seed Scratch projects used in Experience CS. See individual commit notes for details.