### PR TITLE
Enable reseed on test API

### DIFF
--- a/app/controllers/test_utilities_controller.rb
+++ b/app/controllers/test_utilities_controller.rb
@@ -28,15 +28,11 @@ class TestUtilitiesController < ApplicationController
   private
 
   def reseed_allowed?
-    api_key_valid? && environment_allowed? && host_allowed?
+    api_key_valid? && host_allowed?
   end
 
   def api_key_valid?
     ENV['RESEED_API_KEY'].present? && request.headers['X-RESEED-API-KEY'] == ENV['RESEED_API_KEY']
-  end
-
-  def environment_allowed?
-    Rails.env.development? || Rails.env.test?
   end
 
   def host_allowed?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     root to: 'projects#index'
   end
 
-  post '/test/reseed', to: 'test_utilities#reseed' if Rails.env.development? || Rails.env.test?
+  post '/test/reseed', to: 'test_utilities#reseed'
 
   post '/graphql', to: 'graphql#execute'
   mount GraphiQL::Rails::Engine, at: '/graphql', graphql_path: '/graphql#execute' unless Rails.env.production?

--- a/spec/requests/test_utilities_spec.rb
+++ b/spec/requests/test_utilities_spec.rb
@@ -107,26 +107,4 @@ RSpec.describe 'POST /test/reseed' do
       expect(Rake::Task['test_seeds:create']).not_to have_received(:invoke)
     end
   end
-
-  context 'when requested in production' do
-    before do
-      allow(Rails.env).to receive(:test?).and_return(false)
-      allow(Rails.env).to receive(:production?).and_return(true)
-    end
-
-    it 'returns not found' do
-      request
-      expect(response).to be_not_found
-    end
-
-    it 'does not destroy test seeds' do
-      request
-      expect(Rake::Task['test_seeds:destroy']).not_to have_received(:invoke)
-    end
-
-    it 'does not recreate test seeds' do
-      request
-      expect(Rake::Task['test_seeds:create']).not_to have_received(:invoke)
-    end
-  end
 end


### PR DESCRIPTION
Removes the env check so we can run this on the test API which has Rails env set to production. There are other safeguards in place such as an API key and host check that should prevent this from actually running on production.