### PR TITLE
Tolerate Authorization headers in the form 'Bearer [token]'

### DIFF
--- a/app/controllers/concerns/identifiable.rb
+++ b/app/controllers/concerns/identifiable.rb
@@ -9,8 +9,10 @@ module Identifiable
   end
 
   def load_current_user
-    token = request.headers['Authorization']
-    return if token.blank?
+    header = request.headers['Authorization']&.strip
+    return if header.blank?
+
+    token = extract_token(header)
 
     @current_user = User.from_token(token:)
     return if @current_user.blank?
@@ -18,5 +20,9 @@ module Identifiable
 
     RequestStore.store[:safeguarding_flag_users_by_token] ||= {}
     RequestStore.store[:safeguarding_flag_users_by_token][token] = @current_user
+  end
+
+  def extract_token(header)
+    header.sub(/^Bearer\s+/i, '')
   end
 end

--- a/spec/controllers/concerns/identifiable_spec.rb
+++ b/spec/controllers/concerns/identifiable_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Identifiable do
+  subject(:extract_token) { identifiable.extract_token(header) }
+
+  let(:identifiable) { Class.new(ActionController::API) { include Identifiable }.new }
+
+  context 'when the header is a raw token' do
+    let(:header) { 'secret-token' }
+
+    it { is_expected.to eq('secret-token') }
+  end
+
+  context 'when the header is Bearer-prefixed' do
+    let(:header) { 'Bearer secret-token' }
+
+    it { is_expected.to eq('secret-token') }
+  end
+
+  context 'when the header uses a lowercase bearer prefix' do
+    let(:header) { 'bearer secret-token' }
+
+    it { is_expected.to eq('secret-token') }
+  end
+
+  context 'when the header is Bearer with no token' do
+    let(:header) { 'Bearer ' }
+
+    it { is_expected.to eq('') }
+  end
+end


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1532 (see comments)
- More context in [Slack](https://raspberrypifoundation.slack.com/archives/C02PZ96UXJP/p1782742221851929)

## Points for consideration:

- Security: we already assume everything in the Authorization header is a Bearer token, so no material change here.
- Performance: the regex will match once at the start of the string only, so should have minimal performance impact.

## What's changed?

- Authorization headers are currently expected to be in the non-standard form `Authorization: [token]` - the auth scheme is missing. This change means the API will also tolerate the more correct form `Authorization: Bearer [token]` by normalising it to omit `Bearer`. Previously, the API would accept such headers, but they would cause errors when re-used to authenticate calls to other systems like Hydra.

