### PR TITLE
Foreign-key dependent fix Project assets, causing issue in reseed task and endpoint (integration)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,6 +14,7 @@ class Project < ApplicationRecord
   has_many :remixes, dependent: :nullify, class_name: :Project, foreign_key: :remixed_from_id, inverse_of: :parent
   has_many :components, -> { order(default: :desc, name: :asc) }, dependent: :destroy, inverse_of: :project
   has_one :scratch_component, dependent: :destroy, inverse_of: :project, required: false
+  has_many :scratch_assets, dependent: :destroy
   has_many :project_errors, dependent: :nullify
   has_many_attached :images
   has_many_attached :videos

--- a/spec/lib/test_seeds_spec.rb
+++ b/spec/lib/test_seeds_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'test_seeds', type: :task do
   describe ':destroy' do
     let(:task) { Rake::Task['test_seeds:destroy'] }
     let(:school) { create(:school, creator_id:, id: school_id) }
+    let(:scratch_project_id) { ScratchAsset.first.project_id }
 
     before do
       create(:role, user_id: creator_id, school:)
@@ -23,10 +24,11 @@ RSpec.describe 'test_seeds', type: :task do
       lesson = create(:lesson, school_id: school.id, user_id: creator_id)
       lesson.project.update!(project_type: Project::Types::CODE_EDITOR_SCRATCH)
       create(:scratch_asset, project: lesson.project)
-      @scratch_project_id = lesson.project.id
     end
 
     it 'destroys all seed data' do
+      scratch_project_id
+
       task.invoke
       expect(Role.where(user_id: [creator_id, teacher_id, student_1, student_2])).not_to exist
       expect(School.where(creator_id:)).not_to exist
@@ -34,7 +36,7 @@ RSpec.describe 'test_seeds', type: :task do
       expect(SchoolClass.where(school_id: school.id)).not_to exist
       expect(Lesson.where(school_id: school.id)).not_to exist
       expect(Project.where(school_id: school.id)).not_to exist
-      expect(ScratchAsset.where(project_id: @scratch_project_id)).not_to exist
+      expect(ScratchAsset.where(project_id: scratch_project_id)).not_to exist
     end
   end
 

--- a/spec/lib/test_seeds_spec.rb
+++ b/spec/lib/test_seeds_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe 'test_seeds', type: :task do
       create(:teacher_role, user_id: creator_id, school:)
       school_class = create(:school_class, school_id: school.id, teacher_ids: [creator_id])
       create(:class_student, student_id: student_1, school_class_id: school_class.id)
-      create(:lesson, school_id: school.id, user_id: creator_id)
+      lesson = create(:lesson, school_id: school.id, user_id: creator_id)
+      lesson.project.update!(project_type: Project::Types::CODE_EDITOR_SCRATCH)
+      create(:scratch_asset, project: lesson.project)
+      @scratch_project_id = lesson.project.id
     end
 
     it 'destroys all seed data' do
@@ -31,6 +34,7 @@ RSpec.describe 'test_seeds', type: :task do
       expect(SchoolClass.where(school_id: school.id)).not_to exist
       expect(Lesson.where(school_id: school.id)).not_to exist
       expect(Project.where(school_id: school.id)).not_to exist
+      expect(ScratchAsset.where(project_id: @scratch_project_id)).not_to exist
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Project, :versioning do
     it { is_expected.to belong_to(:parent).optional(true) }
     it { is_expected.to have_many(:remixes).dependent(:nullify) }
     it { is_expected.to have_many(:components) }
+    it { is_expected.to have_many(:scratch_assets).dependent(:destroy) }
     it { is_expected.to have_many(:project_errors).dependent(:nullify) }
     it { is_expected.to have_many_attached(:images) }
     it { is_expected.to have_many_attached(:videos) }


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1419

## Points for consideration:

- Security
- Performance

## What's changed?

Fix /test/reseed failures caused by Scratch project assets blocking seeded project cleanup.
The test seed destroy task removes seeded lesson projects with Project.destroy_all, but project-scoped ScratchAsset records still referenced those projects.

Added a test and found is red with same error as sentry.

I only wonder here maybe if we want to make dependent :destroy or dependent nullify. (I guess this doesn't happen manually but it's worht to think if we would like to solve it in other way)