### PR TITLE
Add rammodhvadia to CLA contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -34,6 +34,7 @@
     "peconia",
     "PetarSimonovic",
     "pjbRPF",
+    "rammodhvadia",
     "sra405",
     "tuzz",
     "zetter-rpf"


### PR DESCRIPTION
Adds the GitHub username `rammodhvadia` to the `.clabot` contributors list, inserted in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)