### PR TITLE
Use new cached project count column (part 2 of 2)

### DIFF
--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -9,16 +9,16 @@ module Api
     load_and_authorize_resource :lesson
 
     def index
-      accessible_lessons = filtered_lessons_scope
-                           .accessible_by(current_ability)
-                           .includes(project: :remixes)
-      @lessons_with_users = accessible_lessons.with_users
+      accessible_lessons = filtered_lessons_scope.accessible_by(current_ability)
 
       if current_user&.school_teacher?(school) || current_user&.school_owner?(school)
+        accessible_lessons = accessible_lessons.includes(:project)
+        @lessons_with_users = accessible_lessons.with_users
         render :teacher_index, formats: [:json], status: :ok
       else
         remixes = user_remixes(accessible_lessons)
-        @lessons_with_users_and_remixes = @lessons_with_users.zip(remixes)
+        accessible_lessons = accessible_lessons.includes(project: :remixes)
+        @lessons_with_users_and_remixes = accessible_lessons.with_users.zip(remixes)
         render :student_index, formats: [:json], status: :ok
       end
     end

--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -131,7 +131,7 @@ module Api
 
     def accessible_school_classes
       if current_user&.school_teacher?(@school) || current_user&.school_owner?(@school)
-        @school.classes.accessible_by(current_ability).includes(lessons: { project: { remixes: { school_project: :school_project_transitions } } })
+        @school.classes.accessible_by(current_ability).includes(:lessons)
       else
         @school.classes.accessible_by(current_ability)
       end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -34,12 +34,6 @@ class Lesson < ApplicationRecord
     [self, User.from_userinfo(ids: user_id).first]
   end
 
-  def submitted_count
-    return 0 unless project
-
-    project.remixes.count { |remix| remix.school_project&.submitted? }
-  end
-
   def recalculate_submitted_projects_count!
     with_lock do
       count = school_projects.in_state(:submitted).count

--- a/app/models/school_class.rb
+++ b/app/models/school_class.rb
@@ -58,19 +58,8 @@ class SchoolClass < ApplicationRecord
     errors.add(:code, 'could not be generated')
   end
 
-  def submitted_count
-    return 0 if lessons.empty?
-
-    Lesson
-      .joins(project: { remixes: { school_project: :school_project_transitions } })
-      .where(school_class_id: id)
-      .where(
-        school_project_transitions: {
-          to_state: 'submitted',
-          most_recent: true
-        }
-      )
-      .count
+  def submitted_projects_count
+    lessons.to_a.sum(&:submitted_projects_count)
   end
 
   private

--- a/app/views/api/lessons/teacher_index.json.jbuilder
+++ b/app/views/api/lessons/teacher_index.json.jbuilder
@@ -2,5 +2,5 @@
 
 json.array!(@lessons_with_users) do |lesson, user|
   json.partial! 'lesson', lesson: lesson, user: user
-  json.submitted_count(lesson.submitted_count)
+  json.submitted_count(lesson.submitted_projects_count)
 end

--- a/app/views/api/school_classes/teacher_index.json.jbuilder
+++ b/app/views/api/school_classes/teacher_index.json.jbuilder
@@ -3,5 +3,5 @@
 json.array!(@school_classes_with_teachers) do |school_class, teachers|
   json.partial! 'school_class', school_class: school_class, teachers: teachers
 
-  json.submitted_count(school_class.submitted_count)
+  json.submitted_count(school_class.submitted_projects_count)
 end

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -86,14 +86,12 @@ RSpec.describe 'Listing lessons', type: :request do
   end
 
   it 'includes the submitted_count for each lesson' do
-    lesson.update!(school_class_id: school_class.id)
-    remix = create(:project, school:, remixed_from_id: lesson.project.id, user_id: student.id)
-    remix.school_project.transition_status_to!(:submitted, student.id)
+    lesson.update!(school_class_id: school_class.id, submitted_projects_count: 17)
 
     get("/api/lessons?school_class_id=#{school_class.id}", headers:)
     data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data.first[:submitted_count]).to eq(1)
+    expect(data.first[:submitted_count]).to eq(17)
   end
 
   context 'when filtering by project_identifier' do

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -206,28 +206,6 @@ RSpec.describe Lesson do
     end
   end
 
-  describe '#submitted_count' do
-    it 'returns 0 if there is no project' do
-      lesson = create(:lesson, project: nil)
-      expect(lesson.submitted_count).to eq(0)
-    end
-
-    it 'returns the count of submitted remixes of the lesson project' do
-      student = create(:student, school:)
-      lesson = create(:lesson, school:, user_id: teacher.id)
-
-      remix_1 = create(:project, school:, remixed_from_id: lesson.project.id, user_id: student.id)
-      remix_1.school_project.transition_status_to!(:submitted, remix_1.user_id)
-
-      remix_2 = create(:project, school:, remixed_from_id: lesson.project.id, user_id: student.id)
-      remix_2.school_project.transition_status_to!(:submitted, remix_2.user_id)
-
-      create(:project, school:, remixed_from_id: lesson.project.id, user_id: student.id) # Not submitted
-
-      expect(lesson.submitted_count).to eq(2)
-    end
-  end
-
   describe '#recalculate_submitted_projects_count!' do
     it 'sets the submitted projects count to 0 if there is no project' do
       lesson = create(:lesson, project: nil, submitted_projects_count: 3)

--- a/spec/models/school_class_spec.rb
+++ b/spec/models/school_class_spec.rb
@@ -262,26 +262,19 @@ RSpec.describe SchoolClass, :versioning do
     end
   end
 
-  describe '#submitted_count' do
+  describe '#submitted_projects_count' do
     it 'returns 0 if there are no lessons' do
       school_class = create(:school_class, teacher_ids: [teacher.id], school:)
-      expect(school_class.submitted_count).to eq(0)
+      expect(school_class.submitted_projects_count).to eq(0)
     end
 
     it 'returns the sum of submitted counts from all lessons' do
       school_class = create(:school_class, teacher_ids: [teacher.id], school:)
 
-      lesson_1 = create(:lesson, school_class:, user_id: teacher.id)
-      remix_1 = create(:project, school:, remixed_from_id: lesson_1.project.id, user_id: student.id)
-      remix_1.school_project.transition_status_to!(:submitted, remix_1.user_id)
+      create(:lesson, school_class:, user_id: teacher.id, submitted_projects_count: 5)
+      create(:lesson, school_class:, user_id: teacher.id, submitted_projects_count: 3)
 
-      lesson_2 = create(:lesson, school_class:, user_id: teacher.id)
-      remix_2 = create(:project, school:, remixed_from_id: lesson_2.project.id, user_id: student.id)
-      remix_2.school_project.transition_status_to!(:submitted, remix_2.user_id)
-      remix_3 = create(:project, school:, remixed_from_id: lesson_2.project.id, user_id: student.id)
-      remix_3.school_project.transition_status_to!(:submitted, remix_3.user_id)
-
-      expect(school_class.submitted_count).to eq(3)
+      expect(school_class.submitted_projects_count).to eq(8)
     end
   end
 


### PR DESCRIPTION


**MUST BE DEPLOYED AFTER #804** 

## Status

Related to: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1313
Follows on from: https://github.com/RaspberryPiFoundation/editor-api/pull/804


## What's changed?

In [part 1 ](https://github.com/RaspberryPiFoundation/editor-api/pull/804 )we started caching the value of submitted projects. Now we can use that value to simplify the code and reduce N+1 queries.
