### PR TITLE
Update student ability and json response to handle remix project

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -115,7 +115,7 @@ class Ability
     can(%i[read], SchoolClass, school: { id: school.id }, students: { student_id: user.id })
     # Ensure no access to ClassMember resources, relationships otherwise allow access in some circumstances.
     can(%i[read], Lesson, school_id: school.id, visibility: 'students', school_class: { students: { student_id: user.id } })
-    can(%i[read create update], Project, school_id: school.id, user_id: user.id, lesson_id: nil, remixed_from_id: visible_lesson_project_ids)
+    can(%i[read create update show_context], Project, school_id: school.id, user_id: user.id, lesson_id: nil, remixed_from_id: visible_lesson_project_ids)
     can(%i[read show_context], Project, lesson: { school_id: school.id, visibility: 'students', school_class: { students: { student_id: user.id } } })
     can(%i[read set_read], Feedback, school_project: { project: { school_id: school.id, user_id: user.id, lesson_id: nil, remixed_from_id: visible_lesson_project_ids } })
     can(%i[show_finished set_finished show_status unsubmit submit], SchoolProject, project: { user_id: user.id, lesson_id: nil }, school_id: school.id)

--- a/app/views/api/projects/context.json.jbuilder
+++ b/app/views/api/projects/context.json.jbuilder
@@ -6,8 +6,7 @@ json.call(
   @project,
   :identifier,
   :project_type,
-  :school_id,
-  :lesson_id
+  :school_id
 )
 
 json.lesson_id source_lesson&.id

--- a/app/views/api/projects/context.json.jbuilder
+++ b/app/views/api/projects/context.json.jbuilder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+source_lesson = @project.lesson || @project.parent&.lesson
+
 json.call(
   @project,
   :identifier,
@@ -8,4 +10,5 @@ json.call(
   :lesson_id
 )
 
-json.class_id(@project.lesson.school_class_id)
+json.lesson_id source_lesson&.id
+json.class_id source_lesson&.school_class_id

--- a/spec/requests/projects/show_context_spec.rb
+++ b/spec/requests/projects/show_context_spec.rb
@@ -136,6 +136,29 @@ RSpec.describe 'Project context requests' do
         end
       end
 
+      context 'when loading context of a remixed project that is visible to students' do
+        let!(:student_remix) { create(:project, school:, user_id: student.id, remixed_from_id: project.id, locale: nil) }
+        let(:expected_context_json) do
+          {
+            identifier: student_remix.identifier,
+            project_type: project.project_type,
+            school_id: school.id,
+            lesson_id: lesson.id,
+            class_id: school_class.id
+          }.to_json
+        end
+
+        it 'returns success response' do
+          get("/api/projects/#{student_remix.identifier}/context", headers:)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'returns the remix project context json' do
+          get("/api/projects/#{student_remix.identifier}/context", headers:)
+          expect(response.body).to eq(expected_context_json)
+        end
+      end
+
       context 'when loading context of a lesson project that is not visible to students' do
         before do
           project.lesson.update(visibility: 'teachers')


### PR DESCRIPTION
## Status

- Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1509

## What's changed?
- Allow school students to access show_context for their own remix projects.
- Update the context response view to get lesson_id/class_id from the project’s lesson or the parent’s lesson for remixes.
- Add test covering the remix context response for a student.

## Steps to perform after deploying to production

_If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, a migration, or upgrading a Gem. That kind of thing._
