### PR TITLE
Restrict teacher ability so that they can only access their own class projects

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,7 +91,7 @@ class Ability
     can(%i[create], Project) do |project|
       school_teacher_can_manage_project?(user:, school:, project:)
     end
-    can(%i[read update show_context], Project, school_id: school.id, lesson: { visibility: %w[teachers students] })
+    can(%i[read update show_context], Project, school_id: school.id, lesson: { visibility: %w[teachers students], school_class: { teachers: { teacher_id: user.id } } })
     teacher_project_ids = Project.where(
       school_id: school.id,
       remixed_from_id: nil,

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -186,15 +186,15 @@ RSpec.describe Ability do
         it { is_expected.not_to be_able_to(:destroy, project) }
       end
 
-      context 'when user is a school teacher' do
+      context 'when user is another teacher in the same school' do
         before do
           create(:teacher_role, user_id: user.id, school:)
         end
 
-        it { is_expected.to be_able_to(:read, project) }
-        it { is_expected.to be_able_to(:show_context, project) }
+        it { is_expected.not_to be_able_to(:read, project) }
+        it { is_expected.not_to be_able_to(:show_context, project) }
         it { is_expected.not_to be_able_to(:create, project) }
-        it { is_expected.to be_able_to(:update, project) }
+        it { is_expected.not_to be_able_to(:update, project) }
         it { is_expected.not_to be_able_to(:set_finished, project.school_project) }
         it { is_expected.not_to be_able_to(:destroy, project) }
       end
@@ -248,15 +248,15 @@ RSpec.describe Ability do
         it { is_expected.not_to be_able_to(:destroy, project) }
       end
 
-      context 'when user is a school teacher' do
+      context 'when user is another teacher in the same school' do
         before do
           create(:teacher_role, user_id: user.id, school:)
         end
 
-        it { is_expected.to be_able_to(:read, project) }
-        it { is_expected.to be_able_to(:show_context, project) }
+        it { is_expected.not_to be_able_to(:read, project) }
+        it { is_expected.not_to be_able_to(:show_context, project) }
         it { is_expected.not_to be_able_to(:create, project) }
-        it { is_expected.to be_able_to(:update, project) }
+        it { is_expected.not_to be_able_to(:update, project) }
         it { is_expected.not_to be_able_to(:set_finished, project.school_project) }
         it { is_expected.not_to be_able_to(:destroy, project) }
       end


### PR DESCRIPTION
## Status

- Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/526

## What's changed?

- Fixed a bug where teachers could access projects in school classes they don't belong to by adding class membership check to the project rule in school teacher abilities. 
