### PR TITLE
Stop transition failed errors

### DIFF
--- a/app/models/school_project.rb
+++ b/app/models/school_project.rb
@@ -40,7 +40,7 @@ class SchoolProject < ApplicationRecord
     state_machine.in_state?(:returned)
   end
 
-  delegate :can_transition_to?, :history, to: :state_machine
+  delegate :can_transition_to?, :history, :in_state?, to: :state_machine
 
   private
 

--- a/lib/concepts/school_project/set_status.rb
+++ b/lib/concepts/school_project/set_status.rb
@@ -6,11 +6,15 @@ class SchoolProject
       def call(school_project:, status:, user_id:)
         response = OperationResponse.new
         response[:school_project] = school_project
+
+        unless response[:school_project].can_transition_to?(status)
+          message = "Cannot transition from '#{response[:school_project].status}' to '#{status}'"
+          response[:error] = message
+          return response
+        end
+
         response[:school_project].transition_status_to!(status, user_id)
-        response
-      rescue StandardError => e
-        Sentry.capture_exception(e)
-        response[:error] = e.message
+
         response
       end
     end

--- a/lib/concepts/school_project/set_status.rb
+++ b/lib/concepts/school_project/set_status.rb
@@ -7,6 +7,8 @@ class SchoolProject
         response = OperationResponse.new
         response[:school_project] = school_project
 
+        return response if response[:school_project].in_state?(status)
+
         unless response[:school_project].can_transition_to?(status)
           message = "Cannot transition from '#{response[:school_project].status}' to '#{status}'"
           response[:error] = message
@@ -14,7 +16,6 @@ class SchoolProject
         end
 
         response[:school_project].transition_status_to!(status, user_id)
-
         response
       end
     end

--- a/lib/concepts/school_project/set_status.rb
+++ b/lib/concepts/school_project/set_status.rb
@@ -4,19 +4,21 @@ class SchoolProject
   class SetStatus
     class << self
       def call(school_project:, status:, user_id:)
-        response = OperationResponse.new
-        response[:school_project] = school_project
+        Statesman::Machine.retry_conflicts(1) do
+          response = OperationResponse.new
+          response[:school_project] = school_project
 
-        return response if response[:school_project].in_state?(status)
+          return response if school_project.in_state?(status)
 
-        unless response[:school_project].can_transition_to?(status)
-          message = "Cannot transition from '#{response[:school_project].status}' to '#{status}'"
-          response[:error] = message
-          return response
+          unless school_project.can_transition_to?(status)
+            message = "Cannot transition from '#{school_project.status}' to '#{status}'"
+            response[:error] = message
+            return response
+          end
+
+          school_project.transition_status_to!(status, user_id)
+          response
         end
-
-        response[:school_project].transition_status_to!(status, user_id)
-        response
       end
     end
   end

--- a/spec/concepts/school_project/set_status_spec.rb
+++ b/spec/concepts/school_project/set_status_spec.rb
@@ -36,5 +36,27 @@ RSpec.describe SchoolProject::SetStatus, type: :unit do
       expect(response.success?).to be(true)
       expect(school_project.status).to eq('submitted')
     end
+
+    it 'retries when transition raises a "Statesman::TransitionConflictError" error' do
+      call_count = 0
+      allow(school_project).to receive(:transition_status_to!).and_wrap_original do |original, *args|
+        call_count += 1
+        raise Statesman::TransitionConflictError if call_count == 1
+
+        original.call(*args)
+      end
+
+      response = described_class.call(school_project:, status: :submitted, user_id: student.id)
+      expect(response.success?).to be(true)
+      expect(school_project.status).to eq('submitted')
+    end
+
+    it 'raises the "Statesman::TransitionConflictError" error after 2 attempts' do
+      allow(school_project).to receive(:transition_status_to!).and_raise(Statesman::TransitionConflictError).twice
+
+      expect do
+        described_class.call(school_project:, status: :submitted, user_id: student.id)
+      end.to raise_error(Statesman::TransitionConflictError)
+    end
   end
 end

--- a/spec/concepts/school_project/set_status_spec.rb
+++ b/spec/concepts/school_project/set_status_spec.rb
@@ -27,7 +27,14 @@ RSpec.describe SchoolProject::SetStatus, type: :unit do
     it 'returns an error when transitioning to an invalid status' do
       response = described_class.call(school_project:, status: :returned, user_id: student.id)
       expect(response.success?).to be(false)
-      expect(response[:error]).to eq("Cannot transition from #{school_project.status} to returned")
+      expect(response[:error]).to eq("Cannot transition from '#{school_project.status}' to 'returned'")
+    end
+
+    it 'is successful when transitioning to the same status' do
+      school_project.transition_status_to!(:submitted, student.id)
+      response = described_class.call(school_project:, status: :submitted, user_id: student.id)
+      expect(response.success?).to be(true)
+      expect(school_project.status).to eq('submitted')
     end
   end
 end

--- a/spec/concepts/school_project/set_status_spec.rb
+++ b/spec/concepts/school_project/set_status_spec.rb
@@ -9,42 +9,25 @@ RSpec.describe SchoolProject::SetStatus, type: :unit do
   let(:school_project) { create(:school_project, school:, project:) }
 
   describe '.call' do
-    context 'when status transition is successful' do
-      it 'returns a successful operation response' do
-        response = described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(response.success?).to be(true)
-      end
-
-      it 'updates the school project status' do
-        described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(school_project.status).to eq('submitted')
-      end
-
-      it 'returns the updated school project in the response' do
-        response = described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(response[:school_project]).to be_a(SchoolProject)
-      end
+    it 'returns a successful operation response' do
+      response = described_class.call(school_project:, status: :submitted, user_id: student.id)
+      expect(response.success?).to be(true)
     end
 
-    context 'when status transition fails' do
-      before do
-        allow(school_project).to receive(:transition_status_to!).and_raise(StandardError, 'Transition failed')
-      end
+    it 'updates the school project status' do
+      described_class.call(school_project:, status: :submitted, user_id: student.id)
+      expect(school_project.status).to eq('submitted')
+    end
 
-      it 'returns a failed operation response' do
-        response = described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(response.success?).to be(false)
-      end
+    it 'returns the updated school project in the response' do
+      response = described_class.call(school_project:, status: :submitted, user_id: student.id)
+      expect(response[:school_project]).to be_a(SchoolProject)
+    end
 
-      it 'does not update the school project status' do
-        described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(school_project.status).to eq('unsubmitted')
-      end
-
-      it 'includes the error message in the response' do
-        response = described_class.call(school_project:, status: :submitted, user_id: student.id)
-        expect(response[:error]).to eq('Transition failed')
-      end
+    it 'returns an error when transitioning to an invalid status' do
+      response = described_class.call(school_project:, status: :returned, user_id: student.id)
+      expect(response.success?).to be(false)
+      expect(response[:error]).to eq("Cannot transition from #{school_project.status} to returned")
     end
   end
 end

--- a/spec/features/school_project/complete_spec.rb
+++ b/spec/features/school_project/complete_spec.rb
@@ -60,21 +60,6 @@ RSpec.describe 'School project complete requests', type: :request do
         expect(student_project.school_project).to be_complete
       end
     end
-
-    context 'when attempting an invalid status transition' do
-      before do
-        student_project.school_project.transition_status_to!(:complete, student.id)
-        post("/api/projects/#{student_project.identifier}/complete", headers:)
-      end
-
-      it 'completes unauthorized response' do
-        expect(response).to have_http_status(:unprocessable_content)
-      end
-
-      it 'completes error message' do
-        expect(JSON.parse(response.body)['error']).to eq("Cannot transition from 'complete' to 'complete'")
-      end
-    end
   end
 
   context 'when user does not own the project and is not the class teacher' do


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1310

## What's changed?

- Don't raise errors when projects are already in the state being transitioned to
- Don't `StandardError`, and instead handle the `Statesman::TransitionConflictError` by retrying and `Statesman::TransitionFailedError` by avoiding those transitions

See commits for more.
