### PR TITLE
Add a link to the NCES search page for a school from its adminstrate dashboard

### DIFF
--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -80,3 +80,9 @@ as well as a link to its edit page.
     <% end %>
   </dl>
 </section>
+
+<% if page.resource.country_code == "US" && page.resource.postal_code.present? %>
+<section class="main-content__body">
+  <%= link_to "Search for this school in the NCES database", "https://nces.ed.gov/ccd/schoolsearch/school_list.asp?Search=1&Zip=#{url_encode(page.resource.postal_code)}" %>
+</section>
+<% end %>

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe 'Schools', type: :request do
       expect(response.body).to include(I18n.t('administrate.actions.reject_school'))
     end
 
+    it 'does not include a link to search for this school by its ZIP code in the NCES public schools database' do
+      expect(response.body).not_to include('Search for this school in the NCES database')
+    end
+
     describe 'when the school is verified' do
       let(:verified_at) { Time.zone.now }
       let(:code) { '00-00-00' }
@@ -70,6 +74,17 @@ RSpec.describe 'Schools', type: :request do
 
       it 'includes link to reopen school' do
         expect(response.body).to include(I18n.t('administrate.actions.reopen_school'))
+      end
+    end
+
+    describe 'when the school is in the United States and has a postal code' do
+      before do
+        school.update(country_code: 'US', postal_code: '90210')
+        get admin_school_path(school)
+      end
+
+      it 'includes a link to search for this school by its ZIP code in the NCES public schools database' do
+        expect(response.body).to include('Search for this school in the NCES database')
       end
     end
   end


### PR DESCRIPTION
Our customer success team want to know which School District a school in the US belongs to. At the moment we do not collect this information during registration so the team have to spend time working this out from the School's website and other information.

<img width="907" height="537" alt="image" src="https://github.com/user-attachments/assets/01f4ffeb-a26e-4d96-b69d-2856ba32f085" />

The Institute of Education Sciences maintains a website with data about all public schools in the US, including their School District.

This commit adds a link to the bottom of the school show page in the administrate dashboard to take the user to the search page on `https://nces.ed.gov`/ for the school's ZIP code.

I've shown a rough version of this feature to the team who will use it and they think it will be very useful until we start collecting this data at source.

The commit note has some additional context.
