### PR TITLE
Reenable reseed rake tasks

### DIFF
--- a/app/controllers/test_utilities_controller.rb
+++ b/app/controllers/test_utilities_controller.rb
@@ -4,7 +4,7 @@ class TestUtilitiesController < ApplicationController
   skip_before_action :verify_authenticity_token
   ALLOWED_HOSTS = ['test-editor-api.raspberrypi.org', 'localhost'].freeze
 
-  Rails.application.load_tasks unless Rake::Task.task_defined?('test_seeds:destroy')
+  Rails.application.load_tasks if Rake::Task.tasks.empty?
 
   def reseed
     # rubocop:disable Rails/Output


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/764

## What's changed?

Rake tasks can only be run once per process, so we need to reenable prior to running so they can be run multiple times, which is necessary in this context since it's an api call.

## Steps to perform after deploying to production

N/A
