### PR TITLE
Fix schema.rb version to match consolidated migration (2025_11_20_145…

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_21_101546) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_20_145032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
# Fix schema.rb version mismatch after migration consolidation

## Context: Original PR (https://github.com/RaspberryPiFoundation/editor-api/pull/623)

The original PR added `district_name` and `district_nces_id` to the `schools` table:

* Created first migration (`20251120145032_add_district_fields_to_schools.rb`) to add the columns
* Created second migration (`20251121101546_make_district_nces_id_unique.rb`) to add a unique index

## What Changed During Code Review

Code review suggested consolidating the two migrations into one:

* Moved the unique index from the second migration into the first migration
* Deleted the second migration file (`20251121101546_make_district_nces_id_unique.rb`)
* The consolidated migration (`20251120145032`) now includes `unique: true` on the index

## The Issue

After consolidation, `schema.rb` still referenced the deleted migration's timestamp:

* `schema.rb` showed `version: 2025_11_21_101546` (the deleted second migration)
* But that migration file no longer exists
* This created a mismatch between `schema.rb` and the actual migration files

## What This PR Fixes

This PR regenerates `schema.rb` to match the consolidated migration:

* Updates `schema.rb` version from `2025_11_21_101546` to `2025_11_20_145032`
* Ensures the schema version matches the existing migration file

## Verification

* The consolidated migration (`20251120145032`) exists and includes the unique index
* `schema.rb` now correctly references this migration
* District fields (`district_name`, `district_nces_id`) and the unique index are present in the schema