### PR TITLE
Grant teachers access to project context on student remix projects

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -98,7 +98,7 @@ class Ability
         school_class_id: ClassTeacher.where(teacher_id: user.id).select(:school_class_id)
       )
     ).pluck(:id)
-    can(%i[read], Project, remixed_from_id: teacher_project_ids)
+    can(%i[read show_context], Project, remixed_from_id: teacher_project_ids)
     can(%i[show_status unsubmit return complete], SchoolProject, project: { remixed_from_id: teacher_project_ids })
     can(%i[read create destroy], Feedback, school_project: { project: { remixed_from_id: teacher_project_ids } })
     can(%i[exchange_code], :google_auth)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -98,9 +98,9 @@ class Ability
         school_class_id: ClassTeacher.where(teacher_id: user.id).select(:school_class_id)
       )
     ).pluck(:id)
-    can(%i[read show_context], Project, remixed_from_id: teacher_project_ids)
-    can(%i[show_status unsubmit return complete], SchoolProject, project: { remixed_from_id: teacher_project_ids })
-    can(%i[read create destroy], Feedback, school_project: { project: { remixed_from_id: teacher_project_ids } })
+    can(%i[read show_context], Project, school_id: school.id, remixed_from_id: teacher_project_ids)
+    can(%i[show_status unsubmit return complete], SchoolProject, project: { school_id: school.id, remixed_from_id: teacher_project_ids })
+    can(%i[read create destroy], Feedback, school_project: { project: { school_id: school.id, remixed_from_id: teacher_project_ids } })
     can(%i[exchange_code], :google_auth)
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -372,6 +372,19 @@ RSpec.describe Ability do
         it { is_expected.to be_able_to(:complete, remixed_project.school_project) }
       end
 
+      context 'when remix school_id does not match the parent lesson project school' do
+        let(:other_school) { create(:school) }
+        let(:other_student) { create(:student, school: other_school) }
+        let!(:cross_school_remix) do
+          create(:project, school: other_school, user_id: other_student.id, remixed_from_id: original_project.id)
+        end
+        let(:user) { teacher }
+
+        it { is_expected.not_to be_able_to(:read, cross_school_remix) }
+        it { is_expected.not_to be_able_to(:show_context, cross_school_remix) }
+        it { is_expected.not_to be_able_to(:return, cross_school_remix.school_project) }
+      end
+
       context 'when user is another teacher of the class' do
         let(:user) { another_teacher }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -338,6 +338,7 @@ RSpec.describe Ability do
         let(:user) { create(:teacher, school:) }
 
         it { is_expected.not_to be_able_to(:read, remixed_project) }
+        it { is_expected.not_to be_able_to(:show_context, remixed_project) }
         it { is_expected.not_to be_able_to(:create, feedback) }
         it { is_expected.not_to be_able_to(:read, feedback) }
         it { is_expected.not_to be_able_to(:set_read, feedback) }
@@ -356,6 +357,7 @@ RSpec.describe Ability do
         let(:user) { teacher }
 
         it { is_expected.to be_able_to(:read, remixed_project) }
+        it { is_expected.to be_able_to(:show_context, remixed_project) }
         it { is_expected.to be_able_to(:create, feedback) }
         it { is_expected.to be_able_to(:read, feedback) }
         it { is_expected.not_to be_able_to(:set_read, feedback) }
@@ -382,6 +384,7 @@ RSpec.describe Ability do
         it { is_expected.to be_able_to(:update, original_project) }
 
         it { is_expected.to be_able_to(:read, remixed_project) }
+        it { is_expected.to be_able_to(:show_context, remixed_project) }
         it { is_expected.not_to be_able_to(:create, remixed_project) }
         it { is_expected.not_to be_able_to(:update, remixed_project) }
         it { is_expected.not_to be_able_to(:destroy, remixed_project) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -373,12 +373,12 @@ RSpec.describe Ability do
       end
 
       context 'when remix school_id does not match the parent lesson project school' do
-        let(:other_school) { create(:school) }
-        let(:other_student) { create(:student, school: other_school) }
+        let(:user) { teacher }
         let!(:cross_school_remix) do
+          other_school = create(:school)
+          other_student = create(:student, school: other_school)
           create(:project, school: other_school, user_id: other_student.id, remixed_from_id: original_project.id)
         end
-        let(:user) { teacher }
 
         it { is_expected.not_to be_able_to(:read, cross_school_remix) }
         it { is_expected.not_to be_able_to(:show_context, cross_school_remix) }

--- a/spec/requests/projects/show_context_spec.rb
+++ b/spec/requests/projects/show_context_spec.rb
@@ -75,6 +75,37 @@ RSpec.describe 'Project context requests' do
       end
     end
 
+    context 'when loading a student remix context for a lesson the teacher teaches' do
+      let(:student) { create(:student, school:) }
+      let!(:project) { create(:project, :with_instructions, school:, lesson:, user_id: teacher.id, locale: nil) }
+      let!(:student_remix) { create(:project, school:, user_id: student.id, remixed_from_id: project.id, locale: nil) }
+      let(:expected_context_json) do
+        {
+          identifier: student_remix.identifier,
+          project_type: project.project_type,
+          school_id: school.id,
+          lesson_id: lesson.id,
+          class_id: school_class.id
+        }.to_json
+      end
+
+      before do
+        create(:class_student, school_class:, student_id: student.id)
+      end
+
+      it 'returns success response' do
+        get("/api/projects/#{student_remix.identifier}/context", headers:)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the remix project context json' do
+        get("/api/projects/#{student_remix.identifier}/context", headers:)
+
+        expect(response.body).to eq(expected_context_json)
+      end
+    end
+
     context 'when loading another user\'s project context' do
       let!(:another_project) { create(:project, user_id: SecureRandom.uuid, locale: nil) }
       let(:another_project_json) do


### PR DESCRIPTION
Fixes the problem described in issue [1522](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1522)

## Summary

Teachers can already read student remixes for lessons they teach, but were denied access to `GET /api/projects/:identifier/context` on those remix URLs. This PR adds `show_context` to the existing teacher remix read rule so a teacher reopening a saved link to a student's project gets full lesson/class/school context after re-login.

## Problem

When a teacher opens a saved link to a student's project (the remix identifier, e.g. `/school/project/{student-remix-id}`) in a new session:

- `GET /api/projects/{id}` succeeds (teacher can read the remix)
- `GET /api/projects/{id}/context` returns **403**

Student remix rows have `lesson_id: nil` and point at the lesson template via `remixed_from_id`. The context endpoint resolves lesson and class from the parent project (`context.json.jbuilder`), but teachers only had `read` on remixes - not `show_context`.

Without context, **editor-standalone** cannot load the lesson, detect "teacher viewing student work", or enter view-only mode on a cold load.

## Solution

Add `show_context` to the same rule teachers already use to read student remixes:

```ruby
# app/models/ability.rb - define_school_teacher_abilities
can(%i[read show_context], Project, remixed_from_id: teacher_project_ids)
```

No change to the context response shape or jbuilder - `context.json.jbuilder` already resolves `lesson_id` and `class_id` from `@project.parent&.lesson`.

No new security boundary: teachers who can read a student remix (lesson owner or co-teacher of the class) can now load the context needed to display it. Teachers not in the class remain denied.

## Changes

| File | Change |
|------|--------|
| `app/models/ability.rb` | Add `show_context` to teacher remix project rule |
| `spec/models/ability_spec.rb` | Assert `show_context` allowed for lesson owner and co-teacher; denied for teacher not in class |
| `spec/requests/projects/show_context_spec.rb` | Request spec: teacher `GET …/context` on student remix returns 200 with full JSON |

## Test plan

- [x] `bundle exec rspec spec/models/ability_spec.rb -e "remix of a teacher"`
- [x] `bundle exec rspec spec/requests/projects/show_context_spec.rb`
- [x] Manual: log in as teacher, open a student's project, save the link, log out and back in, reopen the link
  - [x] `GET /api/projects/{student-remix-id}/context` returns **200**
  - [x] Response includes `school_id`, `lesson_id`, `class_id`
  - [x] Editor opens in view-only mode (requires **editor-standalone** with context consumer in place)

