### PR TITLE
Project importer fixes

### DIFF
--- a/app/jobs/upload_job.rb
+++ b/app/jobs/upload_job.rb
@@ -21,8 +21,6 @@ class UploadJob < ApplicationJob
 
   VALID_LOCALES = Locales.load_locales.freeze
 
-  @skip_job = false
-
   ProjectContentQuery = GithubApi::Client.parse <<-GRAPHQL
     query($owner: String!, $repository: String!, $expression: String!) {
       repository(owner: $owner, name: $repository) {
@@ -63,7 +61,7 @@ class UploadJob < ApplicationJob
 
       projects_data.data.repository.object.entries.each do |project_dir|
         project = format_project(project_dir, locale, repository(payload), owner(payload))
-        if @skip_job
+        if project[:build] == false
           Rails.logger.warn "Build skipped for #{project[:name]}"
           next
         end
@@ -107,10 +105,8 @@ class UploadJob < ApplicationJob
     proj_config_file = data.entries.find { |file| file.name == PROJECT_CONFIG }
     proj_config = YAML.safe_load(proj_config_file.object.text, symbolize_names: true)
 
-    if proj_config[:build] == false
-      @skip_job = true
-      return proj_config
-    end
+    # if the build is false, no need to check files, just return the config
+    return proj_config if proj_config[:build] == false
 
     files = data.entries.reject { |file| file.name == PROJECT_CONFIG }
     categorized_files = categorize_files(files, project_dir, locale, repository, owner)

--- a/spec/jobs/upload_job_spec.rb
+++ b/spec/jobs/upload_job_spec.rb
@@ -255,6 +255,60 @@ RSpec.describe UploadJob do
     end
   end
 
+  context 'with multiple projects where an earlier one has build set to false' do
+    let(:raw_response) { modifiable_response.deep_dup }
+
+    before do
+      entries = raw_response['data']['repository']['object']['entries']
+
+      # Turn the existing project into a build: false project
+      build_false_dir = entries.find { |entry| entry['name'] == 'dont-collide-starter' }
+      build_false_config = build_false_dir['object']['entries'].find { |entry| entry['name'] == 'project_config.yml' }
+      build_false_config['object']['text'] += "build: false\n"
+
+      # add second project with build set to true
+      entries << {
+        'name' => 'build-me-starter',
+        'object' => {
+          '__typename' => 'Tree',
+          'entries' => [
+            {
+              'name' => 'main.py',
+              'extension' => '.py',
+              'object' => {
+                '__typename' => 'Blob',
+                'text' => "print('hello')\n",
+                'isBinary' => false
+              }
+            },
+            {
+              'name' => 'project_config.yml',
+              'extension' => '.yml',
+              'object' => {
+                '__typename' => 'Blob',
+                'text' => "name: \"Build Me\"\nidentifier: \"build-me-starter\"\ntype: \"python\"\nbuild: true\n",
+                'isBinary' => true
+              }
+            }
+          ]
+        }
+      }
+
+      allow(GithubApi::Client).to receive(:query).and_return(graphql_response)
+      allow(ProjectImporter).to receive(:new).and_call_original
+    end
+
+    it 'still imports the later buildable project' do
+      expect { described_class.perform_now(payload) }.to change(Project, :count).by(1)
+      expect(Project.find_by(identifier: 'build-me-starter', locale: 'ja-JP')).to be_present
+    end
+
+    it 'does not import the build: false project' do
+      described_class.perform_now(payload)
+      expect(Project.find_by(identifier: 'dont-collide-starter', locale: 'ja-JP')).to be_nil
+    end
+  end
+
   context 'when GitHub returns nothing for the locale' do
     let(:raw_response) { { data: { repository: nil } } }
 


### PR DESCRIPTION
## What's changed?

- Fixes an issue with the `skip_job` variable. Once `@skip_job` was set to true by a project with `build: false` in its `project_config.yml`, it stayed true for the rest of the run, meaning every following project import for every locale would be skipped.
- Adds a test to check the old behaviour does not happen

