### PR TITLE
Make profile api client more robust

### DIFF
--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -7,7 +7,6 @@ class ProfileApiClient
   }.freeze
 
   # rubocop:disable Naming/MethodName
-  SafeguardingFlag = Data.define(:id, :userId, :schoolId, :flag, :email, :createdAt, :updatedAt, :discardedAt)
   Student = Data.define(:id, :schoolId, :name, :username, :createdAt, :updatedAt, :discardedAt, :email, :ssoProviders)
   # rubocop:enable Naming/MethodName
 
@@ -187,15 +186,6 @@ class ProfileApiClient
 
       unauthorized!(response)
       raise UnexpectedResponse, response unless response.status == 204
-    end
-
-    def safeguarding_flags(token:)
-      response = connection(token).get('/api/v1/safeguarding-flags')
-
-      unauthorized!(response)
-      raise UnexpectedResponse, response unless response.status == 200
-
-      response.body.map { |flag| SafeguardingFlag.new(**flag.symbolize_keys) }
     end
 
     def create_safeguarding_flag(token:, flag:, email:, school_id:)

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -7,7 +7,6 @@ class ProfileApiClient
   }.freeze
 
   # rubocop:disable Naming/MethodName
-  School = Data.define(:id, :schoolCode, :studentEmailDomains, :updatedAt, :createdAt, :discardedAt)
   SafeguardingFlag = Data.define(:id, :userId, :schoolId, :flag, :email, :createdAt, :updatedAt, :discardedAt)
   Student = Data.define(:id, :schoolId, :name, :username, :createdAt, :updatedAt, :discardedAt, :email, :ssoProviders)
   # rubocop:enable Naming/MethodName
@@ -65,7 +64,7 @@ class ProfileApiClient
       unauthorized!(response)
       raise UnexpectedResponse, response unless response.status == 201
 
-      School.new(**response.body)
+      true
     end
 
     def school_student(token:, school_id:, student_id:)
@@ -227,7 +226,7 @@ class ProfileApiClient
       unauthorized!(response)
       raise UnexpectedResponse, response unless response.status == 200
 
-      School.new(**response.body)
+      true
     end
 
     private

--- a/lib/profile_api_client.rb
+++ b/lib/profile_api_client.rb
@@ -255,7 +255,9 @@ class ProfileApiClient
       symbolized_attrs[:email] ||= nil
       symbolized_attrs[:ssoProviders] ||= []
 
-      Student.new(**symbolized_attrs)
+      allowed_keys = ProfileApiClient::Student.members
+
+      Student.new(**symbolized_attrs.slice(*allowed_keys))
     end
 
     def unauthorized!(response)

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -104,43 +104,6 @@ RSpec.describe ProfileApiClient do
     end
   end
 
-  describe '.safeguarding_flags' do
-    subject(:safeguarding_flags_response) { list_safeguarding_flags }
-
-    let(:list_safeguarding_flags_url) { "#{api_url}/api/v1/safeguarding-flags" }
-
-    before do
-      stub_request(:get, list_safeguarding_flags_url).to_return(status: 200, body: '[]', headers: { 'content-type' => 'application/json' })
-    end
-
-    it_behaves_like 'an authenticated API request', :get, url: -> { list_safeguarding_flags_url }
-    it_behaves_like 'a request that handles standard HTTP errors', :get, url: -> { list_safeguarding_flags_url }
-    it_behaves_like 'a request that handles an unexpected response status', :get, url: -> { list_safeguarding_flags_url }, status: 201
-
-    it 'returns list of safeguarding flags if successful' do
-      flag = {
-        id: '7ac79585-e187-4d2f-bf0c-a1cbe72ecc9a',
-        userId: '583ba872-b16e-46e1-9f7d-df89d267550d',
-        flag: 'school:owner',
-        email: 'user@example.com',
-        createdAt: '2024-07-01T12:49:18.926Z',
-        updatedAt: '2024-07-01T12:49:18.926Z',
-        discardedAt: nil,
-        schoolId: SecureRandom.uuid
-      }
-      expected = ProfileApiClient::SafeguardingFlag.new(**flag)
-      stub_request(:get, list_safeguarding_flags_url)
-        .to_return(status: 200, body: [flag].to_json, headers: { 'content-type' => 'application/json' })
-      expect(safeguarding_flags_response).to eq([expected])
-    end
-
-    private
-
-    def list_safeguarding_flags
-      described_class.safeguarding_flags(token:)
-    end
-  end
-
   describe '.create_safeguarding_flag' do
     subject(:create_safeguarding_flag_response) { create_safeguarding_flag }
 

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -515,6 +515,15 @@ RSpec.describe ProfileApiClient do
       expect(school_student_response).to eq(expected)
     end
 
+    it 'returns student even if response contains unexpected keys' do
+      data = { id: student_id, schoolId: school.id, name: 'name', username: 'username', email: 'test@example.com', ssoProviders: [], createdAt: '', updatedAt: '', discardedAt: '' }
+      response = data.merge({ unexpectedKey: 'unexpectedValue' })
+      expected = ProfileApiClient::Student.new(**data)
+      stub_request(:get, student_url)
+        .to_return(status: 200, body: response.to_json, headers: { 'content-type' => 'application/json' })
+      expect(school_student_response).to eq(expected)
+    end
+
     private
 
     def school_student

--- a/spec/lib/profile_api_client_spec.rb
+++ b/spec/lib/profile_api_client_spec.rb
@@ -73,13 +73,12 @@ RSpec.describe ProfileApiClient do
       expect(WebMock).to have_requested(:post, create_school_url).with(body: expected_body)
     end
 
-    it 'returns the created school if successful' do
+    it 'returns true if successful' do
       data = { id: 'id', schoolCode: 'code', updatedAt: '2024-07-09T10:31:13.196Z', createdAt: '2024-07-09T10:31:13.196Z', discardedAt: nil,
                studentEmailDomains: [] }
-      expected = ProfileApiClient::School.new(**data)
       stub_request(:post, create_school_url)
         .to_return(status: 201, body: data.to_json, headers: { 'Content-Type' => 'application/json' })
-      expect(create_school_response).to eq(expected)
+      expect(create_school_response).to be(true)
     end
 
     describe 'when BYPASS_OAUTH is true' do
@@ -586,13 +585,12 @@ RSpec.describe ProfileApiClient do
       expect(WebMock).to have_requested(:patch, update_school_email_domains_url).with(body: expected_body)
     end
 
-    it 'returns a school if successful' do
+    it 'returns true if successful' do
       data = { id: 'id', schoolCode: 'code', updatedAt: '2024-07-09T10:31:13.196Z', createdAt: '2024-07-09T10:31:13.196Z', discardedAt: nil,
                studentEmailDomains: school_email_domains }
-      expected = ProfileApiClient::School.new(**data)
       stub_request(:patch, update_school_email_domains_url)
         .to_return(status: 200, body: data.to_json, headers: { 'Content-Type' => 'application/json' })
-      expect(update_school_email_domains_response).to eq(expected)
+      expect(update_school_email_domains_response).to be(true)
     end
 
     describe 'when BYPASS_OAUTH is true' do

--- a/spec/support/profile_api_mock.rb
+++ b/spec/support/profile_api_mock.rb
@@ -30,18 +30,8 @@ module ProfileApiMock
     allow(ProfileApiClient).to receive(:create_school_student).and_return(created: [user_id])
   end
 
-  def stub_profile_api_create_school(id: SecureRandom.uuid, code: '99-12-34', student_email_domains: [])
-    now = Time.current.to_fs(:iso8601) # rubocop:disable Naming/VariableNumber
-    allow(ProfileApiClient).to receive(:create_school).and_return(
-      ProfileApiClient::School.new(
-        id:,
-        schoolCode: code,
-        studentEmailDomains: student_email_domains,
-        updatedAt: now,
-        createdAt: now,
-        discardedAt: nil
-      )
-    )
+  def stub_profile_api_create_school
+    allow(ProfileApiClient).to receive(:create_school).and_return(true)
   end
 
   def stub_profile_api_create_school_students(user_ids: [SecureRandom.uuid])


### PR DESCRIPTION
## Status

- Related to this error on production - https://raspberrypifoundation.slack.com/archives/C09PC0EKG13/p1779198884095679

## What's changed?

The error was caused by editor-api erroring when unexpected keys were added in the profile API response.

I think generally JSON APIs should be able to add more attributes without breaking clients.

- Remove the profile API response objects that aren't used
- Remove profile API `safeguarding_flags` methods that aren't used
- Make profile API response succeed even if new keys are added.

See commits for more