### PR TITLE
Use Rails 7.2 defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'propshaft'
 gem 'puma', '~> 7.2'
 gem 'rack_content_type_default', '~> 1.1'
 gem 'rack-cors'
-gem 'rails', '~> 7.1'
+gem 'rails', '~> 7.2'
 gem 'ruby-progressbar', '~> 1.13', require: false
 gem 'sentry-rails'
 gem 'statesman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ DEPENDENCIES
   puma (~> 7.2)
   rack-cors
   rack_content_type_default (~> 1.1)
-  rails (~> 7.1)
+  rails (~> 7.2)
   rails-erd
   rspec
   rspec-rails

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+# explicit rubocop config increases performance slightly while avoiding config confusion.
+ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
+
+load Gem.bin_path("rubocop", "rubocop")

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ Bundler.require(*Rails.groups)
 
 module App
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
     config.add_autoload_paths_to_load_path = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ Bundler.require(*Rails.groups)
 module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     config.add_autoload_paths_to_load_path = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,19 +82,6 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
Split out of #784 

You can see new settings at [1], they all seem safe for us to switch to.

This is in preparation for upgrading to Rails 8 and later using those defaults.

I'll monitor RAM usage in Heroku after deploying because of the YJIT change.

[1] https://redirect.github.com/rails/rails/blob/v7.2.3.1/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt