### PR TITLE
Change order of operations in persist_changes

### DIFF
--- a/lib/concepts/project/operations/update.rb
+++ b/lib/concepts/project/operations/update.rb
@@ -83,8 +83,8 @@ class Project
         return if response.failure?
 
         ActiveRecord::Base.transaction do
-          response[:project].save!
           response[:project].components.where(id: response[:component_ids_to_delete]).destroy_all
+          response[:project].save!
         end
       end
     end


### PR DESCRIPTION
## Description
Attempted fix for Sentry errors saying `Validation failed: Components extension can't be blank (ActiveRecord::RecordInvalid)`
Example [here](https://raspberrypifoundation.sentry.io/issues/5254866725?project=6143981&statsPeriod=7d)

## Status
- [Closes](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1268)

## What's changed?
Update the order of operations in persist_changes. Currently we validate and save before deleting components marked for deletion. If one of the components is invalid and going to be deleted this will cause save to fail.
