### PR TITLE
Add a cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
 - package-ecosystem: "bundler"
   directory: "/" # Location of package manifests
+  cooldown:
+    default-days: 10
   schedule:
     interval: "daily"


### PR DESCRIPTION
This has become a recommended way to reduce the risk of supply chain attacks. 10 days is fairly arbitrary and could be shortened or lengthened in the future.

A shorter cooldown might mean that we're more to encounter supply chain attacks or newly released versions with major issues. A longer cooldown means that we're less likely to get bug fixes. 

Note that security updates are not affected by this setting.

Documentation: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
Github announcement: https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/