### PR TITLE
Adding `project_type` to project context

### DIFF
--- a/app/views/api/lessons/index.json.jbuilder
+++ b/app/views/api/lessons/index.json.jbuilder
@@ -23,7 +23,6 @@ json.array!(@lessons_with_users) do |lesson, user|
       :identifier,
       :project_type
     )
-    json.project.finished(lesson.project.finished) if lesson.project.remixed_from_id.present?
   end
 
   json.user_name(user&.name)

--- a/app/views/api/projects/context.json.jbuilder
+++ b/app/views/api/projects/context.json.jbuilder
@@ -3,6 +3,7 @@
 json.call(
   @project,
   :identifier,
+  :project_type,
   :school_id,
   :lesson_id
 )

--- a/spec/requests/projects/show_context_spec.rb
+++ b/spec/requests/projects/show_context_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Project context requests' do
       let(:project_context_json) do
         {
           identifier: project.identifier,
+          project_type: project.project_type,
           school_id: project.school_id,
           lesson_id: project.lesson_id,
           class_id: project.lesson.school_class_id
@@ -57,6 +58,7 @@ RSpec.describe 'Project context requests' do
       let(:another_teacher_project_context_json) do
         {
           identifier: another_teacher_project.identifier,
+          project_type: another_teacher_project.project_type,
           school_id: another_teacher_project.school_id,
           lesson_id: another_teacher_project.lesson_id,
           class_id: another_teacher_project.lesson.school_class_id
@@ -102,6 +104,7 @@ RSpec.describe 'Project context requests' do
     let(:project_context_json) do
       {
         identifier: project.identifier,
+        project_type: project.project_type,
         school_id: project.school_id,
         lesson_id: project.lesson_id,
         class_id: project.lesson.school_class_id


### PR DESCRIPTION
## Status

Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/648 and #558 

## What's changed?

- Added project type to the project context route to support redirecting away from Scratch projects on the frontend
- Removed project finished data from the lessons index (which appears not to have been used and was throwing errors)
