### PR TITLE
Change the response format for `ClassMembersController#create_batch`

### DIFF
--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -49,16 +49,8 @@ module Api
       owners = SchoolOwner::List.call(school: @school).fetch(:school_owners, [])
       @school_owner_ids = owners.map(&:id)
 
-      # Teacher objects needs to be the compliment of student objects so that every user creation is attempted and validated.
-      student_objects = create_batch_params.select { |user| user[:type] == 'student' }
-      teacher_objects = create_batch_params.select { |user| student_objects.pluck(:user_id).exclude?(user[:user_id]) }
-      student_ids = student_objects.pluck(:user_id)
-      teacher_ids = teacher_objects.pluck(:user_id)
-
-      students = list_students(@school, current_user.token, student_ids)
-      teachers = list_teachers(@school, teacher_ids)
-
-      result = ClassMember::Create.call(school_class: @school_class, students: students[:school_students], teachers: teachers[:school_teachers])
+      students, teachers = members_existing_in_profile
+      result = ClassMember::Create.call(school_class: @school_class, students:, teachers:)
 
       if result.success?
         @class_members = result[:class_members]
@@ -79,6 +71,19 @@ module Api
     end
 
     private
+
+    def members_existing_in_profile
+      # Teacher objects needs to be the compliment of student objects so that every user creation is attempted and validated.
+      student_objects = create_batch_params.select { |user| user[:type] == 'student' }
+      teacher_objects = create_batch_params.select { |user| student_objects.pluck(:user_id).exclude?(user[:user_id]) }
+      student_ids = student_objects.pluck(:user_id)
+      teacher_ids = teacher_objects.pluck(:user_id)
+
+      [
+        list_students(@school, current_user.token, student_ids)[:school_students],
+        list_teachers(@school, teacher_ids)[:school_teachers]
+      ]
+    end
 
     def class_member_params
       params.require(:class_member).permit(:user_id, :type)

--- a/app/models/class_student.rb
+++ b/app/models/class_student.rb
@@ -18,6 +18,10 @@ class ClassStudent < ApplicationRecord
     }
   )
 
+  def user_id
+    student_id
+  end
+
   private
 
   def student_has_the_school_student_role_for_the_school

--- a/app/models/class_teacher.rb
+++ b/app/models/class_teacher.rb
@@ -18,6 +18,10 @@ class ClassTeacher < ApplicationRecord
     }
   )
 
+  def user_id
+    teacher_id
+  end
+
   private
 
   def teacher_has_the_school_teacher_role_for_the_school


### PR DESCRIPTION
So that it treats the request as successful even if some (or any) of the members couldn't be added to the class. Previously if _any_ member couldn't be added (likely due to them already being in the class) then the response code was 422 and the response only contained information about the errors and nothing about the members that were succesfully added.

In order to [use this `#create_batch` endpoint in Editor Standalone][1] we need to differentiate between a request that was processed successfully (irrespective of how many members were added to the class) and a request that couldn't be processed (e.g. because none of the supplied members exist in Profile API).

We've modified the return value from `#create_batch` such that it contains enough information to differentiate between the members that were added to the class and those that couldn't be added, along with the reasons they couldn't be added.

In the case where none of the supplied members exist in Profile API we've retained the existing behaviour of returning an `error` key only in the response.

We think it's safe to make this change because the only place we'd expect this endpoint to be used is in editor-standalone and we're confident it's not currently being used in that project.

[1]: https://github.com/RaspberryPiFoundation/editor-standalone/pull/624