### PR TITLE
Archive schools

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -28,6 +28,12 @@ module Admin
       redirect_to admin_school_path(requested_resource)
     end
 
+    def archive
+      requested_resource.archive!
+
+      redirect_to admin_school_path(requested_resource)
+    end
+
     def default_sorting_attribute
       :created_at
     end

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -29,7 +29,11 @@ module Admin
     end
 
     def archive
-      requested_resource.archive!
+      if requested_resource.archive
+        flash[:notice] = t('administrate.controller.archive_school.success')
+      else
+        flash[:error] = requested_resource.errors.full_messages.to_sentence.presence || t('administrate.controller.archive_school.error')
+      end
 
       redirect_to admin_school_path(requested_resource)
     end

--- a/app/controllers/api/teacher_invitations_controller.rb
+++ b/app/controllers/api/teacher_invitations_controller.rb
@@ -13,7 +13,8 @@ module Api
     end
 
     def accept
-      role = Role.teacher.find_or_initialize_by(user_id: current_user.id, school: @invitation.school)
+      role = Role.unscoped.teacher.find_or_initialize_by(user_id: current_user.id, school: @invitation.school)
+      role.archived_at = nil
       if role.save
         @invitation.update!(accepted_at: Time.current) if @invitation.accepted_at.blank?
         head :ok

--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -33,6 +33,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     school_roll_number: Field::String,
     verified_at: Field::DateTime,
     rejected_at: Field::DateTime,
+    archived_at: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     user_origin: EnumField
@@ -84,6 +85,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     updated_at
     verified_at
     rejected_at
+archived_at
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -27,6 +27,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     lessons: Field::HasMany,
     projects: Field::HasMany,
     roles: SchoolRolesField,
+    student_count: Field::Number,
     reference: Field::String,
     district_name: Field::String,
     district_nces_id: Field::String,
@@ -65,6 +66,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     user_origin
     creator
     roles
+    student_count
     creator_role
     creator_department
     reference
@@ -85,7 +87,7 @@ class SchoolDashboard < Administrate::BaseDashboard
     updated_at
     verified_at
     rejected_at
-archived_at
+    archived_at
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/jobs/salesforce/role_sync_job.rb
+++ b/app/jobs/salesforce/role_sync_job.rb
@@ -9,12 +9,13 @@ module Salesforce
       contact__r__pi_accounts_unique_id__c: :user_id,
       editor__r__editoruuid__c: :school_id,
       roletype__c: :role,
+      offboardedat__c: :archived_at,
       createdat__c: :created_at,
       updatedat__c: :updated_at
     }.freeze
 
     def perform(role_id:)
-      role = ::Role.find(role_id)
+      role = ::Role.unscoped.find(role_id)
 
       return if role.student?
 

--- a/app/jobs/salesforce/school_sync_job.rb
+++ b/app/jobs/salesforce/school_sync_job.rb
@@ -22,7 +22,8 @@ module Salesforce
       website__c: :website,
       districtnamesupplied__c: :district_name,
       ncesid__c: :district_nces_id,
-      schoolrollnumber__c: :school_roll_number
+      schoolrollnumber__c: :school_roll_number,
+      discardedat__c: :archived_at
     }.freeze
 
     def perform(school_id:, is_create: false)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,7 @@ class Ability
     return unless user
 
     define_authenticated_non_student_abilities(user)
-    user.schools.each do |school|
+    user.schools.active.each do |school|
       define_school_student_abilities(user:, school:) if user.school_student?(school)
       define_school_teacher_abilities(user:, school:) if user.school_teacher?(school)
       define_school_owner_abilities(school:) if user.school_owner?(school)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -10,6 +10,8 @@ class Role < ApplicationRecord
   validate :students_cannot_have_additional_roles
   validate :users_can_only_have_roles_in_one_school
 
+  default_scope { where(archived_at: nil) }
+
   has_paper_trail(
     meta: {
       meta_school_id: ->(cm) { cm.school&.id }
@@ -17,6 +19,10 @@ class Role < ApplicationRecord
   )
 
   after_commit :do_salesforce_sync, on: %i[create update], if: -> { FeatureFlags.salesforce_sync? && !student? }
+
+  def archive!
+    update!(archived_at: Time.zone.now)
+  end
 
   private
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -46,6 +46,7 @@ class School < ApplicationRecord
   validates :code,
             uniqueness: { allow_nil: true },
             format: { with: /\d\d-\d\d-\d\d/, allow_nil: true }
+  validate :cannot_archive_with_students, on: :archive
   validate :verified_at_cannot_be_changed
   validate :code_cannot_be_changed
 
@@ -109,8 +110,18 @@ class School < ApplicationRecord
     update(rejected_at: nil)
   end
 
-  def archive!
-    update!(archived_at: Time.zone.now, verified_at: nil)
+  def archive
+    return true if archived?
+
+    transaction do
+      self.archived_at = Time.zone.now
+      save!(context: :archive)
+      roles.where(role: %i[owner teacher]).find_each(&:archive!)
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 
   def archived?
@@ -167,6 +178,10 @@ class School < ApplicationRecord
   # Also normalize to uppercase for consistent validation
   def normalize_school_roll_number
     self.school_roll_number = (school_roll_number.presence&.upcase)
+  end
+
+  def cannot_archive_with_students
+    errors.add(:base, 'Cannot archive a school with students') if roles.student.exists?
   end
 
   def verified_at_cannot_be_changed

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -128,6 +128,10 @@ class School < ApplicationRecord
     archived_at.present?
   end
 
+  def student_count
+    roles.student.count
+  end
+
   def postal_code=(str)
     super(str.to_s.upcase)
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,6 +12,8 @@ class School < ApplicationRecord
 
   enum :user_origin, { for_education: 0, experience_cs: 1 }, default: :for_education, validate: true
 
+  scope :active, -> { where(rejected_at: nil, archived_at: nil) }
+
   validates :name, presence: true
   validates :website, presence: true, format: { with: VALID_URL_REGEX, message: I18n.t('validations.school.website') }
   validates :address_line_1, presence: true
@@ -20,22 +22,22 @@ class School < ApplicationRecord
   validates :postal_code, presence: true
   validates :country_code, presence: true, inclusion: { in: ISO3166::Country.codes }
   validates :reference,
-            uniqueness: { conditions: -> { where(rejected_at: nil) }, case_sensitive: false, allow_blank: true, message: I18n.t('validations.school.reference_urn_exists') },
+            uniqueness: { conditions: -> { active }, case_sensitive: false, allow_blank: true, message: I18n.t('validations.school.reference_urn_exists') },
             format: { with: /\A\d{5,6}\z/, allow_nil: true, message: I18n.t('validations.school.reference') },
-            if: :united_kingdom?, on: :create, unless: :rejected?
+            if: :united_kingdom?, on: :create, unless: :hidden?
   validates :district_nces_id,
             format: { with: /\A\d{7}\z/, allow_nil: true, message: I18n.t('validations.school.district_nces_id') },
             if: :united_states?, on: :create
   validates :district_name, presence: true, if: :united_states?
   validates :school_roll_number,
-            uniqueness: { conditions: -> { where(rejected_at: nil) }, case_sensitive: false, allow_blank: true, message: I18n.t('validations.school.school_roll_number_exists') },
+            uniqueness: { conditions: -> { active }, case_sensitive: false, allow_blank: true, message: I18n.t('validations.school.school_roll_number_exists') },
             format: { with: /\A[0-9]+[A-Z]+\z/, allow_nil: true, message: I18n.t('validations.school.school_roll_number') },
-            presence: true, on: :create, if: :ireland?, unless: :rejected?
+            presence: true, on: :create, if: :ireland?, unless: :hidden?
   validates :creator_id,
             presence: true,
             uniqueness: {
-              conditions: -> { where(rejected_at: nil) }
-            }, unless: :rejected?
+              conditions: -> { active }
+            }, unless: :hidden?
   validates :creator_agree_authority, presence: true, acceptance: true
   validates :creator_agree_terms_and_conditions, presence: true, acceptance: true
   validates :creator_agree_responsible_safeguarding, presence: true, acceptance: true
@@ -59,7 +61,7 @@ class School < ApplicationRecord
   after_commit -> { do_salesforce_sync(is_create: false) }, on: :update, if: -> { FeatureFlags.salesforce_sync? }
 
   def self.find_for_user!(user)
-    school = Role.find_by(user_id: user.id)&.school || find_by(creator_id: user.id, rejected_at: nil)
+    school = Role.find_by(user_id: user.id)&.school || active.find_by(creator_id: user.id)
     raise ActiveRecord::RecordNotFound unless school
 
     school
@@ -80,6 +82,10 @@ class School < ApplicationRecord
   def verify!
     generate_code!
     update!(verified_at: Time.zone.now)
+  end
+
+  def hidden?
+    rejected? || archived?
   end
 
   def generate_code!

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -103,6 +103,14 @@ class School < ApplicationRecord
     update(rejected_at: nil)
   end
 
+  def archive!
+    update!(archived_at: Time.zone.now, verified_at: nil)
+  end
+
+  def archived?
+    archived_at.present?
+  end
+
   def postal_code=(str)
     super(str.to_s.upcase)
   end

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -45,6 +45,15 @@ as well as a link to its edit page.
       style: "background-color: darkorange; margin: 5px;",
       data: { turbo_confirm: t("administrate.actions.confirm_reopen_school") }
     ) unless page.resource.verified? || !page.resource.rejected? %>
+
+    <%= button_to(
+      t("administrate.actions.archive_school"),
+      archive_admin_school_path(page.resource),
+      class: "button button--archive",
+      method: :patch,
+      style: "background-color: firebrick; margin: 5px;",
+      data: { turbo_confirm: t("administrate.actions.confirm_archive_school") }
+    ) unless page.resource.archived? %>
   </div>
 </header>
 

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -28,22 +28,22 @@ as well as a link to its edit page.
       class: "button",
     ) if accessible_action?(page.resource, :edit) %>
 
-    <%= link_to(
+    <%= button_to(
       t("administrate.actions.verify_school"),
       verify_admin_school_path(page.resource),
       class: "button button--verify",
       method: :post,
       style: "background-color: green; margin: 5px;",
-      data: { confirm: t("administrate.actions.confirm_verify_school") }
+      data: { turbo_confirm: t("administrate.actions.confirm_verify_school") }
     ) unless page.resource.verified? || page.resource.rejected? %>
 
-    <%= link_to(
+    <%= button_to(
       t("administrate.actions.reopen_school"),
       reopen_admin_school_path(page.resource),
       class: "button button--verify",
       method: :patch,
       style: "background-color: darkorange; margin: 5px;",
-      data: { confirm: t("administrate.actions.confirm_reopen_school") }
+      data: { turbo_confirm: t("administrate.actions.confirm_reopen_school") }
     ) unless page.resource.verified? || !page.resource.rejected? %>
   </div>
 </header>

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -8,6 +8,8 @@ en:
       confirm_verify_school: Are you sure you want to verify this school?
       reopen_school: Reopen School
       confirm_reopen_school: Are you sure you want to reopen this school?
+      archive_school: Archive School
+      confirm_archive_school: Are you sure you want to archive this school?
     controller:
       verify_school:
         success: "Successfully verified."
@@ -15,6 +17,9 @@ en:
       reopen_school:
         success: "Successfully reopened."
         error: "There was an error reopening the school"
+      archive_school:
+        success: "Successfully archived."
+        error: "There was an error archiving the school"
   activerecord:
     attributes:
       school:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       member do
         post :verify
         patch :reopen
+        patch :archive
       end
     end
 

--- a/db/migrate/20260703145125_add_archived_at_to_schools.rb
+++ b/db/migrate/20260703145125_add_archived_at_to_schools.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToSchools < ActiveRecord::Migration[8.1]
+  def change
+    add_column :schools, :archived_at, :datetime
+  end
+end

--- a/db/migrate/20260703150521_update_school_index_conditions.rb
+++ b/db/migrate/20260703150521_update_school_index_conditions.rb
@@ -1,0 +1,12 @@
+class UpdateSchoolIndexConditions < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :schools, :creator_id
+    add_index :schools, :creator_id, unique: true, where: "rejected_at IS NULL AND archived_at IS NULL"
+
+    remove_index :schools, :reference
+    add_index :schools, :reference, unique: true, where: "rejected_at IS NULL AND archived_at IS NULL"
+
+    remove_index :schools, :school_roll_number
+    add_index :schools, :school_roll_number, unique: true, where: "rejected_at IS NULL AND archived_at IS NULL"
+  end
+end

--- a/db/migrate/20260703151018_add_archived_at_to_roles.rb
+++ b/db/migrate/20260703151018_add_archived_at_to_roles.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToRoles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :roles, :archived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_150521) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_151018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -253,6 +253,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_150521) do
   end
 
   create_table "roles", force: :cascade do |t|
+    t.datetime "archived_at"
     t.datetime "created_at", null: false
     t.integer "role"
     t.uuid "school_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_145125) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_150521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -349,9 +349,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_145125) do
     t.datetime "verified_at"
     t.string "website", null: false
     t.index ["code"], name: "index_schools_on_code", unique: true
-    t.index ["creator_id"], name: "index_schools_on_creator_id_active_only", unique: true, where: "(rejected_at IS NULL)"
-    t.index ["reference"], name: "index_schools_on_reference", unique: true, where: "(rejected_at IS NULL)"
-    t.index ["school_roll_number"], name: "index_schools_on_school_roll_number", unique: true, where: "(rejected_at IS NULL)"
+    t.index ["creator_id"], name: "index_schools_on_creator_id", unique: true, where: "((rejected_at IS NULL) AND (archived_at IS NULL))"
+    t.index ["reference"], name: "index_schools_on_reference", unique: true, where: "((rejected_at IS NULL) AND (archived_at IS NULL))"
+    t.index ["school_roll_number"], name: "index_schools_on_school_roll_number", unique: true, where: "((rejected_at IS NULL) AND (archived_at IS NULL))"
   end
 
   create_table "scratch_assets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_144637) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_145125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -324,6 +324,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_144637) do
     t.string "address_line_1", null: false
     t.string "address_line_2"
     t.string "administrative_area"
+    t.datetime "archived_at"
     t.string "code"
     t.string "country_code", null: false
     t.datetime "created_at", null: false

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe 'Schools', type: :request do
       expect(response.body).to include(I18n.t('administrate.actions.verify_school'))
     end
 
+    it 'includes link to archive school' do
+      expect(response.body).to include(I18n.t('administrate.actions.archive_school'))
+    end
+
     it 'does not include a link to search for this school by its ZIP code in the NCES public schools database' do
       expect(response.body).not_to include('Search for this school in the NCES database')
     end
@@ -198,6 +202,25 @@ RSpec.describe 'Schools', type: :request do
       it 'displays failure message' do
         expect(response.body).to include(I18n.t('administrate.controller.reopen_school.error'))
       end
+    end
+  end
+
+  describe 'PUT #archive' do
+    let(:creator) { create(:user) }
+    let(:school) { create(:school, creator_id: creator.id) }
+
+    before do
+      stub_user_info_api_for(creator)
+    end
+
+    it 'marks the school as archived' do
+      patch archive_admin_school_path(school)
+      expect(school.reload).to be_archived
+    end
+
+    it 'redirects to school path' do
+      patch archive_admin_school_path(school)
+      expect(response).to redirect_to(admin_school_path(school))
     end
   end
 

--- a/spec/features/admin/schools_spec.rb
+++ b/spec/features/admin/schools_spec.rb
@@ -218,6 +218,15 @@ RSpec.describe 'Schools', type: :request do
       expect(school.reload).to be_archived
     end
 
+    it 'displays the validation error when the school has students' do
+      create(:student_role, school:)
+
+      patch archive_admin_school_path(school)
+      follow_redirect!
+
+      expect(response.body).to include('Cannot archive a school with students')
+    end
+
     it 'redirects to school path' do
       patch archive_admin_school_path(school)
       expect(response).to redirect_to(admin_school_path(school))

--- a/spec/features/teacher_invitations/accepting_an_invitation_spec.rb
+++ b/spec/features/teacher_invitations/accepting_an_invitation_spec.rb
@@ -197,9 +197,7 @@ RSpec.describe 'Accepting an invitations', type: :request do
       end
 
       context 'when user already has teacher role for the same school' do
-        before do
-          Role.teacher.create!(user_id: user.id, school:)
-        end
+        let(:role) { Role.teacher.create!(user_id: user.id, school:) }
 
         it 'responds 200 OK' do
           put("/api/teacher_invitations/#{token}/accept", headers:)
@@ -211,6 +209,15 @@ RSpec.describe 'Accepting an invitations', type: :request do
           put("/api/teacher_invitations/#{token}/accept", headers:)
 
           expect(user).to be_school_teacher(school)
+        end
+
+        it 'makes the user active if they were previously archived' do
+          role.update!(archived_at: Time.current)
+
+          put("/api/teacher_invitations/#{token}/accept", headers:)
+
+          expect(user).to be_school_teacher(school)
+          expect(role.reload.archived_at).to be_nil
         end
 
         it 'sets the accepted_at timestamp on the invitation' do

--- a/spec/jobs/salesforce/role_sync_job_spec.rb
+++ b/spec/jobs/salesforce/role_sync_job_spec.rb
@@ -17,22 +17,20 @@ RSpec.describe Salesforce::RoleSyncJob, :requires_salesforce_db do
     ClimateControl.modify(SALESFORCE_ENABLED: 'true') { example.run }
   end
 
-  context 'when the job has run' do
-    before { perform_job }
-
-    it 'syncs all FIELD_MAPPINGS to the correct role values' do
-      sf_role = Salesforce::Role.find_by(affiliation_id__c: role.id)
-      described_class::FIELD_MAPPINGS.each do |sf_field, role_field|
-        expected = Salesforce::Role.type_for_attribute(sf_field).cast(role.send(role_field))
-        expect(sf_role.send(sf_field)).to eq(expected),
-                                          "Expected #{sf_field} to equal role.#{role_field}"
-      end
+  it 'syncs all FIELD_MAPPINGS to the correct role values' do
+    perform_job
+    sf_role = Salesforce::Role.find_by(affiliation_id__c: role.id)
+    described_class::FIELD_MAPPINGS.each do |sf_field, role_field|
+      expected = Salesforce::Role.type_for_attribute(sf_field).cast(role.send(role_field))
+      expect(sf_role.send(sf_field)).to eq(expected),
+                                        "Expected #{sf_field} to equal role.#{role_field}"
     end
+  end
 
-    it 'sets editor_type__c from the school user_origin' do
-      sf_role = Salesforce::Role.find_by(affiliation_id__c: role.id)
-      expect(sf_role.editor_type__c).to eq(role.school.user_origin)
-    end
+  it 'sets editor_type__c from the school user_origin' do
+    perform_job
+    sf_role = Salesforce::Role.find_by(affiliation_id__c: role.id)
+    expect(sf_role.editor_type__c).to eq(role.school.user_origin)
   end
 
   context 'when the Salesforce role fails to save' do

--- a/spec/jobs/salesforce/role_sync_job_spec.rb
+++ b/spec/jobs/salesforce/role_sync_job_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Salesforce::RoleSyncJob, :requires_salesforce_db do
     expect(sf_role.editor_type__c).to eq(role.school.user_origin)
   end
 
+  it 'syncs archived roles' do
+    role.update!(archived_at: Time.zone.now)
+    perform_job
+    sf_role = Salesforce::Role.find_by(affiliation_id__c: role.id)
+    expect(sf_role.offboardedat__c.to_date).to eq(role.archived_at.to_date)
+  end
+
   context 'when the Salesforce role fails to save' do
     let(:sf_role) { instance_double(Salesforce::Role) }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,7 +4,7 @@ require 'cancan/matchers'
 require 'rails_helper'
 
 RSpec.describe Ability do
-  subject { described_class.new(user) }
+  subject(:ability) { described_class.new(user) }
 
   let(:user_id) { SecureRandom.uuid }
   let(:project) { build(:project, user_id:) }
@@ -485,6 +485,11 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:read, school) }
       it { is_expected.to be_able_to(:update, school) }
       it { is_expected.to be_able_to(:destroy, school) }
+
+      it 'cannot interact with an inactive school' do
+        school.update!(archived_at: Time.current)
+        expect(ability).not_to be_able_to(:read, school)
+      end
     end
 
     context 'when user is a school teacher' do
@@ -495,6 +500,11 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:read, school) }
       it { is_expected.not_to be_able_to(:update, school) }
       it { is_expected.not_to be_able_to(:destroy, school) }
+
+      it 'cannot interact with an inactive school' do
+        school.update!(archived_at: Time.current)
+        expect(ability).not_to be_able_to(:read, school)
+      end
     end
 
     context 'when user is a school student' do
@@ -505,6 +515,11 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:read, school) }
       it { is_expected.not_to be_able_to(:update, school) }
       it { is_expected.not_to be_able_to(:destroy, school) }
+
+      it 'cannot interact with an inactive school' do
+        school.update(archived_at: Time.current)
+        expect(ability).not_to be_able_to(:read, school)
+      end
 
       context 'with a starter project' do
         it { is_expected.not_to be_able_to(:index, starter_project) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -217,6 +217,14 @@ RSpec.describe School do
       expect { new_school.save! }.not_to raise_error
     end
 
+    it 'allows reference reuse when original school is archived' do
+      school.update!(reference: '100000', archived_at: Time.zone.now)
+
+      new_school = build(:school, reference: '100000')
+      expect(new_school).to be_valid
+      expect { new_school.save! }.not_to raise_error
+    end
+
     it 'does not require a district_nces_id for UK schools' do
       school.country_code = 'GB'
       school.district_nces_id = nil
@@ -347,6 +355,14 @@ RSpec.describe School do
 
     it 'allows school_roll_number reuse when original school is rejected' do
       ireland_school.update!(rejected_at: Time.zone.now)
+
+      new_school = build(:school, school_roll_number: '01572D', country_code: 'IE')
+      expect(new_school).to be_valid
+      expect { new_school.save! }.not_to raise_error
+    end
+
+    it 'allows school_roll_number reuse when original school is archived' do
+      ireland_school.update!(archived_at: Time.zone.now)
 
       new_school = build(:school, school_roll_number: '01572D', country_code: 'IE')
       expect(new_school).to be_valid

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -706,6 +706,35 @@ RSpec.describe School do
     end
   end
 
+  describe '#archive' do
+    it 'sets archived_at and returns true' do
+      result = nil
+
+      expect do
+        result = school.archive
+      end.to change { school.reload.archived? }.from(false).to(true)
+
+      expect(result).to be(true)
+    end
+
+    it 'archives owner and teacher roles' do
+      owner_role = create(:owner_role, school:)
+      teacher_role = create(:teacher_role, school:)
+
+      school.archive
+
+      expect(Role.unscoped.find(owner_role.id).archived_at).to be_present
+      expect(Role.unscoped.find(teacher_role.id).archived_at).to be_present
+    end
+
+    it 'does not archive school if students exist and returns false' do
+      create(:student_role, school:)
+
+      expect(school.archive).to be(false)
+      expect(school.reload).not_to be_archived
+    end
+  end
+
   describe '#auto_join_enabled?' do
     it 'returns true when the school has at least one registered email domain' do
       SchoolEmailDomain.create!(school:, domain: 'valid.edu')


### PR DESCRIPTION
## Status

- Related to https://github.com/orgs/RaspberryPiFoundation/projects/51/views/82?pane=issue&itemId=208270329&issue=RaspberryPiFoundation%7Cdigital-editor-issues%7C1547

## Context

Currently educators can only belong to one school. We often have requests from educators to remove their old School so they can create/join a new one. We've been [following a manual process to do this](https://digital-docs.rpf-internal.org/docs/technology/codebases-and-products/editor/processes/code-editor-for-education/removing-rejected-school).

## What's changed?

This adds a button to the admin panel so any admin can 'archive' a school. This marks the school and all owner/teacher roles as archived.

Archiving a School does not delete any data so we could recover from it if it was done accidentally.
To prevent us from archiving a school that is in use, archiving requires there be no students in the school. Teachers will need to remove any students before we can archive.

I haven't removed any safeguarding flags as part of this - the safeguarding flags should remain as we may still need to link usage to an individual later.

See commits for more.