### PR TITLE
Create events tracking table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,5 @@ PARDOT_SUBSCRIPTION_URL=
 # Others are available for testing purposes at
 # https://developers.cloudflare.com/turnstile/troubleshooting/testing/.
 CLOUDFLARE_TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+
+HOSTNAME=localhost

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  class EventsController < ApiController
+    before_action :authorize_user
+
+    def create
+      event = Event.new(event_params.merge(user_id: current_user.id, time: Time.current))
+      if event.save
+        head :created
+      else
+        render json: { error: event.errors }, status: :unprocessable_content
+      end
+    end
+
+    private
+
+    def event_params
+      params.expect(event: [:name, { properties: {} }])
+    end
+  end
+end

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -20,6 +20,7 @@ module Api
 
       if result.success?
         @school = result[:school]
+        track_event('School - Created', school_id: @school.id)
         render :show, formats: [:json], status: :created
       else
         render json: {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -47,4 +47,8 @@ class ApiController < ActionController::API
   def render_error_as_json(exception, status)
     render json: { error: "#{exception.class}: #{exception.message}" }, status:
   end
+
+  def track_event(name, properties = {})
+    Event.create!(user_id: current_user.id, name:, properties:, time: Time.current)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  validates :name, presence: true
+  validates :time, presence: true
+  validates :user_id, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,8 @@ Rails.application.routes.draw do
 
     get  '/join/:join_code', to: 'join#show'
     post '/join/:join_code', to: 'join#create'
+
+    resources :events, only: %i[create]
   end
 
   resource :github_webhooks, only: :create, defaults: { formats: :json }

--- a/db/migrate/20260612144637_create_events_table.rb
+++ b/db/migrate/20260612144637_create_events_table.rb
@@ -1,0 +1,10 @@
+class CreateEventsTable < ActiveRecord::Migration[8.1]
+  def change
+    create_table :events, id: :uuid do |t|
+      t.uuid :user_id
+      t.string :name, null: false
+      t.jsonb :properties
+      t.datetime :time, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_141937) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_144637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -72,6 +72,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_141937) do
     t.uuid "project_id"
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_components_on_project_id"
+  end
+
+  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.jsonb "properties"
+    t.datetime "time", null: false
+    t.uuid "user_id"
   end
 
   create_table "feedback", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/event/creating_event_spec.rb
+++ b/spec/features/event/creating_event_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create events', type: :request do
+  let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:user) { create(:user) }
+
+  before do
+    authenticated_in_hydra_as(user)
+  end
+
+  it('posting event returns created status') do
+    post('/api/events', headers:, params: { event: { name: 'Test Event', properties: { key: 'value' } } })
+    expect(response).to have_http_status(:created)
+  end
+
+  it('creating an event without a name returns unprocessable content') do
+    post('/api/events', headers:, params: { event: { properties: { key: 'value' } } })
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it('created event is stored in the database with correct attributes') do
+    post('/api/events', headers:, params: { event: { name: 'Test Event', properties: { key: 'value' } } })
+    event = Event.last
+    expect(event.name).to eq('Test Event')
+    expect(event.properties).to eq({ 'key' => 'value' })
+  end
+
+  it('creating an event without authentication returns unauthorized') do
+    post('/api/events', params: { event: { name: 'Test Event', properties: { key: 'value' } } })
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/features/school/creating_a_school_spec.rb
+++ b/spec/features/school/creating_a_school_spec.rb
@@ -57,4 +57,14 @@ RSpec.describe 'Creating a school', type: :request do
     post '/api/schools'
     expect(response).to have_http_status(:unauthorized)
   end
+
+  it 'records a school created event' do
+    post('/api/schools', headers:, params:)
+    expect(Event.last).to have_attributes(
+      name: 'School - Created',
+      user_id: user.id,
+      properties: { 'school_id' => School.last.id },
+      time: be_within(1.second).of(Time.current)
+    )
+  end
 end


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1482

## What's changed?
- Created events table
- Event is created on school creation
- Created events API route
- Add tests around new functionality

## Decision

We've decided to follow the event schema of ahoy to make it easier to migrate to that later if we want.
We've also chosen to restrict the events endpoint to logged in users and require a user_id for events for now as all the events we plan to track are for logged in users, but we could change this in the future. 