### PR TITLE
Remove id_token from google auth response, since we're no longer requesting that in the scope

### DIFF
--- a/app/views/api/google_auth/exchange_code.json.jbuilder
+++ b/app/views/api/google_auth/exchange_code.json.jbuilder
@@ -5,6 +5,5 @@ json.call(
   'access_token',
   'expires_in',
   'token_type',
-  'scope',
-  'id_token'
+  'scope'
 )

--- a/spec/requests/api/google_auth_controller_spec.rb
+++ b/spec/requests/api/google_auth_controller_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'Google Auth requests' do
         'access_token' => 'test-access-token',
         'expires_in' => 3599,
         'token_type' => 'Bearer',
-        'scope' => 'openid email profile',
-        'id_token' => 'test-id-token'
+        'scope' => 'email profile'
       }
     end
 


### PR DESCRIPTION
## Status

- Ready for review

## What's changed?

Removes the  id_token form google auth response, since we're no longer requesting that in the scope

## Steps to perform after deploying to production

N/A
