### PR TITLE
Add second task clear

### DIFF
--- a/lib/tasks/for_education.rake
+++ b/lib/tasks/for_education.rake
@@ -29,13 +29,13 @@ namespace :for_education do
 
       # Destroy the project and then the lesson itself (The lesson's `before_destroy` prevents us using destroy)
       lesson_ids = Lesson.where(school_id:).pluck(:id)
-      Project.where(lesson_id: [lesson_ids]).destroy_all
-      Lesson.where(id: [lesson_ids]).delete_all
+      Project.where(lesson_id: lesson_ids).destroy_all
+      Lesson.where(id: lesson_ids).delete_all
 
       # Destroy the class members and then the class itself
       school_class_ids = SchoolClass.where(school_id:).pluck(:id)
-      ClassStudent.where(school_class_id: [school_class_ids]).destroy_all
-      SchoolClass.where(id: [school_class_ids]).destroy_all
+      ClassStudent.where(school_class_id: school_class_ids).destroy_all
+      SchoolClass.where(id: school_class_ids).destroy_all
 
       # Destroy the school
       School.where(id: school_id).destroy_all
@@ -46,9 +46,9 @@ namespace :for_education do
 
   desc 'Create an unverified school'
   task seed_an_unverified_school: :environment do
-    if School.find_by(code: TEST_SCHOOL)
-      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over)."
-      return
+    if School.exists?(id: TEST_SCHOOL)
+      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over."
+      next
     end
 
     ActiveRecord::Base.transaction do
@@ -62,9 +62,9 @@ namespace :for_education do
 
   desc 'Create a verified school'
   task seed_a_verified_school: :environment do
-    if School.find_by(code: TEST_SCHOOL)
-      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over)."
-      return
+    if School.exists?(id: TEST_SCHOOL)
+      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over."
+      next
     end
 
     ActiveRecord::Base.transaction do
@@ -79,9 +79,9 @@ namespace :for_education do
 
   desc 'Create a school with lessons and students'
   task seed_a_school_with_lessons_and_students: :environment do
-    if School.find_by(code: TEST_SCHOOL)
-      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over)."
-      return
+    if School.exists?(id: TEST_SCHOOL)
+      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over."
+      next
     end
 
     ActiveRecord::Base.transaction do

--- a/spec/lib/tasks/for_education_spec.rb
+++ b/spec/lib/tasks/for_education_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe 'for_education', type: :task do
       expect(projects.length).to eq(2)
     end
 
+    it 'does not add more lessons or projects when run again' do
+      allow($stdout).to receive(:puts)
+
+      expect do
+        task.reenable
+        task.invoke
+      end.not_to change {
+        [
+          Lesson.where(school_id: school.id).count,
+          Project.where(school_id: school.id).count
+        ]
+      }
+    end
+
     it 'assigns a teacher' do
       expect(Role.teacher.where(user_id: teacher_id, school_id: school.id)).to exist
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,6 +108,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
 
     DatabaseCleaner.cleaning do
+      Rake::Task.clear
       Rails.application.load_tasks
       example.run
       Rake::Task.clear


### PR DESCRIPTION
## Status

- Closes [1300](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1300)

## What's changed?

This PR fixes an intermittent CI failure in the for_education:seed_a_school_with_lessons_and_students task spec where the test expected two projects but sometimes found four.

The debug output showed four lessons and four projects for the same seeded school, class, and creator. That points to the seed task being run twice in the same test context, rather than unrelated data leaking from another school.

There were two related issues:

1. Rake tasks are global within the test process. If tasks have already been loaded, calling Rails.application.load_tasks again can append duplicate actions to the same task. That means one task.invoke can execute the task body more than once depending on spec order.

2. The for_education seed tasks were not safely idempotent. They checked for an existing school using School.find_by(code: TEST_SCHOOL), but TEST_SCHOOL is the seeded school id. Once the school is verified, its code is changed to SCHOOL_CODE, so the guard did not detect that the seeded school already existed. A second task execution could therefore add another pair of randomly named lessons and projects.

The PR handles both sides of the problem:

- Resets rake tasks before each task spec, so a task does not accidentally run the same code twice.
- Checks whether the seed school already exists by its id, which is how we create it.
- Uses the correct way to stop early inside a rake task.
- Adds a test to make sure running the seed task twice does not create extra lessons or projects.
- Simplifies a few database queries in the cleanup task.