### PR TITLE
Add secure route to reseed data in test env only

### DIFF
--- a/app/controllers/test_utilities_controller.rb
+++ b/app/controllers/test_utilities_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class TestUtilitiesController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  ALLOWED_HOSTS = ['test-editor-api.raspberrypi.org', 'localhost'].freeze
+
+  def reseed
+    if ENV['RESEED_API_KEY'].present? &&
+       request.headers['X-RESEED-API-KEY'] == ENV['RESEED_API_KEY'] &&
+       (Rails.env.development? || Rails.env.test?) &&
+       ALLOWED_HOSTS.include?(request.host)
+      Rails.application.load_tasks
+      Rake::Task['test_seeds:destroy'].invoke
+      Rake::Task['test_seeds:create'].invoke
+      render json: { message: 'Database reseeded successfully.' }, status: :ok
+    else
+      head :not_found
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     root to: 'projects#index'
   end
 
+  post '/test/reseed', to: 'test_utilities#reseed'
+
   post '/graphql', to: 'graphql#execute'
   mount GraphiQL::Rails::Engine, at: '/graphql', graphql_path: '/graphql#execute' unless Rails.env.production?
 

--- a/spec/requests/test_utilities_spec.rb
+++ b/spec/requests/test_utilities_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /test/reseed' do
+  subject(:request) { post('/test/reseed', headers: headers) }
+
+  let(:headers) { { 'X-RESEED-API-KEY' => ENV['RESEED_API_KEY'] } }
+
+  before do
+    Rails.application.load_tasks
+    host! 'test-editor-api.raspberrypi.org'
+  end
+
+  it 'returns OK' do
+    request
+    expect(response).to be_ok
+  end
+
+  it 'destroys the test seeds' do
+    expect(Rake::Task['test_seeds:destroy']).to receive(:invoke).and_call_original
+    request
+  end
+
+  it 'recreates the test seeds' do
+    expect(Rake::Task['test_seeds:create']).to receive(:invoke).and_call_original
+    request
+  end
+
+  context 'when the host is not allowed' do
+    before do
+      host! 'editor-api.raspberrypi.org'
+    end
+
+    it 'returns not found' do
+      request
+      expect(response).to be_not_found
+    end
+
+    it 'does not destroy test seeds' do
+      expect(Rake::Task['test_seeds:destroy']).not_to receive(:invoke)
+      request
+    end
+
+    it 'does not recreate test seeds' do
+      expect(Rake::Task['test_seeds:create']).not_to receive(:invoke)
+      request
+    end
+  end
+
+  context 'when the RESEED_API_KEY is not provided' do
+    let(:headers) { {} }
+
+    it 'returns not found' do
+      request
+      expect(response).to be_not_found
+    end
+
+    it 'does not destroy test seeds' do
+      expect(Rake::Task['test_seeds:destroy']).not_to receive(:invoke)
+      request
+    end
+
+    it 'does not recreate test seeds' do
+      expect(Rake::Task['test_seeds:create']).not_to receive(:invoke)
+      request
+    end
+  end
+
+  context 'when the RESEED_API_KEY is incorrect' do
+    let(:headers) { { 'X-RESEED-API-KEY' => 'my_dodgy_api_key' } }
+
+    it 'returns not found' do
+      request
+      expect(response).to be_not_found
+    end
+
+    it 'does not destroy test seeds' do
+      expect(Rake::Task['test_seeds:destroy']).not_to receive(:invoke)
+      request
+    end
+
+    it 'does not recreate test seeds' do
+      expect(Rake::Task['test_seeds:create']).not_to receive(:invoke)
+      request
+    end
+  end
+
+  context 'when requested in production' do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it 'returns not found' do
+      request
+      expect(response).to be_not_found
+    end
+
+    it 'does not destroy test seeds' do
+      expect(Rake::Task['test_seeds:destroy']).not_to receive(:invoke)
+      request
+    end
+
+    it 'does not recreate test seeds' do
+      expect(Rake::Task['test_seeds:create']).not_to receive(:invoke)
+      request
+    end
+  end
+end


### PR DESCRIPTION
## Status

- Closes _add issue numbers or delete_
- Related to _add issue numbers or delete_

## Points for consideration:

- Security
- Performance

## What's changed?

_Description of what's been done - bullets are often best_

## Steps to perform after deploying to production

_If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, a migration, or upgrading a Gem. That kind of thing._
