### PR TITLE
Add rake task for removing teacher role

### DIFF
--- a/lib/tasks/remove_teacher.rake
+++ b/lib/tasks/remove_teacher.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :remove_teacher do
+  desc 'Remove teacher from their school'
+  task :run, %i[teacher_email] => :environment do |_task, args|
+    teacher = UserInfoApiClient.find_user_by_email(args[:teacher_email])
+
+    unless teacher
+      Rails.logger.error("No user found for email '#{args[:teacher_email]}'. Did you spell it correctly?")
+      next
+    end
+
+    role = Role.find_by(roles: { user_id: teacher[:id], role: 'teacher' })
+
+    unless role
+      Rails.logger.error("No teacher role found for user with email '#{args[:teacher_email]}'. Is this the right user?")
+      next
+    end
+
+    Rails.logger.info("Deleting '#{role[:role]}' role for user '#{args[:teacher_email]}' in school '#{role.school.name}'")
+    role.destroy!
+
+    Rails.logger.info "Removed teacher role for #{args[:teacher_email]} successfully."
+    Rails.logger.warn '⚠️ You must now manually remove the teacher safeguarding flag for the teacher.'
+    Rails.logger.warn 'Open a bash console on the rpf-profile app: `heroku run bash -a rpf-profile`'
+    Rails.logger.warn "Remove the teacher safeguarding flag: `node profile-cli remove-safeguarding-flag #{args[:teacher_email]} school:teacher`"
+  end
+end

--- a/spec/lib/tasks/remove_teacher_spec.rb
+++ b/spec/lib/tasks/remove_teacher_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'remove_teacher', type: :task do
+  describe ':run' do
+    let(:task) { Rake::Task['remove_teacher:run'] }
+    let(:owner_id) { SecureRandom.uuid }
+    let(:student_id) { SecureRandom.uuid }
+    let(:school) { create(:school, creator_id: owner_id) }
+    let(:teacher_id) { SecureRandom.uuid }
+
+    before do
+      stub_user_info_api_find_by_email(
+        email: 'teacher@example.com',
+        user: { id: teacher_id, email: 'teacher@example.com' }
+      )
+
+      stub_user_info_api_find_by_email(
+        email: 'owner@example.com',
+        user: { id: owner_id, email: 'owner@example.com' }
+      )
+
+      stub_user_info_api_find_by_email(
+        email: 'student@example.com',
+        user: { id: student_id, email: 'student@example.com' }
+      )
+
+      create(:teacher_role, school:, user_id: teacher_id)
+      create(:owner_role, school:, user_id: owner_id)
+      create(:student_role, school:, user_id: student_id)
+    end
+
+    it "exits early if the user doesn't exist" do
+      # Arrange
+      allow(UserInfoApiClient).to receive(:find_user_by_email)
+        .with('not_real_teacher@example.com')
+        .and_return(nil)
+
+      # Act
+      task.invoke('not_real_teacher@example.com')
+
+      # assert
+      expect(Role.find_by(user_id: teacher_id)).not_to be_nil
+    end
+
+    it 'exits early if the user has no teacher role' do
+      # Act
+      task.invoke('student@example.com')
+
+      # Assert
+      expect(Role.find_by(user_id: student_id)).not_to be_nil
+    end
+
+    it 'removes the role if it exists' do
+      # Act
+      task.invoke('teacher@example.com')
+
+      # Assert
+      expect(Role.find_by(user_id: teacher_id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Based on the instructions here:
https://digital-docs.rpf-internal.org/docs/technology/codebases-and-products/editor/processes/code-editor-for-education/removing-teachers

Key differences:
- The instructions say to connect to Profile's Postgres instance to lookup the user ID, but we instead use the `UserInfoApiClient` for that here.
- This task doesn't ask for a school, since it should not be possible for the user to have roles in more than one school (see `role.rb`).

## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1318

## What's changed?

Adds Rake task to remove a user's current teacher role given their email address.

## Steps to perform after deploying to production

Update https://digital-docs.rpf-internal.org/docs/technology/codebases-and-products/editor/processes/code-editor-for-education/removing-teachers.
