### PR TITLE
Upgrade bundler to fix update command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -645,4 +645,4 @@ RUBY VERSION
   ruby 3.4.8
 
 BUNDLED WITH
-  4.0.5
+  4.0.10


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/editor-api/security/dependabot/143

Run `bundle update --bundler`

The update command was failing for specific gems for example, `bundle update addressable` fails with:

```
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Could not find compatible versions

Because every version of omniauth-rpi depends on omniauth-oauth2 ~> 1.4
  and omniauth-oauth2 ~> 1.4 could not be found in https://github.com/RaspberryPiFoundation/omniauth-rpi.git (at v1.4.1@ff02d94),
  omniauth-rpi cannot be used.
So, because Gemfile depends on omniauth-rpi >= 0,
  version solving has failed.
```

This error has nothing to do with addressable and seems to be something that is fixed in a newer version of bundler.