### PR TITLE
Avoid mutating args in `CreateStudentsJob#perform`

### DIFF
--- a/app/jobs/create_students_job.rb
+++ b/app/jobs/create_students_job.rb
@@ -47,8 +47,15 @@ class CreateStudentsJob < ApplicationJob
   end
 
   def perform(school_id:, students:, token:)
-    students.each { |student| student[:password] = DecryptionHelpers.decrypt_password(student[:password]) }
-    responses = ProfileApiClient.create_school_students(token:, students:, school_id:)
+    decrypted_students = students.map do |student|
+      {
+        name: student[:name],
+        username: student[:username],
+        password: DecryptionHelpers.decrypt_password(student[:password])
+      }
+    end
+
+    responses = ProfileApiClient.create_school_students(token:, students: decrypted_students, school_id:)
     return if responses[:created].blank?
 
     responses[:created].each do |user_id|


### PR DESCRIPTION
If GoodJob encounters a retriable error then it updates the serialized args, as described in [this discussion post][1]. In our case that meant that if the call to `ProfileApiClient.create_school_students` raised an exception inheriting from `StandardError` (e.g. `Faraday::UnauthorizedError` or `Faraday::Timeout`) then the job arguments would be updated so that the student passwords were unencrypted. When the job was later retried it would fail because the passwords could no longer be decrypted. The storing and logging of unencrypted passwords in the GoodJob database tables is also problematic from a security perspective.

We tried but failed to write a test around this fix. It seems to depend on GoodJob's retry mechanism which we couldn't work out how to invoke in the test environment.

This is hopefully a temporary fix until we move the decrypting of passwords into the Profile app so that there's no risk of exposing unencrypted passwords in Editor API.

[1]: https://github.com/bensheldon/good_job/discussions/1627
