### PR TITLE
Only handle requests via HOST_URL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,10 +86,10 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    URI.parse(ENV.fetch('HOST_URL')).host
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/editor-api/issues/533

## Points for consideration:

This does not make any allowances for preview deployments, however preview deployments are currently not working for other reasons. Once they are, we should add them to the allow-list.

## What's changed?

- Uses the `HOST_URL` value for `config.hosts` in production configuration, which means the server will reject requests where the `Host` header doesn't match `HOST_URL`. This will prevent the API being accessed via `editor-xyz.herokuapp.com` domains.


