### PR TITLE
 Fix missing authorization check before REST project remix creation

### DIFF
--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -25,6 +25,8 @@ module Api
       end
 
       def create
+        authorize! :show, project
+
         # Ensure we have a fallback value to prevent bad requests
         remix_origin = request.origin || request.referer
         result = Project::CreateRemix.call(params: remix_params,

--- a/spec/requests/projects/remix_spec.rb
+++ b/spec/requests/projects/remix_spec.rb
@@ -168,6 +168,49 @@ RSpec.describe 'Remix requests' do
         expect(response).to have_http_status(:not_found)
       end
 
+      context 'when the original project belongs to another user' do
+        let!(:original_project) { create(:project, user_id: create(:user).id) }
+
+        it 'returns forbidden without creating a remix' do
+          allow(Project::CreateRemix).to receive(:call).and_call_original
+
+          expect do
+            post("/api/projects/#{original_project.identifier}/remix", params: { project: project_params }, headers:)
+          end.not_to change(Project, :count)
+
+          expect(response).to have_http_status(:forbidden)
+          expect(Project::CreateRemix).not_to have_received(:call)
+        end
+      end
+
+      context 'when a student cannot view the teacher-only original project' do
+        let(:student) { create(:student, school:) }
+        let(:teacher) { create(:teacher, school:) }
+        let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }
+        let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'teachers') }
+        let!(:original_project) do
+          lesson.project.tap do |project|
+            project.update!(school:, user_id: teacher.id, instructions: 'Teacher-only instructions')
+          end
+        end
+
+        before do
+          create(:class_student, school_class:, student_id: student.id)
+          authenticated_in_hydra_as(student)
+        end
+
+        it 'returns forbidden without creating a remix' do
+          allow(Project::CreateRemix).to receive(:call).and_call_original
+
+          expect do
+            post("/api/projects/#{original_project.identifier}/remix", params: { project: project_params }, headers:)
+          end.not_to change(Project, :count)
+
+          expect(response).to have_http_status(:forbidden)
+          expect(Project::CreateRemix).not_to have_received(:call)
+        end
+      end
+
       context 'when project cannot be saved' do
         before do
           authenticated_in_hydra_as(owner)


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1468

### Why

  The REST project remix endpoint authenticated the caller but did not verify that the caller could view the original project before cloning it. That meant a user who knew a project
  identifier could create a remix from a project they were not authorized to read.

  This now aligns the REST remix flow with the existing Scratch and GraphQL remix authorization behavior.

### What Changed

  - Added an explicit authorize! :show, project check before Project::CreateRemix.call.
  - Added regression coverage for:
      - remixing another user’s private project
      - a student remixing a teacher-only lesson project they cannot view
  - The regression specs assert the request is forbidden, no remix is created, and the clone operation is not called.

_Follow-up: consider enabling CanCanCan check_authorization at the API controller layer so missing authorization becomes fail-closed by default. This should be handled separately because it requires auditing existing controllers and adding explicit skip_authorization_check for intentionally public or non-CanCan endpoints._
