### PR TITLE
821-import-students-using-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ which should update the Gems in the container, without the need for rebuilding.
 
 ### Seeding
 
+Note: If running within a dev-container, remove the `docker compose run --rm api ` prefix from the cmd
+
 By default in development only, two tasks are called to seed data:
 
 `docker compose run --rm api rails projects:create_all`
@@ -62,7 +64,7 @@ For CEfE the following scenarios are modelled by the tasks:
 
 To clear CEfE data the following cmd will remove the school associated with the `jane.doe@example.com` user, and associated school data:
 
-`rails for_education:destroy_seed_data`
+`docker compose run --rm api rails for_education:destroy_seed_data`
 
 To override values, you can prefix the tasks with environment variables, for example:
 

--- a/app/controllers/api/class_members_controller.rb
+++ b/app/controllers/api/class_members_controller.rb
@@ -41,6 +41,8 @@ module Api
       else
         render json: result.slice(:error, :errors), status: :unprocessable_entity
       end
+    rescue ArgumentError => e
+      render json: { error: e.message }, status: :unprocessable_entity
     end
 
     def create_batch

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -30,13 +30,27 @@ module Api
     end
 
     def import
-      result = SchoolClass::Create.call(school: @school, school_class_params: school_class_import_params, current_user:, validate_context: :import)
+      school_class_params = import_school_class_params
+      school_students_params = import_school_students_params
 
-      if result.success?
-        @school_class_with_teachers = result[:school_class].with_teachers
-        render :show, formats: [:json], status: :created
+      # Find or create the school class
+      school_class_result = find_or_create_school_class(school_class_params)
+
+      if school_class_result.success?
+        school_class = school_class_result[:school_class]
+        @school_class_with_teachers = school_class.with_teachers
+
+        # Create students if class exists
+        school_students_result = create_school_students(school_students_params, school_class)
+        @school_students = school_students_result[:school_students]
+        @school_students_errors = school_students_result[:errors]
+
+        # Assign students to class
+        @class_members = assign_students_to_class(school_class, @school_students)
+
+        render :import, formats: [:json], status: :created
       else
-        render json: { error: result[:error] }, status: :unprocessable_entity
+        render json: { error: school_class_result[:error] }, status: :unprocessable_entity
       end
     end
 
@@ -63,6 +77,59 @@ module Api
     end
 
     private
+
+    def find_or_create_school_class(school_class_params)
+      # First try and find the class (in case we're re-importing)
+      existing_school_class = SchoolClass.find_by(
+        school: @school,
+        import_origin: school_class_params[:import_origin],
+        import_id: school_class_params[:import_id]
+      )
+
+      if existing_school_class.present?
+        response = OperationResponse.new
+        response[:school_class] = existing_school_class
+        return response
+      end
+
+      # Create new school class if none exists
+      SchoolClass::Create.call(
+        school: @school,
+        school_class_params: school_class_params,
+        current_user:,
+        validate_context: :import
+      )
+    end
+
+    def create_school_students(school_students_params, school_class)
+      return { school_students: [], errors: nil } unless school_class.present? && school_students_params.present?
+
+      school_students_result = SchoolStudent::CreateBatchSSO.call(
+        school: @school,
+        school_students_params: school_students_params,
+        current_user:
+      )
+
+      {
+        school_students: school_students_result[:school_students] || [],
+        errors: school_students_result[:errors]
+      }
+    end
+
+    def assign_students_to_class(school_class, school_students)
+      return [] unless school_class.present? && school_students.present? && school_students.any?
+
+      # Extract the student objects for class member creation
+      students = school_students.map { |student_data| student_data[:student] }
+      class_members_result = ClassMember::Create.call(school_class:, students:, teachers: [])
+
+      # Put the errors in a more useful format for the response
+      class_members_errors = class_members_result[:errors].map do |user_id, error|
+        { success: false, student_id: user_id, school_class_id: school_class.id, error: error }
+      end
+
+      class_members_result[:class_members] + class_members_errors
+    end
 
     def load_and_authorize_school
       @school = if params[:school_id].match?(/\d\d-\d\d-\d\d/)
@@ -92,8 +159,19 @@ module Api
       params.require(:school_class).permit(:name, :description)
     end
 
-    def school_class_import_params
+    def import_school_class_params
       params.require(:school_class).permit(:name, :description, :import_origin, :import_id)
+    end
+
+    def import_school_students_params
+      school_students_data = params[:school_students]
+      return [] if school_students_data.blank?
+
+      school_students_data.filter_map do |student|
+        next if student.blank?
+
+        student.permit(:name, :email).to_h.with_indifferent_access
+      end
     end
 
     def school_owner?

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -120,7 +120,7 @@ module Api
       return [] unless school_class.present? && school_students.present? && school_students.any?
 
       # Extract the student objects for class member creation
-      students = school_students.map { |student_data| student_data[:student] }
+      students = school_students.pluck(:student)
       class_members_result = ClassMember::Create.call(school_class:, students:, teachers: [])
 
       # Put the errors in a more useful format for the response

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,12 @@ class User
     roles&.to_s&.split(',')&.map(&:strip) || []
   end
 
+  def sso
+    return nil unless student?
+
+    email.present? && username.blank?
+  end
+
   def ==(other)
     id == other.id
   end

--- a/app/views/api/class_members/_class_member.json.jbuilder
+++ b/app/views/api/class_members/_class_member.json.jbuilder
@@ -8,14 +8,14 @@ json.call(
   :updated_at
 )
 
-if class_member.respond_to?(:student)
+if class_member.respond_to?(:student) && class_member.student.present?
   json.student_id(class_member.student_id)
   json.set! :student do
     json.partial! '/api/school_students/school_student', student: class_member.student
   end
-elsif class_member.respond_to?(:teacher)
+elsif class_member.respond_to?(:teacher) && class_member.teacher.present?
   json.teacher_id(class_member.teacher_id)
-  if @school_owner_ids.include?(class_member.teacher_id)
+  if @school_owner_ids&.include?(class_member.teacher_id)
     json.set! :owner do
       json.partial! '/api/school_owners/school_owner', owner: class_member.teacher
     end

--- a/app/views/api/school_classes/import.json.jbuilder
+++ b/app/views/api/school_classes/import.json.jbuilder
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+school_class, teachers = @school_class_with_teachers
+
+json.school_class do
+  json.call(
+    school_class,
+    :id,
+    :description,
+    :school_id,
+    :name,
+    :code,
+    :created_at,
+    :updated_at,
+    :import_origin,
+    :import_id
+  )
+
+  json.teachers(teachers) do |teacher|
+    json.partial! '/api/school_teachers/school_teacher', teacher:, include_email: false
+  end
+end
+
+if @school_students.any?
+  json.students(@school_students) do |student_item|
+    json.partial! '/api/school_students/school_student', student: student_item[:student]
+
+    # Add the metadata
+    json.success student_item[:success]
+    json.error student_item[:error]
+    json.created student_item[:created]
+  end
+elsif @school_students_errors.present?
+  # This is the validation error case - errors occurred during student creation
+  json.students do
+    json.errors @school_students_errors
+  end
+else
+  # No students provided or created
+  json.students @school_students
+end
+
+if @class_members.any?
+  json.class_members(@class_members) do |class_member|
+    if class_member.is_a?(Hash) && class_member.key?(:success) && !class_member[:success]
+      # This is an error object from assign_students_to_class
+      json.merge! class_member
+    else
+      # This is a successful class member
+      json.partial! '/api/class_members/class_member', class_member: class_member
+      json.success true
+      json.error nil
+    end
+  end
+else
+  # No class members created
+  json.class_members @class_members
+end

--- a/app/views/api/school_students/_school_student.json.jbuilder
+++ b/app/views/api/school_students/_school_student.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.call(student, :id, :username, :name)
+json.call(student, :id, :username, :name, :email, :sso)
 json.type('student')

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,6 +13,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'SSO'
+end

--- a/lib/concepts/class_member/operations/list.rb
+++ b/lib/concepts/class_member/operations/list.rb
@@ -23,9 +23,9 @@ module ClassMember
           return response
         end
 
-        response[:class_members] = teachers + class_students.sort do |a, b|
-          a.student.name <=> b.student.name
-        end
+        students_with_data = class_students.filter { |cs| cs.student.present? }
+        sorted_students = students_with_data.sort { |a, b| a.student.name <=> b.student.name }
+        response[:class_members] = teachers + sorted_students
 
         response
       end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -2,7 +2,12 @@
 
 module SchoolMember
   class List
-    SchoolMember = Struct.new(:id, :name, :username, :email, :type)
+    # TODO: This should be using the User model for consistency
+    SchoolMember = Struct.new(:id, :name, :username, :email, :type, :sso) do
+      def initialize(id, name, username, email, type, sso = nil)
+        super
+      end
+    end
 
     class << self
       # rubocop:disable Metrics/CyclomaticComplexity
@@ -18,7 +23,8 @@ module SchoolMember
           owners_response = SchoolOwner::List.call(school:).fetch(:school_owners, [])
 
           students = students_response.map do |student|
-            SchoolMember.new(student.id, student.name, student.username, nil, :student)
+            sso_student = student.email.present? && student.username.blank?
+            SchoolMember.new(student.id, student.name, student.username, student.email, :student, sso_student)
           end
           owners = owners_response.map do |owner|
             SchoolMember.new(owner.id, owner.name, nil, owner.email, :owner)

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -10,42 +10,56 @@ module SchoolMember
     end
 
     class << self
-      # rubocop:disable Metrics/CyclomaticComplexity
       def call(school:, token:)
         response = OperationResponse.new
         response[:school_members] = []
 
-        students = teachers = owners = []
-
         begin
-          # Only call students API if there are actually students in the school
-          student_roles = Role.student.where(school:)
-          students_response = student_roles.any? ? SchoolStudent::List.call(school:, token:).fetch(:school_students, []) : []
-          
-          teachers_response = SchoolTeacher::List.call(school:).fetch(:school_teachers, [])
-          owners_response = SchoolOwner::List.call(school:).fetch(:school_owners, [])
+          students = fetch_students(school:, token:)
+          teachers = fetch_teachers(school:)
+          owners = fetch_owners(school:)
 
-          students = students_response.map do |student|
-            sso_student = student.email.present? && student.username.blank?
-            SchoolMember.new(student.id, student.name, student.username, student.email, :student, sso_student)
-          end
-          owners = owners_response.map do |owner|
-            SchoolMember.new(owner.id, owner.name, nil, owner.email, :owner)
-          end
+          # Filter out teachers who are also owners
           owner_ids = owners.map(&:id)
-          teachers = teachers_response.reject { |teacher| owner_ids.include?(teacher.id) }.map do |teacher|
-            SchoolMember.new(teacher.id, teacher.name, nil, teacher.email, :teacher)
-          end
+          filtered_teachers = teachers.reject { |teacher| owner_ids.include?(teacher.id) }
+
+          response[:school_members] = (owners + filtered_teachers + students).sort_by(&:name)
         rescue StandardError => e
           Sentry.capture_exception(e)
           response[:error] = "Error listing school members: #{e}"
-          response
+          return response
         end
 
-        response[:school_members] = (owners + teachers + students).sort_by(&:name)
         response
       end
+
+      private
+
+      def fetch_students(school:, token:)
+        student_roles = Role.student.where(school:)
+        students_response = student_roles.any? ? SchoolStudent::List.call(school:, token:).fetch(:school_students, []) : []
+
+        students_response.map do |student|
+          sso_student = student.email.present? && student.username.blank?
+          SchoolMember.new(student.id, student.name, student.username, student.email, :student, sso_student)
+        end
+      end
+
+      def fetch_teachers(school:)
+        teachers_response = SchoolTeacher::List.call(school:).fetch(:school_teachers, [])
+
+        teachers_response.map do |teacher|
+          SchoolMember.new(teacher.id, teacher.name, nil, teacher.email, :teacher)
+        end
+      end
+
+      def fetch_owners(school:)
+        owners_response = SchoolOwner::List.call(school:).fetch(:school_owners, [])
+
+        owners_response.map do |owner|
+          SchoolMember.new(owner.id, owner.name, nil, owner.email, :owner)
+        end
+      end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -18,7 +18,10 @@ module SchoolMember
         students = teachers = owners = []
 
         begin
-          students_response = SchoolStudent::List.call(school:, token:).fetch(:school_students, [])
+          # Only call students API if there are actually students in the school
+          student_roles = Role.student.where(school:)
+          students_response = student_roles.any? ? SchoolStudent::List.call(school:, token:).fetch(:school_students, []) : []
+          
           teachers_response = SchoolTeacher::List.call(school:).fetch(:school_teachers, [])
           owners_response = SchoolOwner::List.call(school:).fetch(:school_owners, [])
 

--- a/lib/concepts/school_student/create_batch_sso.rb
+++ b/lib/concepts/school_student/create_batch_sso.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module SchoolStudent
+  class Error < StandardError; end
+
+  class ValidationError < StandardError
+    attr_reader :errors
+
+    def initialize(errors)
+      @errors = errors
+      super
+    end
+  end
+
+  class CreateBatchSSO
+    class << self
+      def call(school:, school_students_params:, current_user:)
+        response = OperationResponse.new
+        response[:school_students] = create_batch_sso(school, school_students_params, current_user.token)
+        response
+      rescue ValidationError => e
+        response[:error] = "Error creating one or more students - see 'errors' key for details"
+        response[:errors] = e.errors
+        response[:error_type] = :validation_error
+        response
+      rescue StandardError => e
+        Sentry.capture_exception(e)
+        response[:error] = "Error creating one or more students - see 'errors' key for details"
+        response[:errors] = "Error importing the class or creating students: #{e}"
+        response[:error_type] = :standard_error
+        response
+      end
+
+      private
+
+      def create_batch_sso(school, students, token)
+        # Ensure that nil values are empty strings, else Profile will swallow validations
+        students = students.map do |student|
+          student.transform_values { |value| value.nil? ? '' : value }
+        end
+
+        responses = ProfileApiClient.create_school_students_sso(token:, students:, school_id: school.id)
+
+        responses.each do |student|
+          Role.student.find_or_create_by(school_id: school.id, user_id: student[:id])
+        end
+
+        # Convert hash responses to User objects with separate metadata
+        # This separates student data from metadata (success, error, created flags)
+        responses.map do |student_data|
+          {
+            student: User.new(student_data.slice(:id, :name, :email)),
+            success: student_data[:success],
+            error: student_data[:error],
+            created: student_data[:created]
+          }
+        end
+      rescue ProfileApiClient::Student422Error => e
+        handle_validations(e.errors)
+      end
+
+      def handle_validations(errors)
+        formatted_errors = errors.each_with_object({}) do |error, hash|
+          name = error['path']
+          hash[name] = error['errorCode'] || error['message']
+        end
+
+        raise ValidationError, formatted_errors
+      end
+    end
+  end
+end

--- a/lib/concepts/school_student/list.rb
+++ b/lib/concepts/school_student/list.rb
@@ -18,7 +18,7 @@ module SchoolStudent
       def list_students(school, token, student_ids)
         student_ids ||= Role.student.where(school:).map(&:user_id)
         ProfileApiClient.list_school_students(token:, school_id: school.id, student_ids:).map do |student|
-          User.new(student.to_h.slice(:id, :username, :name))
+          User.new(student.to_h.slice(:id, :username, :name, :email))
         end
       end
     end

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -9,7 +9,7 @@ class ProfileApiClient
   # rubocop:disable Naming/MethodName
   School = Data.define(:id, :schoolCode, :updatedAt, :createdAt, :discardedAt)
   SafeguardingFlag = Data.define(:id, :userId, :flag, :email, :createdAt, :updatedAt, :discardedAt)
-  Student = Data.define(:id, :schoolId, :name, :username, :createdAt, :updatedAt, :discardedAt)
+  Student = Data.define(:id, :schoolId, :name, :username, :email, :createdAt, :updatedAt, :discardedAt)
   # rubocop:enable Naming/MethodName
 
   class Error < StandardError; end

--- a/spec/concepts/class_member/list_spec.rb
+++ b/spec/concepts/class_member/list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ClassMember::List, type: :unit do
       end
 
       student_attributes = students.map do |student|
-        { id: student.id, name: student.name, username: student.username }
+        { id: student.id, name: student.name, username: student.username, email: student.email }
       end
       stub_profile_api_list_school_students(school:, student_attributes:)
       stub_user_info_api_for(teacher)

--- a/spec/concepts/school_member/list_spec.rb
+++ b/spec/concepts/school_member/list_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe SchoolMember::List, type: :unit do
   context 'when errors occur' do
     before do
       allow(Sentry).to receive(:capture_exception)
+      # Ensure there are students so the error path gets exercised
+      students
     end
 
     it 'captures and handles errors' do

--- a/spec/concepts/school_member/list_spec.rb
+++ b/spec/concepts/school_member/list_spec.rb
@@ -11,13 +11,16 @@ RSpec.describe SchoolMember::List, type: :unit do
   let(:student_ids) { students.map(&:id) }
   let(:teacher_ids) { [teacher.id] }
 
-  context 'with students and a teacher' do
+  context 'with a mixture of students' do
+    let(:sso_student) { create(:student, :sso, school:) }
+    let(:standard_student) { create(:student, school:) }
+
     before do
-      student_attributes = students.map do |student|
-        { id: student.id, name: student.name, username: student.username }
-      end
+      student_attributes = [
+        { id: sso_student.id, name: sso_student.name, username: sso_student.username, email: sso_student.email },
+        { id: standard_student.id, name: standard_student.name, username: standard_student.username, email: standard_student.email }
+      ]
       stub_profile_api_list_school_students(school:, student_attributes:)
-      stub_user_info_api_for(teacher)
     end
 
     it 'returns a successful operation response' do
@@ -27,14 +30,67 @@ RSpec.describe SchoolMember::List, type: :unit do
 
     it 'contains the expected students' do
       response = described_class.call(school:, token:)
-      students.each do |student|
-        expect(response[:school_members].map(&:id)).to include(student.id)
-      end
+      expect(response[:school_members].map(&:id)).to include(sso_student.id)
+      expect(response[:school_members].map(&:id)).to include(standard_student.id)
+    end
+
+    it 'sets sso to true for SSO students (email present, username blank)' do
+      response = described_class.call(school:, token:)
+      school_members = response[:school_members]
+      sso_member = school_members.find { |m| m.id == sso_student.id }
+
+      expect(sso_member.sso).to be(true)
+      expect(sso_member.email).to be_present
+      expect(sso_member.username).to be_nil
+      expect(sso_member.type).to eq(:student)
+    end
+
+    it 'sets sso to false for standard students (username present, email blank)' do
+      response = described_class.call(school:, token:)
+      school_members = response[:school_members]
+      standard_member = school_members.find { |m| m.id == standard_student.id }
+
+      expect(standard_member.sso).to be(false)
+      expect(standard_member.email).to be_nil
+      expect(standard_member.username).to be_present
+      expect(standard_member.type).to eq(:student)
+    end
+  end
+
+  context 'with teachers' do
+    before do
+      stub_user_info_api_for(teacher)
     end
 
     it 'contains the expected teacher' do
       response = described_class.call(school:, token:)
       expect(response[:school_members].map(&:id)).to include(teacher.id)
+    end
+
+    it 'sets sso to nil for teachers (not applicable)' do
+      response = described_class.call(school:, token:)
+      school_members = response[:school_members]
+      teacher_member = school_members.find { |m| m.id == teacher.id }
+
+      expect(teacher_member.sso).to be_nil
+      expect(teacher_member.type).to eq(:teacher)
+    end
+  end
+
+  context 'with owners' do
+    let(:owner) { create(:owner, school:) }
+
+    before do
+      stub_user_info_api_for(owner)
+    end
+
+    it 'sets sso to nil for owners (not applicable)' do
+      response = described_class.call(school:, token:)
+      school_members = response[:school_members]
+      owner_member = school_members.find { |m| m.id == owner.id }
+
+      expect(owner_member.sso).to be_nil
+      expect(owner_member.type).to eq(:owner)
     end
   end
 

--- a/spec/concepts/school_student/create_batch_sso_spec.rb
+++ b/spec/concepts/school_student/create_batch_sso_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SchoolStudent::CreateBatchSSO, type: :unit do
+  let(:school) { create(:verified_school) }
+  let(:current_user) { create(:teacher, school:) }
+
+  let(:school_students_params) do
+    [
+      {
+        name: 'Test Student 1',
+        email: 'student1@example.com'
+      },
+      {
+        name: 'Test Student 2',
+        email: 'student2@example.com'
+      }
+    ]
+  end
+
+  context 'when SSO creation succeeds' do
+    let(:user_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+
+    before do
+      stub_profile_api_create_school_students_sso(user_ids:)
+    end
+
+    it 'returns a successful operation response' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response.success?).to be(true)
+    end
+
+    it 'makes a profile API call with correct parameters' do
+      described_class.call(school:, school_students_params:, current_user:)
+
+      # TODO: Replace with WebMock assertion once the profile API has been built.
+      expect(ProfileApiClient).to have_received(:create_school_students_sso)
+        .with(token: current_user.token, students: school_students_params, school_id: school.id)
+    end
+
+    it 'transforms nil values to empty strings before API call' do
+      params_with_nils = [
+        { name: 'Test Student 1', email: nil },
+        { name: nil, email: 'student2@example.com' }
+      ]
+      expected_params = [
+        { name: 'Test Student 1', email: '' },
+        { name: '', email: 'student2@example.com' }
+      ]
+
+      described_class.call(school:, school_students_params: params_with_nils, current_user:)
+
+      expect(ProfileApiClient).to have_received(:create_school_students_sso)
+        .with(token: current_user.token, students: expected_params, school_id: school.id)
+    end
+
+    it 'creates roles associating students with the school' do
+      described_class.call(school:, school_students_params:, current_user:)
+
+      user_ids.each do |user_id|
+        expect(Role.student.where(school:, user_id:)).to exist
+      end
+    end
+
+    it 'returns the student data from Profile API' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      students = response[:school_students]
+
+      expect(students.length).to eq(2)
+
+      # Verify first student item (hash with :student and metadata)
+      first_student_item = students[0]
+      expect(first_student_item[:student]).to be_a(User)
+      expect(first_student_item[:student].id).to eq(user_ids[0])
+      expect(first_student_item[:student].name).to eq('Test Student')
+      expect(first_student_item[:success]).to be(true)
+
+      # Verify second student item
+      second_student_item = students[1]
+      expect(second_student_item[:student]).to be_a(User)
+      expect(second_student_item[:student].id).to eq(user_ids[1])
+      expect(second_student_item[:student].name).to eq('Test Student')
+      expect(second_student_item[:success]).to be(true)
+    end
+  end
+
+  context 'when validation errors occur' do
+    before do
+      stub_profile_api_create_school_students_sso_validation_error
+    end
+
+    it 'returns a failed operation response' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response.failure?).to be(true)
+    end
+
+    it 'returns the error message in the operation response' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:error]).to eq("Error creating one or more students - see 'errors' key for details")
+    end
+
+    it 'returns the error type as validation_error' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:error_type]).to eq(:validation_error)
+    end
+
+    it 'returns formatted validation errors' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:errors]).to eq({
+                                        '0.name' => 'minLength.openapi.requestValidation',
+                                        '0.email' => 'minLength.openapi.requestValidation'
+                                      })
+    end
+
+    it 'does not create any student roles when validation fails' do
+      initial_student_role_count = Role.student.count
+
+      described_class.call(school:, school_students_params:, current_user:)
+
+      expect(Role.student.count).to eq(initial_student_role_count)
+    end
+  end
+
+  context 'when a standard error occurs' do
+    before do
+      allow(ProfileApiClient).to receive(:create_school_students_sso)
+        .and_raise(StandardError.new('Network timeout'))
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it 'returns a failed operation response' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response.failure?).to be(true)
+    end
+
+    it 'returns the error message in the operation response' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:error]).to eq("Error creating one or more students - see 'errors' key for details")
+    end
+
+    it 'returns the error type as standard_error' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:error_type]).to eq(:standard_error)
+    end
+
+    it 'returns the detailed error message in the errors field' do
+      response = described_class.call(school:, school_students_params:, current_user:)
+      expect(response[:errors]).to eq('Error importing the class or creating students: Network timeout')
+    end
+
+    it 'sends the exception to Sentry' do
+      described_class.call(school:, school_students_params:, current_user:)
+      expect(Sentry).to have_received(:capture_exception).with(kind_of(StandardError))
+    end
+
+    it 'does not create any student roles when standard error occurs' do
+      initial_student_role_count = Role.student.count
+
+      described_class.call(school:, school_students_params:, current_user:)
+
+      expect(Role.student.count).to eq(initial_student_role_count)
+    end
+  end
+end

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SchoolStudent::List, type: :unit do
   context 'without student_ids' do
     before do
       student_attributes = students.map do |student|
-        { id: student.id, name: student.name, username: student.username }
+        { id: student.id, name: student.name, username: student.username, email: student.email }
       end
       stub_profile_api_list_school_students(school:, student_attributes:)
     end
@@ -47,7 +47,7 @@ RSpec.describe SchoolStudent::List, type: :unit do
 
     before do
       student_attributes = filtered_students.map do |student|
-        { id: student.id, name: student.name, username: student.username }
+        { id: student.id, name: student.name, username: student.username, email: student.email }
       end
       stub_profile_api_list_school_students(school:, student_attributes:)
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -19,6 +19,11 @@ FactoryBot.define do
       email { nil }
       username { Faker::Internet.username }
 
+      trait :sso do
+        email { Faker::Internet.email }
+        username { nil }
+      end
+
       transient do
         school { nil }
       end

--- a/spec/features/class_member/creating_a_batch_of_class_members_spec.rb
+++ b/spec/features/class_member/creating_a_batch_of_class_members_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Creating a class member', type: :request do
   context 'with valid params' do
     let(:student_attributes) do
       students.map do |student|
-        { id: student.id, name: student.name, username: student.username, type: 'student' }
+        { id: student.id, name: student.name, username: student.username, email: student.email, sso: false, type: 'student' }
       end
     end
 

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Creating a class member', type: :request do
           }
         }
       end
-      let(:student_attributes) { { id: student.id, name: student.name, username: student.username, type: 'student' } }
+      let(:student_attributes) { { id: student.id, name: student.name, username: student.username, email: student.email, sso: false, type: 'student' } }
 
       before do
         stub_profile_api_list_school_students(school:, student_attributes: [student_attributes])

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Listing class members', type: :request do
     authenticated_in_hydra_as(owner)
 
     student_attributes = students.map do |student|
-      { id: student.id, name: student.name, username: student.username }
+      { id: student.id, name: student.name, username: student.username, email: nil }
     end
     stub_profile_api_list_school_students(school:, student_attributes:)
 
@@ -66,6 +66,8 @@ RSpec.describe 'Listing class members', type: :request do
         id: students[0].id,
         username: students[0].username,
         name: students[0].name,
+        email: students[0].email,
+        sso: false,
         type: 'student'
       }
     )

--- a/spec/features/school_class/importing_a_school_class_spec.rb
+++ b/spec/features/school_class/importing_a_school_class_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'Importing a school class', type: :request do
       # Class members section should contain errors
       expect(response_data[:class_members]).to be_an(Array)
       expect(response_data[:class_members].length).to eq(1)
-      expect(response_data[:class_members].first[:success]).to eq(false)
+      expect(response_data[:class_members].first[:success]).to be(false)
       expect(response_data[:class_members].first[:student_id]).to eq('aa7b5a78-2bd7-4676-8184-318f09a7c494')
       expect(response_data[:class_members].first[:error]).to eq('Error creating class member')
     end

--- a/spec/features/school_class/importing_a_school_class_spec.rb
+++ b/spec/features/school_class/importing_a_school_class_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Importing a school class', type: :request do
   before do
     authenticated_in_hydra_as(teacher)
+    stub_user_info_api_for(teacher)
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
@@ -23,56 +24,351 @@ RSpec.describe 'Importing a school class', type: :request do
     }
   end
 
-  it 'creates a class when import_origin and import_id are provided' do
-    post(import_url, headers:, params: base_import_params)
-    expect(response).to have_http_status(:created)
-    data = JSON.parse(response.body, symbolize_names: true)
-    expect(data[:name]).to eq('Imported Class')
-    expect(data[:description]).to eq('Imported Description')
+  let(:import_params_with_students) do
+    base_import_params.merge(
+      school_students: [
+        { name: 'Jane Student', email: 'jane.student@example.com' },
+        { name: 'John Student', email: 'john.student@example.com' }
+      ]
+    )
   end
 
-  it 'returns 422 if import_origin is missing' do
-    params_missing_origin = base_import_params.deep_dup
-    params_missing_origin[:school_class].delete(:import_origin)
-    post(import_url, headers:, params: params_missing_origin)
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)['error'].to_s).to include("Import origin can't be blank")
+  describe 'School class creation errors' do
+    it 'returns 422 if import_origin is missing' do
+      params_missing_origin = base_import_params.deep_dup
+      params_missing_origin[:school_class].delete(:import_origin)
+
+      post(import_url, headers:, params: params_missing_origin)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body)
+      expect(error_response).to have_key('error')
+      expect(error_response['error']).to include("Import origin can't be blank")
+    end
+
+    it 'returns 422 if import_id is missing' do
+      params_missing_id = base_import_params.deep_dup
+      params_missing_id[:school_class].delete(:import_id)
+
+      post(import_url, headers:, params: params_missing_id)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body)
+      expect(error_response).to have_key('error')
+      expect(error_response['error']).to include("Import id can't be blank")
+    end
+
+    it 'returns 422 if both import_origin and import_id are missing' do
+      params_missing_both = base_import_params.deep_dup
+      params_missing_both[:school_class].delete(:import_origin)
+      params_missing_both[:school_class].delete(:import_id)
+
+      post(import_url, headers:, params: params_missing_both)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body)
+      expect(error_response).to have_key('error')
+      expect(error_response['error']).to include("Import origin can't be blank")
+    end
+
+    it 'returns 422 if import_origin is invalid' do
+      params_invalid_enum = base_import_params.deep_dup
+      params_invalid_enum[:school_class][:import_origin] = 'not_a_valid_origin'
+
+      post(import_url, headers:, params: params_invalid_enum)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body)
+      expect(error_response).to have_key('error')
+      expect(error_response['error']).to include('Import origin is not included in the list')
+    end
+
+    it 'returns 422 if class name is missing' do
+      params_missing_name = base_import_params.deep_dup
+      params_missing_name[:school_class].delete(:name)
+
+      post(import_url, headers:, params: params_missing_name)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body)
+      expect(error_response).to have_key('error')
+      expect(error_response['error']).to include("Name can't be blank")
+    end
   end
 
-  it 'returns 422 if import_id is missing' do
-    params_missing_id = base_import_params.deep_dup
-    params_missing_id[:school_class].delete(:import_id)
-    post(import_url, headers:, params: params_missing_id)
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)['error'].to_s).to include("Import id can't be blank")
+  describe 'Student creation errors' do
+    before do
+      # Mock student creation to return errors
+      student_creation_error_result = OperationResponse.new
+      student_creation_error_result[:school_students] = []
+      student_creation_error_result[:errors] = {
+        'jane.student@example.com' => 'Email already exists',
+        'john.student@example.com' => 'Invalid email format'
+      }
+      allow(SchoolStudent::CreateBatchSSO).to receive(:call).and_return(student_creation_error_result)
+    end
+
+    it 'returns 201 with plural [:errors] in students section when student creation fails' do
+      post(import_url, headers:, params: import_params_with_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # School class should be created successfully
+      expect(response_data[:school_class][:name]).to eq('Imported Class')
+      expect(response_data[:school_class][:description]).to eq('Imported Description')
+
+      # Students section should contain errors
+      expect(response_data[:students]).to have_key(:errors)
+      expect(response_data[:students][:errors]).to include(
+        'jane.student@example.com': 'Email already exists',
+        'john.student@example.com': 'Invalid email format'
+      )
+
+      # Class members should be empty since no students were created
+      expect(response_data[:class_members]).to eq([])
+    end
   end
 
-  it 'returns 422 if both import_origin and import_id are missing' do
-    params_missing_both = base_import_params.deep_dup
-    params_missing_both[:school_class].delete(:import_origin)
-    params_missing_both[:school_class].delete(:import_id)
-    post(import_url, headers:, params: params_missing_both)
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)['error'].to_s).to include("Import origin can't be blank")
+  describe 'Class member creation errors' do
+    let(:mock_students) do
+      [
+        { id: 'student-1-id', name: 'Jane Student', email: 'jane.student@example.com' },
+        { id: 'student-2-id', name: 'John Student', email: 'john.student@example.com' }
+      ].map do |student_data|
+        # Create the new structure with User objects and metadata using factories
+        {
+          student: build_stubbed(:student, student_data),
+          success: true,
+          error: nil,
+          created: true
+        }
+      end
+    end
+
+    before do
+      # Mock successful student creation
+      # Mock successful student creation but failed class assignment
+      student_creation_result = OperationResponse.new
+      student_creation_result[:school_students] = [
+        {
+          student: build_stubbed(:student, id: 'student-1-id', name: 'Jane Student', email: 'jane.student@example.com'),
+          success: true,
+          error: nil,
+          created: true
+        },
+        {
+          student: build_stubbed(:student, id: 'student-2-id', name: 'John Student', email: 'john.student@example.com'),
+          success: true,
+          error: nil,
+          created: true
+        }
+      ]
+      student_creation_result[:errors] = nil
+      allow(SchoolStudent::CreateBatchSSO).to receive(:call).and_return(student_creation_result)
+
+      # Mock class member creation to return errors
+      class_member_creation_result = OperationResponse.new
+      class_member_creation_result[:class_members] = []
+      class_member_creation_result[:errors] = {
+        'aa7b5a78-2bd7-4676-8184-318f09a7c494' => 'Error creating class member'
+      }
+      allow(ClassMember::Create).to receive(:call).and_return(class_member_creation_result)
+    end
+
+    it 'returns 201 errors in class_members section when assignment fails' do
+      post(import_url, headers:, params: import_params_with_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # School class should be created successfully
+      expect(response_data[:school_class][:name]).to eq('Imported Class')
+
+      # Students should be created successfully
+      expect(response_data[:students]).to be_an(Array)
+      expect(response_data[:students].length).to eq(2)
+
+      # Class members section should contain errors
+      expect(response_data[:class_members]).to be_an(Array)
+      expect(response_data[:class_members].length).to eq(1)
+      expect(response_data[:class_members].first[:success]).to eq(false)
+      expect(response_data[:class_members].first[:student_id]).to eq('aa7b5a78-2bd7-4676-8184-318f09a7c494')
+      expect(response_data[:class_members].first[:error]).to eq('Error creating class member')
+    end
   end
 
-  it 'returns 422 if import_origin is invalid and returns correct error in JSON' do
-    params_invalid_enum = base_import_params.deep_dup
-    params_invalid_enum[:school_class][:import_origin] = 'not_a_valid_origin'
-    post(import_url, headers:, params: params_invalid_enum)
-    expect(response).to have_http_status(:unprocessable_entity)
-    error_json = JSON.parse(response.body)
-    expect(error_json['error'].to_s).to include('Import origin is not included in the list')
+  describe 'Successful import scenarios' do
+    let(:mock_successful_students) do
+      [
+        {
+          student: build_stubbed(:student, id: 'student-1-id', name: 'Jane Student', email: 'jane.student@example.com'),
+          success: true,
+          error: nil,
+          created: true
+        },
+        {
+          student: build_stubbed(:student, id: 'student-2-id', name: 'John Student', email: 'john.student@example.com'),
+          success: true,
+          error: nil,
+          created: true
+        }
+      ]
+    end
+
+    let(:mock_successful_class_members) do
+      # Use factories to create proper test objects without database persistence
+      student_1 = build_stubbed(:student, id: 'student-1-id', name: 'Jane Student', username: 'jane.student', email: 'jane@example.com')
+      student_2 = build_stubbed(:student, id: 'student-2-id', name: 'John Student', username: 'john.student', email: 'john@example.com')
+
+      [
+        build_stubbed(:class_student,
+                      id: 'member-1-id',
+                      school_class_id: 'class-1-id',
+                      student_id: 'student-1-id',
+                      student: student_1),
+        build_stubbed(:class_student,
+                      id: 'member-2-id',
+                      school_class_id: 'class-1-id',
+                      student_id: 'student-2-id',
+                      student: student_2)
+      ]
+    end
+
+    before do
+      # Mock successful student creation with new structure
+      student_success_result = OperationResponse.new
+      student_success_result[:school_students] = mock_successful_students
+      student_success_result[:errors] = nil
+      allow(SchoolStudent::CreateBatchSSO).to receive(:call).and_return(student_success_result)
+
+      # Mock successful class member creation
+      class_member_success_result = OperationResponse.new
+      class_member_success_result[:class_members] = mock_successful_class_members
+      class_member_success_result[:errors] = {}
+      allow(ClassMember::Create).to receive(:call).and_return(class_member_success_result)
+    end
+
+    it 'successfully imports a class without students' do
+      post(import_url, headers:, params: base_import_params)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # School class should be created
+      expect(response_data[:school_class]).to include(
+        name: 'Imported Class',
+        description: 'Imported Description',
+        import_origin: 'google_classroom',
+        import_id: 'classroom_123'
+      )
+
+      # Teachers should be included
+      expect(response_data[:school_class][:teachers]).to be_an(Array)
+      expect(response_data[:school_class][:teachers].first[:name]).to eq('School Teacher')
+
+      # Students and class_members should be empty arrays
+      expect(response_data[:students]).to eq([])
+      expect(response_data[:class_members]).to eq([])
+    end
+
+    it 'successfully imports a class with students and assigns them' do
+      post(import_url, headers:, params: import_params_with_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # School class should be created
+      expect(response_data[:school_class]).to include(
+        name: 'Imported Class',
+        description: 'Imported Description',
+        import_origin: 'google_classroom',
+        import_id: 'classroom_123'
+      )
+
+      # Students should be created successfully
+      expect(response_data[:students]).to be_an(Array)
+      expect(response_data[:students].length).to eq(2)
+      response_data[:students].each do |student|
+        expect(student).to include(
+          success: true,
+          created: true
+        )
+        expect(student[:error]).to be_nil
+      end
+
+      # Class members should be assigned successfully
+      expect(response_data[:class_members]).to be_an(Array)
+      expect(response_data[:class_members].length).to eq(2)
+    end
+
+    it 'allows re-importing the same class (finds existing class)' do
+      # First import should create the class
+      post(import_url, headers:, params: base_import_params)
+      expect(response).to have_http_status(:created)
+      first_response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # Second import with the same import_id should find the existing class
+      post(import_url, headers:, params: base_import_params)
+      expect(response).to have_http_status(:created)
+      second_response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # Should return the same class
+      expect(second_response_data[:school_class][:id]).to eq(first_response_data[:school_class][:id])
+      expect(second_response_data[:school_class][:name]).to eq('Imported Class')
+    end
+
+    it 'returns the correct JSON structure for successful import' do
+      post(import_url, headers:, params: import_params_with_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # Verify the complete structure matches the import template
+      expect(response_data).to have_key(:school_class)
+      expect(response_data).to have_key(:students)
+      expect(response_data).to have_key(:class_members)
+
+      # School class structure
+      expect(response_data[:school_class]).to include(
+        :id, :name, :description, :school_id, :code,
+        :created_at, :updated_at, :import_origin, :import_id, :teachers
+      )
+
+      # Students structure (array when successful)
+      expect(response_data[:students]).to be_an(Array)
+
+      # Class members structure (array when successful)
+      expect(response_data[:class_members]).to be_an(Array)
+    end
   end
 
-  it 'prevents importing two classes with the same import_id for the same school' do
-    # First import should succeed
-    post(import_url, headers:, params: base_import_params)
-    expect(response).to have_http_status(:created)
+  describe 'Edge cases' do
+    it 'handles empty students array gracefully' do
+      params_with_empty_students = base_import_params.merge(school_students: [])
 
-    # Second import with the same import_id should fail
-    post(import_url, headers:, params: base_import_params)
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)['error'].to_s).to include('Import id has already been taken')
+      post(import_url, headers:, params: params_with_empty_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_data[:school_class][:name]).to eq('Imported Class')
+      expect(response_data[:students]).to eq([])
+      expect(response_data[:class_members]).to eq([])
+    end
+
+    it 'handles nil students gracefully' do
+      params_with_nil_students = base_import_params.merge(school_students: nil)
+
+      post(import_url, headers:, params: params_with_nil_students)
+
+      expect(response).to have_http_status(:created)
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      # Should still create the class successfully
+      expect(response_data[:school_class][:name]).to eq('Imported Class')
+      expect(response_data[:students]).to eq([])
+      expect(response_data[:class_members]).to eq([])
+    end
   end
 end

--- a/spec/features/school_member/listing_school_members_spec.rb
+++ b/spec/features/school_member/listing_school_members_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe 'Listing school members', type: :request do
         id: students[0].id,
         username: students[0].username,
         name: students[0].name,
+        email: students[0].email,
+        sso: false,
         type: 'student'
       }
     )

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.create_school' do
+    subject(:create_school_response) { create_school }
+
     let(:school) { build(:school, id: SecureRandom.uuid, code: SecureRandom.uuid) }
     let(:create_school_url) { "#{api_url}/api/v1/schools" }
 
@@ -61,33 +63,12 @@ RSpec.describe ProfileApiClient do
         )
     end
 
-    it 'makes a request to the profile api host' do
-      create_school
-      expect(WebMock).to have_requested(:post, create_school_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      create_school
-      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      create_school
-      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets content-type of request to json' do
-      create_school
-      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'sets accept header to json' do
-      create_school
-      expect(WebMock).to have_requested(:post, create_school_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { create_school_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { create_school_url }
+    it_behaves_like 'a request that handles an unexpected response status', :post, url: -> { "#{api_url}/api/v1/schools" }, status: 200
 
     it 'sends the school id and code in the request body as json' do
-      create_school
+      create_school_response
       expected_body = { id: school.id, schoolCode: school.code }.to_json
       expect(WebMock).to have_requested(:post, create_school_url).with(body: expected_body)
     end
@@ -97,21 +78,7 @@ RSpec.describe ProfileApiClient do
       expected = ProfileApiClient::School.new(**data)
       stub_request(:post, create_school_url)
         .to_return(status: 201, body: data.to_json, headers: { 'Content-Type' => 'application/json' })
-      expect(create_school).to eq(expected)
-    end
-
-    it 'raises exception if anything other than a 201 status code is returned' do
-      stub_request(:post, create_school_url)
-        .to_return(status: 200)
-
-      expect { create_school }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:post, create_school_url)
-        .to_return(status: 401)
-
-      expect { create_school }.to raise_error(Faraday::Error)
+      expect(create_school_response).to eq(expected)
     end
 
     describe 'when BYPASS_OAUTH is true' do
@@ -120,13 +87,13 @@ RSpec.describe ProfileApiClient do
       end
 
       it 'does not make a request to Profile API' do
-        create_school
+        create_school_response
         expect(WebMock).not_to have_requested(:post, create_school_url)
       end
 
       it 'returns the id and code of the school supplied' do
         expected = { 'id' => school.id, 'schoolCode' => school.code }
-        expect(create_school).to eq(expected)
+        expect(create_school_response).to eq(expected)
       end
     end
 
@@ -138,31 +105,17 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.safeguarding_flags' do
+    subject(:safeguarding_flags_response) { list_safeguarding_flags }
+
     let(:list_safeguarding_flags_url) { "#{api_url}/api/v1/safeguarding-flags" }
 
     before do
       stub_request(:get, list_safeguarding_flags_url).to_return(status: 200, body: '[]', headers: { 'content-type' => 'application/json' })
     end
 
-    it 'makes a request to the profile api host' do
-      list_safeguarding_flags
-      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      list_safeguarding_flags
-      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      list_safeguarding_flags
-      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets accept header to json' do
-      list_safeguarding_flags
-      expect(WebMock).to have_requested(:get, list_safeguarding_flags_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated API request', :get, url: -> { list_safeguarding_flags_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :get, url: -> { list_safeguarding_flags_url }
+    it_behaves_like 'a request that handles an unexpected response status', :get, url: -> { list_safeguarding_flags_url }, status: 201
 
     it 'returns list of safeguarding flags if successful' do
       flag = {
@@ -177,21 +130,7 @@ RSpec.describe ProfileApiClient do
       expected = ProfileApiClient::SafeguardingFlag.new(**flag)
       stub_request(:get, list_safeguarding_flags_url)
         .to_return(status: 200, body: [flag].to_json, headers: { 'content-type' => 'application/json' })
-      expect(list_safeguarding_flags).to eq([expected])
-    end
-
-    it 'raises exception if anything other than a 200 status code is returned' do
-      stub_request(:get, list_safeguarding_flags_url)
-        .to_return(status: 201)
-
-      expect { list_safeguarding_flags }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:get, list_safeguarding_flags_url)
-        .to_return(status: 401)
-
-      expect { list_safeguarding_flags }.to raise_error(Faraday::Error)
+      expect(safeguarding_flags_response).to eq([expected])
     end
 
     private
@@ -202,6 +141,8 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.create_safeguarding_flag' do
+    subject(:create_safeguarding_flag_response) { create_safeguarding_flag }
+
     let(:flag) { 'school:owner' }
     let(:create_safeguarding_flag_url) { "#{api_url}/api/v1/safeguarding-flags" }
 
@@ -209,61 +150,30 @@ RSpec.describe ProfileApiClient do
       stub_request(:post, create_safeguarding_flag_url).to_return(status: 201, body: '{}', headers: { 'content-type' => 'application/json' })
     end
 
-    it 'makes a request to the profile api host' do
-      create_safeguarding_flag
-      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      create_safeguarding_flag
-      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      create_safeguarding_flag
-      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets content-type of request to json' do
-      create_safeguarding_flag
-      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'sets accept header to json' do
-      create_safeguarding_flag
-      expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { create_safeguarding_flag_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { create_safeguarding_flag_url }
 
     it 'sends the safeguarding flag in the request body' do
-      create_safeguarding_flag
+      create_safeguarding_flag_response
       expect(WebMock).to have_requested(:post, create_safeguarding_flag_url).with(body: { flag:, email: 'user@example.com' }.to_json)
     end
 
     it 'returns empty body if created successfully' do
-      stub_request(:post, create_safeguarding_flag_url)
-        .to_return(status: 201)
-      expect(create_safeguarding_flag).to be_nil
+      stub_request(:post, create_safeguarding_flag_url).to_return(status: 201)
+      expect(create_safeguarding_flag_response).to be_nil
     end
 
     it 'returns empty body if 303 response returned to indicate that the flag already exists' do
-      stub_request(:post, create_safeguarding_flag_url)
-        .to_return(status: 303)
-      expect(create_safeguarding_flag).to be_nil
+      stub_request(:post, create_safeguarding_flag_url).to_return(status: 303)
+      expect(create_safeguarding_flag_response).to be_nil
     end
 
     it 'raises exception if anything other than a 201 or 303 status code is returned' do
-      stub_request(:post, create_safeguarding_flag_url)
-        .to_return(status: 200)
-
-      expect { create_safeguarding_flag }.to raise_error(ProfileApiClient::UnexpectedResponse)
+      stub_request(:post, create_safeguarding_flag_url).to_return(status: 200)
+      expect { create_safeguarding_flag_response }.to raise_error(ProfileApiClient::UnexpectedResponse)
     end
 
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:post, create_safeguarding_flag_url)
-        .to_return(status: 401)
-
-      expect { create_safeguarding_flag }.to raise_error(Faraday::Error)
-    end
+    private
 
     def create_safeguarding_flag
       described_class.create_safeguarding_flag(token:, flag:, email: 'user@example.com')
@@ -271,6 +181,8 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.delete_safeguarding_flag' do
+    subject(:delete_safeguarding_flag_response) { delete_safeguarding_flag }
+
     let(:flag) { 'school:owner' }
     let(:delete_safeguarding_flag_url) { "#{api_url}/api/v1/safeguarding-flags/#{flag}" }
 
@@ -278,45 +190,17 @@ RSpec.describe ProfileApiClient do
       stub_request(:delete, delete_safeguarding_flag_url).to_return(status: 204, body: '')
     end
 
-    it 'makes a request to the profile api host' do
-      delete_safeguarding_flag
-      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      delete_safeguarding_flag
-      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      delete_safeguarding_flag
-      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets accept header to json' do
-      delete_safeguarding_flag
-      expect(WebMock).to have_requested(:delete, delete_safeguarding_flag_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated API request', :delete, url: -> { delete_safeguarding_flag_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :delete, url: -> { delete_safeguarding_flag_url }
+    it_behaves_like 'a request that handles an unexpected response status', :delete, url: -> { delete_safeguarding_flag_url }, status: 200
 
     it 'returns empty body if successful' do
       stub_request(:delete, delete_safeguarding_flag_url)
         .to_return(status: 204, body: '')
-      expect(delete_safeguarding_flag).to be_nil
+      expect(delete_safeguarding_flag_response).to be_nil
     end
 
-    it 'raises exception if anything other than a 204 status code is returned' do
-      stub_request(:delete, delete_safeguarding_flag_url)
-        .to_return(status: 200)
-
-      expect { delete_safeguarding_flag }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:delete, delete_safeguarding_flag_url)
-        .to_return(status: 401)
-
-      expect { delete_safeguarding_flag }.to raise_error(Faraday::Error)
-    end
+    private
 
     def delete_safeguarding_flag
       described_class.delete_safeguarding_flag(token:, flag:)
@@ -324,6 +208,8 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.create_school_student' do
+    subject(:create_school_student_response) { create_school_student }
+
     let(:username) { 'username' }
     let(:password) { 'password' }
     let(:name) { 'name' }
@@ -334,33 +220,12 @@ RSpec.describe ProfileApiClient do
       stub_request(:post, create_students_url).to_return(status: 201, body: '{}', headers: { 'content-type' => 'application/json' })
     end
 
-    it 'makes a request to the profile api host' do
-      create_school_student
-      expect(WebMock).to have_requested(:post, create_students_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      create_school_student
-      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      create_school_student
-      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets content-type of request to json' do
-      create_school_student
-      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'sets accept header to json' do
-      create_school_student
-      expect(WebMock).to have_requested(:post, create_students_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { create_students_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { create_students_url }
+    it_behaves_like 'a request that handles an unexpected response status', :post, url: -> { create_students_url }, status: 200
 
     it 'sends the student details in the request body' do
-      create_school_student
+      create_school_student_response
       expect(WebMock).to have_requested(:post, create_students_url).with(body: [{ name:, username:, password: }].to_json)
     end
 
@@ -368,7 +233,7 @@ RSpec.describe ProfileApiClient do
       response = { created: ['student-id'] }
       stub_request(:post, create_students_url)
         .to_return(status: 201, body: response.to_json, headers: { 'content-type' => 'application/json' })
-      expect(create_school_student).to eq(response)
+      expect(create_school_student_response).to eq(response)
     end
 
     it 'raises 422 exception with the relevant message if 400 status code is returned' do
@@ -380,72 +245,172 @@ RSpec.describe ProfileApiClient do
         .with_message('The password is well dodgy')
     end
 
-    it 'raises exception if anything other that 201 status code is returned' do
-      stub_request(:post, create_students_url)
-        .to_return(status: 200)
-
-      expect { create_school_student }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:post, create_students_url)
-        .to_return(status: 401)
-
-      expect { create_school_student }.to raise_error(Faraday::Error)
-    end
-
     context 'when there are extraneous leading and trailing spaces in the student params' do
       let(:username) { '  username  ' }
       let(:password) { '  password  ' }
       let(:name) { '  name  ' }
 
       it 'strips the extraneous spaces' do
-        create_school_student
+        create_school_student_response
         expect(WebMock).to have_requested(:post, create_students_url).with(body: [{ name: 'name', username: 'username', password: 'password' }].to_json)
       end
     end
+
+    private
 
     def create_school_student
       described_class.create_school_student(token:, username:, password:, name:, school_id: school.id)
     end
   end
 
-  describe '.list_school_student' do
+  describe '.create_school_students' do
+    subject(:create_school_students_response) { create_school_students }
+
+    let(:username) { 'username' }
+    let(:password) { 'password' }
+    let(:name) { 'name' }
+    let(:students) { [{ name:, username:, password: }] }
     let(:school) { build(:school, id: SecureRandom.uuid) }
-    let(:list_students_url) { "#{api_url}/api/v1/schools/#{school.id}/students/list" }
+    let(:create_students_url) { "#{api_url}/api/v1/schools/#{school.id}/students" }
+
+    before do
+      stub_request(:post, create_students_url).to_return(status: 201, body: '{}', headers: { 'content-type' => 'application/json' })
+    end
+
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { create_students_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { create_students_url }
+    it_behaves_like 'a request that handles an unexpected response status', :post, url: -> { create_students_url }, status: 202
+
+    it 'raises 422 exception with the relevant message if 400 status code is returned' do
+      response = { errors: [message: 'The password is well dodgy'] }
+      stub_request(:post, create_students_url)
+        .to_return(status: 400, body: response.to_json, headers: { 'content-type' => 'application/json' })
+
+      expect { create_school_students }.to raise_error(ProfileApiClient::Student422Error) do |error|
+        expect(error.errors.first['message']).to eq('The password is well dodgy')
+      end
+    end
+
+    it 'sends the student details in the request body' do
+      create_school_students_response
+      expect(WebMock).to have_requested(:post, create_students_url).with(body: [{ name:, username:, password: }].to_json)
+    end
+
+    it 'returns the id of the created student(s) if successful' do
+      response = { created: ['student-id'] }
+      stub_request(:post, create_students_url)
+        .to_return(status: 201, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(create_school_students_response).to eq(response)
+    end
+
+    it 'accepts a 200 status code as successful' do
+      response = { created: ['student-id'] }
+      stub_request(:post, create_students_url)
+        .to_return(status: 200, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(create_school_students_response).to eq(response)
+    end
+
+    context 'when preflight is true' do
+      subject(:create_school_students_preflight_response) { create_school_students_preflight }
+
+      let(:create_students_preflight_url) { "#{api_url}/api/v1/schools/#{school.id}/students/preflight" }
+
+      before do
+        stub_request(:post, create_students_preflight_url).to_return(status: 200, body: '{}', headers: { 'content-type' => 'application/json' })
+      end
+
+      it 'sends the request to the preflight endpoint' do
+        create_school_students_preflight_response
+        expect(WebMock).to have_requested(:post, create_students_preflight_url).with(body: students.to_json)
+      end
+
+      def create_school_students_preflight
+        described_class.create_school_students(token:, students:, school_id: school.id, preflight: true)
+      end
+    end
+
+    private
+
+    def create_school_students
+      described_class.create_school_students(token:, students:, school_id: school.id)
+    end
+  end
+
+  describe '.create_school_students_sso' do
+    subject(:create_school_students_sso_response) { create_school_students_sso }
+
+    let(:name) { 'name' }
+    let(:email) { 'email' }
+    let(:students) { [{ name:, email: }] }
+    let(:school) { build(:school, id: SecureRandom.uuid) }
+    let(:create_students_sso_url) { "#{api_url}/api/v1/schools/#{school.id}/students/sso" }
+
+    before do
+      stub_request(:post, create_students_sso_url).to_return(status: 201, body: '[]', headers: { 'content-type' => 'application/json' })
+    end
+
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { create_students_sso_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { create_students_sso_url }
+    it_behaves_like 'a request that handles an unexpected response status', :post, url: -> { create_students_sso_url }, status: 202
+
+    it 'raises 422 exception with the relevant message if 400 status code is returned' do
+      response = { errors: [message: 'The password is well dodgy'] }
+      stub_request(:post, create_students_sso_url)
+        .to_return(status: 400, body: response.to_json, headers: { 'content-type' => 'application/json' })
+
+      expect { create_school_students_sso }.to raise_error(ProfileApiClient::Student422Error) do |error|
+        expect(error.errors.first['message']).to eq('The password is well dodgy')
+      end
+    end
+
+    it 'sends the student details in the request body' do
+      create_school_students_sso_response
+      expect(WebMock).to have_requested(:post, create_students_sso_url).with(body: students.to_json)
+    end
+
+    it 'returns the array of student data if successful' do
+      response = [{ id: 'student-id', name: 'John', success: true }]
+      stub_request(:post, create_students_sso_url)
+        .to_return(status: 201, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(create_school_students_sso_response).to eq([{ id: 'student-id', name: 'John', success: true }])
+    end
+
+    it 'accepts a 200 status code as successful' do
+      response = [{ id: 'student-id', name: 'John', success: true }]
+      stub_request(:post, create_students_sso_url)
+        .to_return(status: 200, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(create_school_students_sso_response).to eq([{ id: 'student-id', name: 'John', success: true }])
+    end
+
+    it 'returns nil if token is blank' do
+      expect(described_class.create_school_students_sso(token: '', students:, school_id: school.id)).to be_nil
+      expect(described_class.create_school_students_sso(token: nil, students:, school_id: school.id)).to be_nil
+    end
+
+    private
+
+    def create_school_students_sso
+      described_class.create_school_students_sso(token:, students:, school_id: school.id)
+    end
+  end
+
+  describe '.list_school_student' do
+    subject(:list_school_students_response) { list_school_students }
+
+    let(:school) { build(:school, id: SecureRandom.uuid) }
     let(:student_ids) { [SecureRandom.uuid] }
+    let(:list_students_url) { "#{api_url}/api/v1/schools/#{school.id}/students/list" }
 
     before do
       stub_request(:post, list_students_url).to_return(status: 200, body: '[]', headers: { 'content-type' => 'application/json' })
     end
 
-    it 'makes a request to the profile api host' do
-      list_school_students
-      expect(WebMock).to have_requested(:post, list_students_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      list_school_students
-      expect(WebMock).to have_requested(:post, list_students_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      list_school_students
-      expect(WebMock).to have_requested(:post, list_students_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets content-type of request to json' do
-      list_school_students
-      expect(WebMock).to have_requested(:post, list_students_url).with(headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'sets accept header to json' do
-      list_school_students
-      expect(WebMock).to have_requested(:post, list_students_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated JSON API request', :post, url: -> { list_students_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :post, url: -> { list_students_url }
+    it_behaves_like 'a request that handles an unexpected response status', :post, url: -> { list_students_url }, status: 201
 
     it 'sets body to the student IDs' do
-      list_school_students
+      list_school_students_response
       expect(WebMock).to have_requested(:post, list_students_url).with(body: student_ids)
     end
 
@@ -455,6 +420,7 @@ RSpec.describe ProfileApiClient do
         schoolId: '132383f1-702a-46a0-9eb2-a40dd4f212e3',
         name: 'student-name',
         username: 'student-username',
+        email: 'test@example.com',
         createdAt: '2024-07-03T13:00:40.041Z',
         updatedAt: '2024-07-03T13:00:40.041Z',
         discardedAt: nil
@@ -462,22 +428,10 @@ RSpec.describe ProfileApiClient do
       expected = ProfileApiClient::Student.new(**student)
       stub_request(:post, list_students_url)
         .to_return(status: 200, body: [student].to_json, headers: { 'content-type' => 'application/json' })
-      expect(list_school_students).to eq([expected])
+      expect(list_school_students_response).to eq([expected])
     end
 
-    it 'raises exception if anything other that 200 status code is returned' do
-      stub_request(:post, list_students_url)
-        .to_return(status: 201)
-
-      expect { list_school_students }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:post, list_students_url)
-        .to_return(status: 401)
-
-      expect { list_school_students }.to raise_error(Faraday::Error)
-    end
+    private
 
     def list_school_students
       described_class.list_school_students(token:, school_id: school.id, student_ids:)
@@ -485,6 +439,8 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.update_school_student' do
+    subject(:update_school_student_response) { update_school_student }
+
     let(:username) { 'username' }
     let(:password) { 'password' }
     let(:name) { 'name' }
@@ -496,47 +452,26 @@ RSpec.describe ProfileApiClient do
       stub_request(:patch, update_student_url)
         .to_return(
           status: 200,
-          body: '{"id":"","schoolId":"","name":"","username":"","createdAt":"","updatedAt":"","discardedAt":""}',
+          body: '{"id":"","schoolId":"","name":"","username":"","email":"","createdAt":"","updatedAt":"","discardedAt":""}',
           headers: { 'content-type' => 'application/json' }
         )
     end
 
-    it 'makes a request to the profile api host' do
-      update_school_student
-      expect(WebMock).to have_requested(:patch, update_student_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      update_school_student
-      expect(WebMock).to have_requested(:patch, update_student_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      update_school_student
-      expect(WebMock).to have_requested(:patch, update_student_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets content-type of request to json' do
-      update_school_student
-      expect(WebMock).to have_requested(:patch, update_student_url).with(headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'sets accept header to json' do
-      update_school_student
-      expect(WebMock).to have_requested(:patch, update_student_url).with(headers: { 'accept' => 'application/json' })
-    end
+    it_behaves_like 'an authenticated JSON API request', :patch, url: -> { update_student_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :patch, url: -> { update_student_url }
+    it_behaves_like 'a request that handles an unexpected response status', :patch, url: -> { update_student_url }, status: 201
 
     it 'sends the student details in the request body' do
-      update_school_student
+      update_school_student_response
       expect(WebMock).to have_requested(:patch, update_student_url).with(body: { name:, username:, password: }.to_json)
     end
 
     it 'returns the updated student if successful' do
-      response = { id: 'id', schoolId: 'school-id', name: 'new-name', username: 'new-username', createdAt: '', updatedAt: '', discardedAt: '' }
+      response = { id: 'id', schoolId: 'school-id', name: 'new-name', username: 'new-username', email: 'test@example.com', createdAt: '', updatedAt: '', discardedAt: '' }
       expected = ProfileApiClient::Student.new(**response)
       stub_request(:patch, update_student_url)
         .to_return(status: 200, body: response.to_json, headers: { 'content-type' => 'application/json' })
-      expect(update_school_student).to eq(expected)
+      expect(update_school_student_response).to eq(expected)
     end
 
     it 'raises 422 exception with the relevant message if 400 status code is returned' do
@@ -548,27 +483,13 @@ RSpec.describe ProfileApiClient do
         .with_message('The username is well dodgy')
     end
 
-    it 'raises exception if anything other that 200 status code is returned' do
-      stub_request(:patch, update_student_url)
-        .to_return(status: 201)
-
-      expect { update_school_student }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:patch, update_student_url)
-        .to_return(status: 401)
-
-      expect { update_school_student }.to raise_error(Faraday::Error)
-    end
-
     context 'when there are extraneous leading and trailing spaces in the student params' do
       let(:username) { '  username  ' }
       let(:password) { '  password  ' }
       let(:name) { '  name  ' }
 
       it 'strips the extraneous spaces' do
-        update_school_student
+        update_school_student_response
         expect(WebMock).to have_requested(:patch, update_student_url).with(body: { name: 'name', username: 'username', password: 'password' }.to_json)
       end
     end
@@ -579,10 +500,12 @@ RSpec.describe ProfileApiClient do
       let(:name) { nil }
 
       it 'does not send empty values' do
-        update_school_student
+        update_school_student_response
         expect(WebMock).to have_requested(:patch, update_student_url).with(body: {}.to_json)
       end
     end
+
+    private
 
     def update_school_student
       described_class.update_school_student(token:, username:, password:, name:, school_id: school.id, student_id: student.id)
@@ -590,129 +513,37 @@ RSpec.describe ProfileApiClient do
   end
 
   describe '.school_student' do
+    subject(:school_student_response) { school_student }
+
     let(:school) { build(:school, id: SecureRandom.uuid) }
-    let(:student_url) { "#{api_url}/api/v1/schools/#{school.id}/students/#{student_id}" }
     let(:student_id) { SecureRandom.uuid }
+    let(:student_url) { "#{api_url}/api/v1/schools/#{school.id}/students/#{student_id}" }
 
     before do
       stub_request(:get, student_url)
         .to_return(
           status: 200,
-          body: '{"id":"","schoolId":"","name":"","username":"","createdAt":"","updatedAt":"","discardedAt":""}',
+          body: '{"id":"","schoolId":"","name":"","username":"","email":"","createdAt":"","updatedAt":"","discardedAt":""}',
           headers: { 'content-type' => 'application/json' }
         )
     end
 
-    it 'makes a request to the profile api host' do
-      school_student
-      expect(WebMock).to have_requested(:get, student_url)
-    end
+    it_behaves_like 'an authenticated API request', :get, url: -> { student_url }
+    it_behaves_like 'a request that handles standard HTTP errors', :get, url: -> { student_url }
+    it_behaves_like 'a request that handles an unexpected response status', :get, url: -> { student_url }, status: 201
 
-    it 'includes token in the authorization request header' do
-      school_student
-      expect(WebMock).to have_requested(:get, student_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      school_student
-      expect(WebMock).to have_requested(:get, student_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets accept header to json' do
-      school_student
-      expect(WebMock).to have_requested(:get, student_url).with(headers: { 'accept' => 'application/json' })
-    end
-
-    it 'returns the student(s) if successful' do
-      student = {
-        id: '549e4674-6ffd-4ac6-9a97-b4d7e5c0e5c5',
-        schoolId: '132383f1-702a-46a0-9eb2-a40dd4f212e3',
-        name: 'student-name',
-        username: 'student-username',
-        createdAt: '2024-07-03T13:00:40.041Z',
-        updatedAt: '2024-07-03T13:00:40.041Z',
-        discardedAt: nil
-      }
-      expected = ProfileApiClient::Student.new(**student)
+    it 'returns the student if successful' do
+      response = { id: student_id, schoolId: school.id, name: 'name', username: 'username', email: 'test@example.com', createdAt: '', updatedAt: '', discardedAt: '' }
+      expected = ProfileApiClient::Student.new(**response)
       stub_request(:get, student_url)
-        .to_return(status: 200, body: student.to_json, headers: { 'content-type' => 'application/json' })
-      expect(school_student).to eq(expected)
-    end
-
-    it 'raises exception if anything other than a 200 status code is returned' do
-      stub_request(:get, student_url)
-        .to_return(status: 201)
-
-      expect { school_student }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:get, student_url)
-        .to_return(status: 401)
-
-      expect { school_student }.to raise_error(Faraday::Error)
+        .to_return(status: 200, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(school_student_response).to eq(expected)
     end
 
     private
 
     def school_student
       described_class.school_student(token:, school_id: school.id, student_id:)
-    end
-  end
-
-  describe '.delete_school_student' do
-    let(:school) { build(:school, id: SecureRandom.uuid) }
-    let(:delete_student_url) { "#{api_url}/api/v1/schools/#{school.id}/students/#{student_id}" }
-    let(:student_id) { SecureRandom.uuid }
-
-    before do
-      stub_request(:delete, delete_student_url).to_return(status: 204, body: '', headers: { 'content-type' => 'application/json' })
-    end
-
-    it 'makes a request to the profile api host' do
-      delete_school_student
-      expect(WebMock).to have_requested(:delete, delete_student_url)
-    end
-
-    it 'includes token in the authorization request header' do
-      delete_school_student
-      expect(WebMock).to have_requested(:delete, delete_student_url).with(headers: { authorization: "Bearer #{token}" })
-    end
-
-    it 'includes the profile api key in the x-api-key request header' do
-      delete_school_student
-      expect(WebMock).to have_requested(:delete, delete_student_url).with(headers: { 'x-api-key' => api_key })
-    end
-
-    it 'sets accept header to json' do
-      delete_school_student
-      expect(WebMock).to have_requested(:delete, delete_student_url).with(headers: { 'accept' => 'application/json' })
-    end
-
-    it 'returns nil if successful' do
-      stub_request(:delete, delete_student_url)
-        .to_return(status: 204, body: '', headers: { 'content-type' => 'application/json' })
-      expect(delete_school_student).to be_nil
-    end
-
-    it 'raises exception if anything other than a 200 status code is returned' do
-      stub_request(:delete, delete_student_url)
-        .to_return(status: 201)
-
-      expect { delete_school_student }.to raise_error(ProfileApiClient::UnexpectedResponse)
-    end
-
-    it 'raises faraday exception for 4xx and 5xx responses' do
-      stub_request(:delete, delete_student_url)
-        .to_return(status: 401)
-
-      expect { delete_school_student }.to raise_error(Faraday::Error)
-    end
-
-    private
-
-    def delete_school_student
-      described_class.delete_school_student(token:, school_id: school.id, student_id:)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -417,4 +417,85 @@ RSpec.describe User do
       expect(user.schools).to eq([school])
     end
   end
+
+  describe '#sso' do
+    subject(:user) { create(:user) }
+
+    context 'when user is not a student' do
+      it 'returns nil for teachers' do
+        create(:teacher_role, school:, user_id: user.id)
+        expect(user.sso).to be_nil
+      end
+
+      it 'returns nil for owners' do
+        create(:owner_role, school:, user_id: user.id)
+        expect(user.sso).to be_nil
+      end
+
+      it 'returns nil for users with no roles' do
+        expect(user.sso).to be_nil
+      end
+    end
+
+    context 'when user is a student' do
+      before do
+        create(:student_role, school:, user_id: user.id)
+      end
+
+      context 'when student has email and no username (SSO student)' do
+        before do
+          user.email = 'student@example.com'
+          user.username = nil
+        end
+
+        it 'returns true' do
+          expect(user.sso).to be(true)
+        end
+      end
+
+      context 'when student has username and no email (standard student)' do
+        before do
+          user.email = nil
+          user.username = 'student123'
+        end
+
+        it 'returns false' do
+          expect(user.sso).to be(false)
+        end
+      end
+
+      context 'when student has both email and username' do
+        before do
+          user.email = 'student@example.com'
+          user.username = 'student123'
+        end
+
+        it 'returns false' do
+          expect(user.sso).to be(false)
+        end
+      end
+
+      context 'when student has neither email nor username' do
+        before do
+          user.email = nil
+          user.username = nil
+        end
+
+        it 'returns false' do
+          expect(user.sso).to be(false)
+        end
+      end
+
+      context 'when student has blank email and username' do
+        before do
+          user.email = ''
+          user.username = ''
+        end
+
+        it 'returns false' do
+          expect(user.sso).to be(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -12,6 +12,7 @@ module ProfileApiMock
         id: student_attrs[:id],
         username: student_attrs[:username],
         name: student_attrs[:name],
+        email: student_attrs[:email],
         createdAt: now, updatedAt: now, discardedAt: nil
       )
     end
@@ -70,5 +71,19 @@ module ProfileApiMock
 
   def stub_profile_api_create_safeguarding_flag
     allow(ProfileApiClient).to receive(:create_safeguarding_flag)
+  end
+
+  def stub_profile_api_create_school_students_sso(user_ids: [SecureRandom.uuid])
+    responses = user_ids.map { |user_id| { id: user_id, name: 'Test Student', success: true } }
+    allow(ProfileApiClient).to receive(:create_school_students_sso).and_return(responses)
+  end
+
+  def stub_profile_api_create_school_students_sso_validation_error
+    allow(ProfileApiClient).to receive(:create_school_students_sso).and_raise(
+      ProfileApiClient::Student422Error.new(
+        [{ 'path' => '0.name', 'errorCode' => 'minLength.openapi.requestValidation', 'message' => 'must NOT have fewer than 1 characters', 'location' => 'body' },
+         { 'path' => '0.email', 'errorCode' => 'minLength.openapi.requestValidation', 'message' => 'must NOT have fewer than 3 characters', 'location' => 'body' }]
+      )
+    )
   end
 end

--- a/spec/support/shared_examples/profile_api_client_examples.rb
+++ b/spec/support/shared_examples/profile_api_client_examples.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an authenticated API request' do |http_method, url:|
+  let(:expected_url) { instance_exec(&url) }
+
+  it 'makes a request to the profile api host' do
+    subject
+    expect(WebMock).to have_requested(http_method, expected_url)
+  end
+
+  it 'includes token in the authorization request header' do
+    subject
+    expect(WebMock).to have_requested(http_method, expected_url)
+      .with(headers: { 'Authorization' => "Bearer #{token}" })
+  end
+
+  it 'includes the profile api key in the x-api-key request header' do
+    subject
+    expect(WebMock).to have_requested(http_method, expected_url)
+      .with(headers: { 'X-API-KEY' => api_key })
+  end
+
+  it 'sets accept header to json' do
+    subject
+    expect(WebMock).to have_requested(http_method, expected_url)
+      .with(headers: { 'Accept' => 'application/json' })
+  end
+end
+
+RSpec.shared_examples 'an authenticated JSON API request' do |http_method, url:|
+  let(:expected_url) { instance_exec(&url) }
+
+  it_behaves_like 'an authenticated API request', http_method, url: url
+
+  it 'sets content-type of request to json' do
+    subject
+    expect(WebMock).to have_requested(http_method, expected_url)
+      .with(headers: { 'Content-Type' => 'application/json' })
+  end
+end
+
+RSpec.shared_examples 'a request that handles standard HTTP errors' do |http_method, url:|
+  let(:expected_url) { instance_exec(&url) }
+
+  it 'raises faraday exception for 4xx and 5xx responses' do
+    stub_request(http_method, expected_url).to_return(status: 401)
+    expect { subject }.to raise_error(Faraday::Error)
+  end
+end
+
+RSpec.shared_examples 'a request that handles an unexpected response status' do |http_method, url:, status:|
+  let(:expected_url) { instance_exec(&url) }
+
+  it 'raises exception if anything other than expected status code is returned' do
+    stub_request(http_method, expected_url).to_return(status: status)
+    expect { subject }.to raise_error(ProfileApiClient::UnexpectedResponse)
+  end
+end


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/821

## Points for consideration:

- Security
- Performance

## What's changed?

- Extended the import functionality to handle student data from profile API 
- Students are now identified as using SSO and email field is supported in the data structure 
- Prevents redundant API call in school_member list when no students exist for a school
- Added validation to exclude students with no data and additional test coverage for email field handling
- Refactored school_member list to reduce complexity and improve maintainability
- Added proper error handling for cases where no valid school members are provided
- Rubocop fixes
- Clarified README instructions for when to use docker compose prefix during seeding
- Refactored profile_api_client spec to use shared example, to make it more DRY

## Steps to perform after deploying to production

This is dependent on (profile changes introduced in #1925 )[https://github.com/RaspberryPiFoundation/profile/pull/1925]
