### PR TITLE
Ensure safeguarding flags before Profile student calls

### DIFF
--- a/app/controllers/api/school_members_controller.rb
+++ b/app/controllers/api/school_members_controller.rb
@@ -6,8 +6,6 @@ module Api
     load_and_authorize_resource :school
     authorize_resource :school_member, class: false
 
-    before_action :create_safeguarding_flags
-
     def index
       result = SchoolMember::List.call(school: @school, token: current_user.token)
 
@@ -17,35 +15,6 @@ module Api
       else
         render json: { error: result[:error] }, status: :unprocessable_content
       end
-    end
-
-    private
-
-    def create_safeguarding_flags
-      create_teacher_safeguarding_flag
-      create_owner_safeguarding_flag
-    end
-
-    def create_teacher_safeguarding_flag
-      return unless current_user.school_teacher?(@school)
-
-      ProfileApiClient.create_safeguarding_flag(
-        token: current_user.token,
-        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
-        email: current_user.email,
-        school_id: @school.id
-      )
-    end
-
-    def create_owner_safeguarding_flag
-      return unless current_user.school_owner?(@school)
-
-      ProfileApiClient.create_safeguarding_flag(
-        token: current_user.token,
-        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner],
-        email: current_user.email,
-        school_id: @school.id
-      )
     end
   end
 end

--- a/app/controllers/api/school_students_controller.rb
+++ b/app/controllers/api/school_students_controller.rb
@@ -10,8 +10,6 @@ module Api
     load_and_authorize_resource :school
     authorize_resource :school_student, class: false
 
-    before_action :create_safeguarding_flags
-
     def index
       result = SchoolStudent::List.call(school: @school, token: current_user.token)
 
@@ -182,33 +180,6 @@ module Api
 
     def student_ids_params
       params.fetch(:student_ids, [])
-    end
-
-    def create_safeguarding_flags
-      create_teacher_safeguarding_flag
-      create_owner_safeguarding_flag
-    end
-
-    def create_teacher_safeguarding_flag
-      return unless current_user.school_teacher?(@school)
-
-      ProfileApiClient.create_safeguarding_flag(
-        token: current_user.token,
-        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
-        email: current_user.email,
-        school_id: @school.id
-      )
-    end
-
-    def create_owner_safeguarding_flag
-      return unless current_user.school_owner?(@school)
-
-      ProfileApiClient.create_safeguarding_flag(
-        token: current_user.token,
-        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner],
-        email: current_user.email,
-        school_id: @school.id
-      )
     end
   end
 end

--- a/app/controllers/concerns/identifiable.rb
+++ b/app/controllers/concerns/identifiable.rb
@@ -13,6 +13,8 @@ module Identifiable
     return unless token
 
     @current_user = User.from_token(token:)
+    return unless RequestStore.respond_to?(:active?) && RequestStore.active?
+
     RequestStore.store[:safeguarding_flag_users_by_token] ||= {}
     RequestStore.store[:safeguarding_flag_users_by_token][token] = @current_user
   end

--- a/app/controllers/concerns/identifiable.rb
+++ b/app/controllers/concerns/identifiable.rb
@@ -10,6 +10,10 @@ module Identifiable
 
   def load_current_user
     token = request.headers['Authorization']
-    @current_user = User.from_token(token:) if token
+    return unless token
+
+    @current_user = User.from_token(token:)
+    RequestStore.store[:safeguarding_flag_users_by_token] ||= {}
+    RequestStore.store[:safeguarding_flag_users_by_token][token] = @current_user
   end
 end

--- a/app/controllers/concerns/identifiable.rb
+++ b/app/controllers/concerns/identifiable.rb
@@ -10,9 +10,10 @@ module Identifiable
 
   def load_current_user
     token = request.headers['Authorization']
-    return unless token
+    return if token.blank?
 
     @current_user = User.from_token(token:)
+    return if @current_user.blank?
     return unless RequestStore.respond_to?(:active?) && RequestStore.active?
 
     RequestStore.store[:safeguarding_flag_users_by_token] ||= {}

--- a/app/jobs/create_students_job.rb
+++ b/app/jobs/create_students_job.rb
@@ -31,7 +31,9 @@ class CreateStudentsJob < ApplicationJob
   end
 
   def perform(school_id:, students:, token:)
+    school = School.find(school_id)
     decrypted_students = StudentHelpers.decrypt_students(students)
+    SafeguardingFlagService.create_for_token(token:, school:)
     responses = ProfileApiClient.create_school_students(token:, students: decrypted_students, school_id:)
     return if responses[:created].blank?
 

--- a/app/services/safeguarding_flag_service.rb
+++ b/app/services/safeguarding_flag_service.rb
@@ -15,7 +15,7 @@ class SafeguardingFlagService
     def create_for_token(token:, school:)
       return if token.blank? || school.blank?
 
-      create_for_school_roles(user: User.from_token(token:), school:)
+      create_for_school_roles(user: user_for_token(token), school:)
     end
 
     def create_for_roles(token:, email:, school:, roles:)
@@ -32,6 +32,15 @@ class SafeguardingFlagService
           school_id: school.id
         )
       end
+    end
+
+    private
+
+    def user_for_token(token)
+      cache = RequestStore.store[:safeguarding_flag_users_by_token] ||= {}
+      return cache[token] if cache.key?(token)
+
+      cache[token] = User.from_token(token:)
     end
   end
 end

--- a/app/services/safeguarding_flag_service.rb
+++ b/app/services/safeguarding_flag_service.rb
@@ -37,10 +37,16 @@ class SafeguardingFlagService
     private
 
     def user_for_token(token)
+      return User.from_token(token:) unless request_store_active?
+
       cache = RequestStore.store[:safeguarding_flag_users_by_token] ||= {}
       return cache[token] if cache.key?(token)
 
       cache[token] = User.from_token(token:)
+    end
+
+    def request_store_active?
+      RequestStore.respond_to?(:active?) && RequestStore.active?
     end
   end
 end

--- a/app/services/safeguarding_flag_service.rb
+++ b/app/services/safeguarding_flag_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class SafeguardingFlagService
+  class << self
+    def create_for_school_roles(user:, school:)
+      return if user.blank? || school.blank?
+
+      roles = []
+      roles << :teacher if user.school_teacher?(school)
+      roles << :owner if user.school_owner?(school)
+
+      create_for_roles(token: user.token, email: user.email, school:, roles:)
+    end
+
+    def create_for_token(token:, school:)
+      return if token.blank? || school.blank?
+
+      create_for_school_roles(user: User.from_token(token:), school:)
+    end
+
+    def create_for_roles(token:, email:, school:, roles:)
+      return if token.blank? || email.blank? || school.blank?
+
+      Array(roles).each do |role|
+        flag = ProfileApiClient::SAFEGUARDING_FLAGS[role.to_sym]
+        next if flag.blank?
+
+        ProfileApiClient.create_safeguarding_flag(
+          token:,
+          flag:,
+          email:,
+          school_id: school.id
+        )
+      end
+    end
+  end
+end

--- a/app/services/safeguarding_flag_service.rb
+++ b/app/services/safeguarding_flag_service.rb
@@ -5,11 +5,7 @@ class SafeguardingFlagService
     def create_for_school_roles(user:, school:)
       return if user.blank? || school.blank?
 
-      roles = []
-      roles << :teacher if user.school_teacher?(school)
-      roles << :owner if user.school_owner?(school)
-
-      create_for_roles(token: user.token, email: user.email, school:, roles:)
+      create_for_roles(token: user.token, email: user.email, school:, roles: user.school_roles(school))
     end
 
     def create_for_token(token:, school:)

--- a/app/services/student_removal_service.rb
+++ b/app/services/student_removal_service.rb
@@ -12,6 +12,8 @@ class StudentRemovalService
   def remove_students
     results = []
 
+    ensure_safeguarding_flag if remove_from_profile?
+
     @students.each do |user_id|
       student_roles = Role.student.where(user_id:, school_id: @school.id)
       if student_roles.empty?
@@ -21,8 +23,6 @@ class StudentRemovalService
 
       result = { user_id: }
       begin
-        ensure_safeguarding_flag if remove_from_profile?
-
         ActiveRecord::Base.transaction do
           # Delete all projects for this user
           projects = Project.where(user_id: user_id)
@@ -53,10 +53,7 @@ class StudentRemovalService
   end
 
   def ensure_safeguarding_flag
-    return if @safeguarding_flag_created
-
     SafeguardingFlagService.create_for_token(token: @token, school: @school)
-    @safeguarding_flag_created = true
   end
 
   def remove_from_profile?

--- a/app/services/student_removal_service.rb
+++ b/app/services/student_removal_service.rb
@@ -21,6 +21,8 @@ class StudentRemovalService
 
       result = { user_id: }
       begin
+        ensure_safeguarding_flag if remove_from_profile?
+
         ActiveRecord::Base.transaction do
           # Delete all projects for this user
           projects = Project.where(user_id: user_id)
@@ -47,7 +49,6 @@ class StudentRemovalService
   private
 
   def delete_from_profile(user_id)
-    ensure_safeguarding_flag
     ProfileApiClient.delete_school_student(token: @token, school_id: @school.id, student_id: user_id)
   end
 

--- a/app/services/student_removal_service.rb
+++ b/app/services/student_removal_service.rb
@@ -34,7 +34,10 @@ class StudentRemovalService
           student_roles.destroy_all
 
           # Remove from profile if requested - inside transaction so it can be rolled back
-          ProfileApiClient.delete_school_student(token: @token, school_id: @school.id, student_id: user_id) if @remove_from_profile && @token.present?
+          if @remove_from_profile && @token.present?
+            SafeguardingFlagService.create_for_token(token: @token, school: @school)
+            ProfileApiClient.delete_school_student(token: @token, school_id: @school.id, student_id: user_id)
+          end
         end
       rescue StandardError => e
         result[:error] = "#{e.class}: #{e.message}"

--- a/app/services/student_removal_service.rb
+++ b/app/services/student_removal_service.rb
@@ -33,11 +33,8 @@ class StudentRemovalService
           # Remove roles
           student_roles.destroy_all
 
-          # Remove from profile if requested - inside transaction so it can be rolled back
-          if @remove_from_profile && @token.present?
-            SafeguardingFlagService.create_for_token(token: @token, school: @school)
-            ProfileApiClient.delete_school_student(token: @token, school_id: @school.id, student_id: user_id)
-          end
+          # Keep local DB changes uncommitted until Profile confirms deletion.
+          delete_from_profile(user_id) if remove_from_profile?
         end
       rescue StandardError => e
         result[:error] = "#{e.class}: #{e.message}"
@@ -45,5 +42,23 @@ class StudentRemovalService
       results << result
     end
     results
+  end
+
+  private
+
+  def delete_from_profile(user_id)
+    ensure_safeguarding_flag
+    ProfileApiClient.delete_school_student(token: @token, school_id: @school.id, student_id: user_id)
+  end
+
+  def ensure_safeguarding_flag
+    return if @safeguarding_flag_created
+
+    SafeguardingFlagService.create_for_token(token: @token, school: @school)
+    @safeguarding_flag_created = true
+  end
+
+  def remove_from_profile?
+    @remove_from_profile && @token.present?
   end
 end

--- a/lib/concepts/class_member/operations/list.rb
+++ b/lib/concepts/class_member/operations/list.rb
@@ -10,7 +10,13 @@ module ClassMember
         begin
           school = school_class.school
           student_ids = class_students.pluck(:student_id)
-          students = SchoolStudent::List.call(school:, token:, student_ids:).fetch(:school_students, [])
+          students_response = SchoolStudent::List.call(school:, token:, student_ids:)
+          if students_response.failure?
+            response[:error] = students_response[:error]
+            return response
+          end
+
+          students = students_response.fetch(:school_students, [])
           class_students.each do |member|
             member.student = students.find { |student| student.id == member.student_id }
           end

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -42,9 +42,9 @@ module SchoolMember
       private
 
       def fetch_students(school:, token:)
-        student_roles = Role.student.where(school:)
+        return OperationResponse[school_students: []] unless Role.student.exists?(school:)
 
-        student_roles.any? ? SchoolStudent::List.call(school:, token:) : OperationResponse[school_students: []]
+        SchoolStudent::List.call(school:, token:)
       end
 
       def build_student_members(students)

--- a/lib/concepts/school_member/list.rb
+++ b/lib/concepts/school_member/list.rb
@@ -15,7 +15,13 @@ module SchoolMember
         response[:school_members] = []
 
         begin
-          students = fetch_students(school:, token:)
+          students_response = fetch_students(school:, token:)
+          if students_response.failure?
+            response[:error] = students_response[:error]
+            return response
+          end
+
+          students = build_student_members(students_response.fetch(:school_students, []))
           teachers = fetch_teachers(school:)
           owners = fetch_owners(school:)
 
@@ -38,9 +44,11 @@ module SchoolMember
       def fetch_students(school:, token:)
         student_roles = Role.student.where(school:)
 
-        students_response = student_roles.any? ? SchoolStudent::List.call(school:, token:).fetch(:school_students, []) : []
+        student_roles.any? ? SchoolStudent::List.call(school:, token:) : OperationResponse[school_students: []]
+      end
 
-        students_response.map do |student|
+      def build_student_members(students)
+        students.map do |student|
           SchoolMember.new(student.id, student.name, student.username, student.email, :student, student.sso_providers)
         end
       end

--- a/lib/concepts/school_student/create.rb
+++ b/lib/concepts/school_student/create.rb
@@ -28,6 +28,7 @@ module SchoolStudent
           name:
         )
 
+        SafeguardingFlagService.create_for_token(token:, school:)
         response = ProfileApiClient.create_school_student(token:, username:, password:, name:, school_id:)
         user_id = response[:created].first
         Role.student.create!(school:, user_id:)

--- a/lib/concepts/school_student/create_batch_sso.rb
+++ b/lib/concepts/school_student/create_batch_sso.rb
@@ -15,7 +15,7 @@ module SchoolStudent
       def call(school:, school_students_params:, current_user:)
         response = OperationResponse.new
         response[:school_students] = []
-        response[:school_students] = create_batch_sso(school, school_students_params, current_user.token)
+        response[:school_students] = create_batch_sso(school, school_students_params, current_user)
         response
       rescue ValidationError => e
         response[:error] = "Error creating one or more students - see 'errors' key for details"
@@ -31,8 +31,10 @@ module SchoolStudent
 
       private
 
-      def create_batch_sso(school, students, token)
+      def create_batch_sso(school, students, current_user)
         students = normalize_student_params(students)
+        token = current_user.token
+        SafeguardingFlagService.create_for_school_roles(user: current_user, school:)
         responses = ProfileApiClient.create_school_students_sso(token:, students:, school_id: school.id)
 
         create_student_roles(school, responses)

--- a/lib/concepts/school_student/delete.rb
+++ b/lib/concepts/school_student/delete.rb
@@ -16,6 +16,7 @@ module SchoolStudent
       private
 
       def delete_student(school, student_id, token)
+        SafeguardingFlagService.create_for_token(token:, school:)
         ProfileApiClient.delete_school_student(token:, student_id:, school_id: school.id)
       end
     end

--- a/lib/concepts/school_student/list.rb
+++ b/lib/concepts/school_student/list.rb
@@ -19,6 +19,7 @@ module SchoolStudent
         student_ids ||= Role.student.where(school:).map(&:user_id)
         return [] if student_ids.empty?
 
+        SafeguardingFlagService.create_for_token(token:, school:)
         students = ProfileApiClient.list_school_students(token:, school_id: school.id, student_ids:)
         students.map do |student|
           User.new(student.to_h.slice(:id, :username, :name, :email).merge(sso_providers: student.ssoProviders))

--- a/lib/concepts/school_student/update.rb
+++ b/lib/concepts/school_student/update.rb
@@ -39,6 +39,7 @@ module SchoolStudent
         validate(username:, password:, name:)
 
         # Prevent updating SSO students (students with ssoProviders present)
+        SafeguardingFlagService.create_for_token(token:, school:)
         student = ProfileApiClient.school_student(
           token: token,
           school_id: school.id,

--- a/lib/concepts/school_student/validate_batch.rb
+++ b/lib/concepts/school_student/validate_batch.rb
@@ -33,6 +33,7 @@ module SchoolStudent
 
       def validate_batch(school:, students:, token:)
         decrypted_students = StudentHelpers.decrypt_students(students)
+        SafeguardingFlagService.create_for_token(token:, school:)
         ProfileApiClient.validate_school_students(token:, students: decrypted_students, school_id: school.id)
       rescue ProfileApiClient::Student422Error => e
         handle_student422_error(e.errors)

--- a/spec/concepts/class_member/list_spec.rb
+++ b/spec/concepts/class_member/list_spec.rb
@@ -72,8 +72,23 @@ RSpec.describe ClassMember::List, type: :unit do
       expect(Sentry).to have_received(:capture_exception).with(instance_of(StandardError))
     end
 
+    it 'propagates student listing operation errors' do
+      students.each do |student|
+        create(:class_student, school_class:, student_id: student.id)
+      end
+      allow(SchoolStudent::List).to receive(:call).and_return(
+        OperationResponse[error: 'Error listing school students: Some API error']
+      )
+
+      response = described_class.call(school_class:, class_students:, token:)
+
+      expect(response.failure?).to be(true)
+      expect(response[:error]).to eq('Error listing school students: Some API error')
+      expect(response[:class_members]).to eq([])
+    end
+
     it 'returns an empty array when no ids match' do
-      allow(SchoolStudent::List).to receive(:call).and_return({ school_students: [] })
+      allow(SchoolStudent::List).to receive(:call).and_return(OperationResponse[school_students: []])
       allow(SchoolTeacher::List).to receive(:call).and_return({ school_teachers: [] })
 
       response = described_class.call(school_class:, class_students:, token:)

--- a/spec/concepts/class_member/list_spec.rb
+++ b/spec/concepts/class_member/list_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe ClassMember::List, type: :unit do
   let(:student_ids) { students.map(&:id) }
   let(:teacher_ids) { [teacher.id] }
 
+  before do
+    allow(SafeguardingFlagService).to receive(:create_for_token)
+  end
+
   context 'with students and a teacher' do
     before do
       student_ids.each do |student_id|

--- a/spec/concepts/school_member/list_spec.rb
+++ b/spec/concepts/school_member/list_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe SchoolMember::List, type: :unit do
   let(:student_ids) { students.map(&:id) }
   let(:teacher_ids) { [teacher.id] }
 
+  before do
+    allow(SafeguardingFlagService).to receive(:create_for_token)
+  end
+
   context 'with a mixture of students' do
     let(:sso_student) { create(:student, :sso, school:) }
     let(:standard_student) { create(:student, school:) }

--- a/spec/concepts/school_member/list_spec.rb
+++ b/spec/concepts/school_member/list_spec.rb
@@ -114,8 +114,20 @@ RSpec.describe SchoolMember::List, type: :unit do
       expect(Sentry).to have_received(:capture_exception).with(instance_of(StandardError))
     end
 
+    it 'propagates student listing operation errors' do
+      allow(SchoolStudent::List).to receive(:call).and_return(
+        OperationResponse[error: 'Error listing school students: Some API error']
+      )
+
+      response = described_class.call(school:, token:)
+
+      expect(response.failure?).to be(true)
+      expect(response[:error]).to eq('Error listing school students: Some API error')
+      expect(response[:school_members]).to eq([])
+    end
+
     it 'returns an empty array when no ids match' do
-      allow(SchoolStudent::List).to receive(:call).and_return({ school_students: [] })
+      allow(SchoolStudent::List).to receive(:call).and_return(OperationResponse[school_students: []])
       allow(SchoolTeacher::List).to receive(:call).and_return({ school_teachers: [] })
 
       response = described_class.call(school:, token:)

--- a/spec/concepts/school_student/create_batch_sso_spec.rb
+++ b/spec/concepts/school_student/create_batch_sso_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe SchoolStudent::CreateBatchSSO, type: :unit do
     ]
   end
 
+  before do
+    allow(SafeguardingFlagService).to receive(:create_for_school_roles)
+  end
+
   context 'when SSO creation succeeds' do
     let(:user_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
 
@@ -37,6 +41,12 @@ RSpec.describe SchoolStudent::CreateBatchSSO, type: :unit do
 
       expect(ProfileApiClient).to have_received(:create_school_students_sso)
         .with(token: current_user.token, students: school_students_params, school_id: school.id)
+    end
+
+    it 'ensures the current user has a safeguarding flag before creating students' do
+      described_class.call(school:, school_students_params:, current_user:)
+
+      expect(SafeguardingFlagService).to have_received(:create_for_school_roles).with(user: current_user, school:)
     end
 
     it 'transforms nil values to empty strings before API call' do

--- a/spec/concepts/school_student/create_spec.rb
+++ b/spec/concepts/school_student/create_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SchoolStudent::Create, type: :unit do
 
   before do
     stub_profile_api_create_school_student(user_id:)
+    allow(SafeguardingFlagService).to receive(:create_for_token)
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_student/delete_spec.rb
+++ b/spec/concepts/school_student/delete_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SchoolStudent::Delete, type: :unit do
 
   before do
     stub_profile_api_delete_school_student
+    allow(SafeguardingFlagService).to receive(:create_for_token)
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_student/list_spec.rb
+++ b/spec/concepts/school_student/list_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe SchoolStudent::List, type: :unit do
   let(:school) { create(:school) }
   let(:students) { create_list(:student, 3, school:) }
 
+  before do
+    allow(SafeguardingFlagService).to receive(:create_for_token)
+  end
+
   context 'without student_ids' do
     before do
       student_attributes = students.map do |student|
@@ -29,6 +33,12 @@ RSpec.describe SchoolStudent::List, type: :unit do
         school_id: school.id,
         student_ids: match_array(students.map(&:id))
       )
+    end
+
+    it 'ensures the current user has a safeguarding flag before listing students' do
+      described_class.call(school:, token:)
+
+      expect(SafeguardingFlagService).to have_received(:create_for_token).with(token:, school:)
     end
 
     it 'returns a school students JSON array' do

--- a/spec/concepts/school_student/update_spec.rb
+++ b/spec/concepts/school_student/update_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SchoolStudent::Update, type: :unit do
   before do
     stub_profile_api_school_student # This is the call made to determine if it's an SSO student
     stub_profile_api_update_school_student
+    allow(SafeguardingFlagService).to receive(:create_for_token)
   end
 
   it 'returns a successful operation response' do

--- a/spec/concepts/school_student/validate_batch_spec.rb
+++ b/spec/concepts/school_student/validate_batch_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe SchoolStudent::ValidateBatch do
   let(:school) { create(:verified_school) }
   let(:token) { UserProfileMock::TOKEN }
 
+  before do
+    allow(SafeguardingFlagService).to receive(:create_for_token)
+  end
+
   context 'when all students are valid' do
     let(:valid_students) do
       [

--- a/spec/features/class_member/creating_a_batch_of_class_members_spec.rb
+++ b/spec/features/class_member/creating_a_batch_of_class_members_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'Creating a class member', type: :request do
   let(:students) { create_list(:student, 3, school:) }
   let(:teacher) { create(:teacher, school:) }
 
+  before do
+    stub_profile_api_create_safeguarding_flag
+  end
+
   context 'with valid params' do
     let(:student_attributes) do
       students.map do |student|

--- a/spec/features/class_member/creating_a_class_member_spec.rb
+++ b/spec/features/class_member/creating_a_class_member_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe 'Creating a class member', type: :request do
   let(:school) { create(:school) }
   let(:student) { create(:student, school:, name: 'School Student', username: 'school-student') }
   let(:teacher) { create(:teacher, school:) }
+  let(:owner) { create(:owner, school:) }
 
   before do
-    owner = create(:owner, school:)
     authenticated_in_hydra_as(owner)
     stub_user_info_api_for(student)
+    stub_profile_api_create_safeguarding_flag
   end
 
   context 'with valid params' do

--- a/spec/features/class_member/listing_class_members_spec.rb
+++ b/spec/features/class_member/listing_class_members_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Listing class members', type: :request do
       { id: student.id, name: student.name, username: student.username, email: nil }
     end
     stub_profile_api_list_school_students(school:, student_attributes:)
+    stub_profile_api_create_safeguarding_flag
 
     students.each do |student|
       create(:class_student, student_id: student.id, school_class:)

--- a/spec/features/school_class/importing_a_school_class_spec.rb
+++ b/spec/features/school_class/importing_a_school_class_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Importing a school class', type: :request do
   before do
     authenticated_in_hydra_as(teacher)
     stub_user_info_api_for(teacher)
+    stub_profile_api_create_safeguarding_flag
   end
 
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }

--- a/spec/features/school_student/deleting_a_school_student_spec.rb
+++ b/spec/features/school_student/deleting_a_school_student_spec.rb
@@ -21,12 +21,14 @@ RSpec.describe 'Deleting a school student', type: :request do
   end
 
   it 'creates the school owner safeguarding flag' do
-    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    student = create(:student, school:)
+    delete("/api/schools/#{school.id}/students/#{student.id}", headers:)
     expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner], email: owner.email, school_id: school.id)
   end
 
   it 'does not create the school teacher safeguarding flag' do
-    delete("/api/schools/#{school.id}/students/#{student_id}", headers:)
+    student = create(:student, school:)
+    delete("/api/schools/#{school.id}/students/#{student.id}", headers:)
     expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag).with(token: UserProfileMock::TOKEN, flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher], email: owner.email, school_id: school.id)
   end
 

--- a/spec/jobs/create_students_job_spec.rb
+++ b/spec/jobs/create_students_job_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CreateStudentsJob do
 
   before do
     stub_profile_api_create_school_students(user_ids: [user_id])
+    allow(SafeguardingFlagService).to receive(:create_for_token)
   end
 
   after do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe Project, :versioning do
 
     before do
       stub_profile_api_list_school_students(school:, student_attributes:)
+      allow(SafeguardingFlagService).to receive(:create_for_token)
     end
 
     it 'returns User instances for the current scope' do
@@ -227,6 +228,7 @@ RSpec.describe Project, :versioning do
 
     before do
       stub_profile_api_list_school_students(school:, student_attributes:)
+      allow(SafeguardingFlagService).to receive(:create_for_token)
     end
 
     it 'returns an array of class members paired with their User instance' do
@@ -264,6 +266,7 @@ RSpec.describe Project, :versioning do
 
     before do
       stub_profile_api_list_school_students(school:, student_attributes:)
+      allow(SafeguardingFlagService).to receive(:create_for_token)
     end
 
     it 'returns the class member paired with their User instance' do

--- a/spec/requests/projects/remix_spec.rb
+++ b/spec/requests/projects/remix_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Remix requests' do
 
     before do
       authenticated_in_hydra_as(owner)
+      stub_profile_api_create_safeguarding_flag
     end
 
     describe '#index' do

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Project show requests' do
     before do
       authenticated_in_hydra_as(teacher)
       stub_profile_api_list_school_students(school:, student_attributes: [{ name: 'Joe Bloggs' }])
+      stub_profile_api_create_safeguarding_flag
     end
 
     context 'when loading own project' do

--- a/spec/services/safeguarding_flag_service_spec.rb
+++ b/spec/services/safeguarding_flag_service_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SafeguardingFlagService do
+  let(:school) { create(:school) }
+  let(:token) { UserProfileMock::TOKEN }
+
+  before do
+    allow(ProfileApiClient).to receive(:create_safeguarding_flag)
+  end
+
+  describe '.create_for_school_roles' do
+    context 'when the user is a school owner' do
+      let(:user) { create(:owner, school:, token:) }
+
+      it 'creates the school owner safeguarding flag' do
+        described_class.create_for_school_roles(user:, school:)
+
+        expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+          token: user.token,
+          flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner],
+          email: user.email,
+          school_id: school.id
+        )
+      end
+    end
+
+    context 'when the user is a school teacher' do
+      let(:user) { create(:teacher, school:, token:) }
+
+      it 'creates the school teacher safeguarding flag' do
+        described_class.create_for_school_roles(user:, school:)
+
+        expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+          token: user.token,
+          flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
+          email: user.email,
+          school_id: school.id
+        )
+      end
+    end
+
+    context 'when the user is a school student' do
+      let(:user) { create(:student, school:, token:) }
+
+      it 'does not create a safeguarding flag' do
+        described_class.create_for_school_roles(user:, school:)
+
+        expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag)
+      end
+    end
+  end
+
+  describe '.create_for_token' do
+    let(:user) { create(:teacher, school:, token:) }
+
+    before do
+      allow(User).to receive(:from_token).with(token:).and_return(user)
+    end
+
+    it 'creates flags for the user identified by the token' do
+      described_class.create_for_token(token:, school:)
+
+      expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+        token:,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
+        email: user.email,
+        school_id: school.id
+      )
+    end
+
+    it 'does not look up a user without a token' do
+      described_class.create_for_token(token: nil, school:)
+
+      expect(User).not_to have_received(:from_token)
+    end
+  end
+
+  describe '.create_for_roles' do
+    it 'creates each requested teacher or owner flag' do
+      described_class.create_for_roles(
+        token:,
+        email: 'user@example.com',
+        school:,
+        roles: %i[owner teacher student]
+      )
+
+      expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+        token:,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:owner],
+        email: 'user@example.com',
+        school_id: school.id
+      )
+      expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+        token:,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
+        email: 'user@example.com',
+        school_id: school.id
+      )
+    end
+
+    it 'does not create flags without an email' do
+      described_class.create_for_roles(token:, email: nil, school:, roles: %i[owner teacher])
+
+      expect(ProfileApiClient).not_to have_received(:create_safeguarding_flag)
+    end
+  end
+end

--- a/spec/services/safeguarding_flag_service_spec.rb
+++ b/spec/services/safeguarding_flag_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SafeguardingFlagService do
   let(:token) { UserProfileMock::TOKEN }
 
   before do
+    RequestStore.store[:safeguarding_flag_users_by_token] = {}
     allow(ProfileApiClient).to receive(:create_safeguarding_flag)
   end
 
@@ -68,6 +69,26 @@ RSpec.describe SafeguardingFlagService do
         email: user.email,
         school_id: school.id
       )
+    end
+
+    it 'uses a user cached for the token' do
+      RequestStore.store[:safeguarding_flag_users_by_token][token] = user
+
+      described_class.create_for_token(token:, school:)
+
+      expect(User).not_to have_received(:from_token)
+      expect(ProfileApiClient).to have_received(:create_safeguarding_flag).with(
+        token:,
+        flag: ProfileApiClient::SAFEGUARDING_FLAGS[:teacher],
+        email: user.email,
+        school_id: school.id
+      )
+    end
+
+    it 'caches the user after looking it up' do
+      2.times { described_class.create_for_token(token:, school:) }
+
+      expect(User).to have_received(:from_token).once
     end
 
     it 'does not look up a user without a token' do

--- a/spec/services/safeguarding_flag_service_spec.rb
+++ b/spec/services/safeguarding_flag_service_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe SafeguardingFlagService do
 
     before do
       allow(User).to receive(:from_token).with(token:).and_return(user)
+      allow(described_class).to receive(:request_store_active?).and_return(false)
     end
 
     it 'creates flags for the user identified by the token' do
@@ -72,6 +73,7 @@ RSpec.describe SafeguardingFlagService do
     end
 
     it 'uses a user cached for the token' do
+      allow(described_class).to receive(:request_store_active?).and_return(true)
       RequestStore.store[:safeguarding_flag_users_by_token][token] = user
 
       described_class.create_for_token(token:, school:)
@@ -86,9 +88,17 @@ RSpec.describe SafeguardingFlagService do
     end
 
     it 'caches the user after looking it up' do
+      allow(described_class).to receive(:request_store_active?).and_return(true)
+
       2.times { described_class.create_for_token(token:, school:) }
 
       expect(User).to have_received(:from_token).once
+    end
+
+    it 'does not cache token lookups outside an active request store' do
+      2.times { described_class.create_for_token(token:, school:) }
+
+      expect(User).to have_received(:from_token).twice
     end
 
     it 'does not look up a user without a token' do

--- a/spec/services/student_removal_service_spec.rb
+++ b/spec/services/student_removal_service_spec.rb
@@ -156,6 +156,21 @@ describe StudentRemovalService do
         expect(SafeguardingFlagService).to have_received(:create_for_token).with(token: token, school: school).once
       end
 
+      it 'does not delete local records if safeguarding flag creation fails' do
+        token = 'abc123'
+        project = create(:project, user_id: student.id, school: school)
+        allow(SafeguardingFlagService).to receive(:create_for_token).and_raise(StandardError, 'flag failure')
+
+        service = described_class.new(students: [student.id], school: school, remove_from_profile: true, token: token)
+        results = service.remove_students
+
+        expect(results.first[:error]).to include('flag failure')
+        expect(ProfileApiClient).not_to have_received(:delete_school_student)
+        expect(Project.exists?(project.id)).to be true
+        expect(ClassStudent.where(student_id: student.id)).to exist
+        expect(Role.where(user_id: student.id, school_id: school.id, role: :student)).to exist
+      end
+
       it 'does not call ProfileApiClient if remove_from_profile is false' do
         service = described_class.new(students: [student.id], school: school, remove_from_profile: false, token: 'token')
         service.remove_students

--- a/spec/services/student_removal_service_spec.rb
+++ b/spec/services/student_removal_service_spec.rb
@@ -146,6 +146,16 @@ describe StudentRemovalService do
         expect(ProfileApiClient).to have_received(:delete_school_student).with(token: token, school_id: school.id, student_id: student.id)
       end
 
+      it 'creates the safeguarding flag once when removing multiple students from Profile' do
+        token = 'abc123'
+        second_student = create(:student, school: school)
+        service = described_class.new(students: [student.id, second_student.id], school: school, remove_from_profile: true, token: token)
+
+        service.remove_students
+
+        expect(SafeguardingFlagService).to have_received(:create_for_token).with(token: token, school: school).once
+      end
+
       it 'does not call ProfileApiClient if remove_from_profile is false' do
         service = described_class.new(students: [student.id], school: school, remove_from_profile: false, token: 'token')
         service.remove_students

--- a/spec/services/student_removal_service_spec.rb
+++ b/spec/services/student_removal_service_spec.rb
@@ -13,6 +13,7 @@ describe StudentRemovalService do
 
   before do
     allow(ProfileApiClient).to receive(:delete_school_student)
+    allow(SafeguardingFlagService).to receive(:create_for_token)
     create(:class_student, student_id: student.id, school_class: school_class)
   end
 

--- a/spec/services/student_removal_service_spec.rb
+++ b/spec/services/student_removal_service_spec.rb
@@ -162,9 +162,8 @@ describe StudentRemovalService do
         allow(SafeguardingFlagService).to receive(:create_for_token).and_raise(StandardError, 'flag failure')
 
         service = described_class.new(students: [student.id], school: school, remove_from_profile: true, token: token)
-        results = service.remove_students
 
-        expect(results.first[:error]).to include('flag failure')
+        expect { service.remove_students }.to raise_error(StandardError, 'flag failure')
         expect(ProfileApiClient).not_to have_received(:delete_school_student)
         expect(Project.exists?(project.id)).to be true
         expect(ClassStudent.where(student_id: student.id)).to exist


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1475

## What's changed?

This change ensures safeguarding flags are created before editor-api calls Profile’s protected school-student endpoints.

Instead of relying on individual controllers to create the flags, flag creation now happens at the `SchoolStudent` / Profile API boundary. This covers controller and non-controller callers, including class member listing, project student-name lookups, SSO student imports, batch student creation jobs, and student removal.

The duplicated safeguarding flag logic has been removed from `SchoolStudentsController` and `SchoolMembersController`, and a new `SafeguardingFlagService` centralizes owner/teacher flag creation.

Member listing now also propagates `SchoolStudent::List` failures instead of treating failed student lookups as empty lists. This prevents school/class member endpoints from returning successful but incomplete responses when safeguarding flag creation or Profile API calls fail.

## Steps to perform after deploying to production

_If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, a migration, or upgrading a Gem. That kind of thing._
