### PR TITLE
Add administrative_area to SchoolDashboard

### DIFF
--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -43,6 +43,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     user_origin
     reference
     country_code
+    administrative_area
     created_at
     verified_at
     rejected_at


### PR DESCRIPTION
Add "administrative_area" to `/admin/schools` dashboard.

This change makes it easier to scan the list of recently added schools and work out whether they are in a US State that is of particular interest to the Experience CS customer success team. Before this change, Kendall, who is part of the team, told us she had to click into each school individually to find out this information.

<img width="3546" height="1814" alt="Screenshot 2025-08-06 at 10-46-40 Schools - App" src="https://github.com/user-attachments/assets/850dd33b-1c15-445d-96ac-7b660e870f65" />
