### PR TITLE
Check authorization as default

### DIFF
--- a/app/controllers/api/default_projects_controller.rb
+++ b/app/controllers/api/default_projects_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class DefaultProjectsController < ApiController
     before_action :authorize_user, only: %i[create]
+    # Public template payloads; no user-owned resource is accessed.
+    skip_authorization_check only: %i[show python html]
 
     def show
       data = if params[:type] == Project::Types::HTML

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class EventsController < ApiController
     before_action :authorize_user
+    # Authenticated telemetry endpoint; authorize_user is the access boundary.
+    skip_authorization_check only: :create
 
     def create
       event = Event.new(event_params.merge(user_id: current_user.id, time: Time.current))

--- a/app/controllers/api/features_controller.rb
+++ b/app/controllers/api/features_controller.rb
@@ -2,6 +2,9 @@
 
 module Api
   class FeaturesController < ApiController
+    # Public feature discovery endpoint; feature visibility is resolved by Flipper.
+    skip_authorization_check only: :index
+
     def index
       school = current_user&.schools&.first
 

--- a/app/controllers/api/join_controller.rb
+++ b/app/controllers/api/join_controller.rb
@@ -4,6 +4,8 @@ module Api
   class JoinController < ApiController
     before_action :authorize_user, only: :create
     before_action :find_school_and_class
+    # Join-code flow is governed by JoinStatusService rather than CanCan.
+    skip_authorization_check only: %i[show create]
 
     def show
       @status = show_status

--- a/app/controllers/api/lessons/batch_controller.rb
+++ b/app/controllers/api/lessons/batch_controller.rb
@@ -12,6 +12,7 @@ module Api
       before_action :authorize_lesson_projects!
 
       def create_batch
+        authorize_blank_lesson_batch! unless lesson_projects?
         raise ParameterError, 'lesson_projects cannot be blank' unless lesson_projects?
 
         @results = Lesson::CreateBatch.call(
@@ -60,6 +61,10 @@ module Api
         batch_lessons_params.each do |lesson_params|
           authorize! :create, Lesson.new(lesson_params.slice(:school_id, :school_class_id, :user_id))
         end
+      end
+
+      def authorize_blank_lesson_batch!
+        authorize! :create, Lesson.new(user_id: current_user.id)
       end
     end
   end

--- a/app/controllers/api/my_school_controller.rb
+++ b/app/controllers/api/my_school_controller.rb
@@ -6,6 +6,7 @@ module Api
 
     def show
       @school = School.find_for_user!(current_user)
+      authorize! :read, @school
       @user = current_user
       render :show, formats: [:json], status: :ok
     end

--- a/app/controllers/api/profile_auth_check_controller.rb
+++ b/app/controllers/api/profile_auth_check_controller.rb
@@ -2,6 +2,9 @@
 
 module Api
   class ProfileAuthCheckController < ApiController
+    # This endpoint reports whether the supplied token works against Profile.
+    skip_authorization_check only: :index
+
     def index
       authorised = ProfileApiClient.check_auth(token: current_user&.token)
 

--- a/app/controllers/api/project_errors_controller.rb
+++ b/app/controllers/api/project_errors_controller.rb
@@ -2,6 +2,9 @@
 
 module Api
   class ProjectErrorsController < ApiController
+    # Public client error intake; project identifiers are used only for attribution.
+    skip_authorization_check only: :create
+
     def create
       project_error = ProjectError.new(project_error_params)
       project_error.save!

--- a/app/controllers/api/projects/remixes_controller.rb
+++ b/app/controllers/api/projects/remixes_controller.rb
@@ -11,6 +11,7 @@ module Api
       before_action :load_and_authorize_remix_identifier, only: :show_identifier
 
       def index
+        authorize! :show, project
         projects = Project.where(remixed_from_id: project.id).accessible_by(current_ability)
         @projects_with_students = projects.includes(:school_project).with_students(project.school, current_user)
         render index: @projects_with_students, formats: [:json]

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class SubscriptionsController < ApiController
     before_action :check_cloudflare_turnstile, only: :create
+    # Public subscription form endpoint; bot checks and validation are not CanCan resources.
+    skip_authorization_check only: :create
 
     def create
       # turnstile token is only used for bot check so strip it out before validation and submission

--- a/app/controllers/api/teacher_invitations_controller.rb
+++ b/app/controllers/api/teacher_invitations_controller.rb
@@ -31,7 +31,7 @@ module Api
     end
 
     def ensure_invitation_email_matches_user_email
-      return if @invitation.email_address.casecmp?(current_user.email)
+      return if invitation_email_matches_user?
 
       render json: { error: 'Invitation email does not match user email' }, status: :forbidden
     end
@@ -42,6 +42,12 @@ module Api
 
     def invitation_authorization_action
       action_name == 'accept' ? :accept : :read
+    end
+
+    def invitation_email_matches_user?
+      current_user.email.present? &&
+        @invitation.email_address.present? &&
+        @invitation.email_address.casecmp?(current_user.email)
     end
   end
 end

--- a/app/controllers/api/teacher_invitations_controller.rb
+++ b/app/controllers/api/teacher_invitations_controller.rb
@@ -7,6 +7,7 @@ module Api
     before_action :authorize_user
     before_action :load_invitation
     before_action :ensure_invitation_email_matches_user_email
+    before_action :authorize_invitation
 
     def show
       render :show, formats: [:json], status: :ok
@@ -33,6 +34,14 @@ module Api
       return if @invitation.email_address.casecmp?(current_user.email)
 
       render json: { error: 'Invitation email does not match user email' }, status: :forbidden
+    end
+
+    def authorize_invitation
+      authorize! invitation_authorization_action, @invitation
+    end
+
+    def invitation_authorization_action
+      action_name == 'accept' ? :accept : :read
     end
   end
 end

--- a/app/controllers/api/user_jobs_controller.rb
+++ b/app/controllers/api/user_jobs_controller.rb
@@ -33,7 +33,10 @@ module Api
     private
 
     def authorized_user_job
-      user_job = UserJob.find_by(good_job_batch_id: params[:id])
+      user_job = UserJob.find_by(
+        good_job_batch_id: params[:id],
+        user_id: current_user.id
+      )
 
       if user_job
         authorize! :read, user_job
@@ -41,8 +44,6 @@ module Api
       end
 
       authorize! :read, UserJob.new(user_id: current_user.id)
-      nil
-    rescue CanCan::AccessDenied
       nil
     end
 

--- a/app/controllers/api/user_jobs_controller.rb
+++ b/app/controllers/api/user_jobs_controller.rb
@@ -5,6 +5,7 @@ module Api
     before_action :authorize_user
 
     def index
+      authorize! :read, UserJob.new(user_id: current_user.id)
       user_jobs = UserJob.where(user_id: current_user.id)
 
       batches = user_jobs.filter_map do |user_job|
@@ -19,10 +20,7 @@ module Api
     end
 
     def show
-      user_job = UserJob.find_by(
-        good_job_batch_id: params[:id],
-        user_id: current_user.id
-      )
+      user_job = authorized_user_job
 
       batch = batch_attributes_for(user_job) if user_job
       if batch.present?
@@ -33,6 +31,20 @@ module Api
     end
 
     private
+
+    def authorized_user_job
+      user_job = UserJob.find_by(good_job_batch_id: params[:id])
+
+      if user_job
+        authorize! :read, user_job
+        return user_job
+      end
+
+      authorize! :read, UserJob.new(user_id: current_user.id)
+      nil
+    rescue CanCan::AccessDenied
+      nil
+    end
 
     def batch_attributes_for(user_job)
       return nil unless user_job

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -49,7 +49,8 @@ class ApiController < ActionController::API
   def authorization_not_performed(exception)
     raise exception if performed?
 
-    internal_server_error(exception)
+    Sentry.capture_exception(exception)
+    render json: { error: 'Internal server error' }, status: :internal_server_error
   end
 
   def render_error_as_json(exception, status)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -9,9 +9,11 @@ class ApiController < ActionController::API
   rescue_from ActionController::ParameterMissing, with: :bad_request
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from CanCan::AccessDenied, with: :denied
+  rescue_from CanCan::AuthorizationNotPerformed, with: :authorization_not_performed
   rescue_from ParameterError, with: :unprocessable
 
   before_action :set_paper_trail_whodunnit
+  check_authorization
 
   private
 
@@ -42,6 +44,12 @@ class ApiController < ActionController::API
   def internal_server_error(exception)
     Sentry.capture_exception(exception)
     render_error_as_json(exception, :internal_server_error)
+  end
+
+  def authorization_not_performed(exception)
+    raise exception if performed?
+
+    internal_server_error(exception)
   end
 
   def render_error_as_json(exception, status)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -5,6 +5,8 @@ class GraphqlController < ApiController
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately
   # protect_from_forgery with: :null_session
+  # Authorization is handled by GraphQL fields and mutations via current_ability.
+  skip_authorization_check only: :execute
 
   def execute
     result = EditorApiSchema.execute(query, variables:, context:, operation_name:)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,7 +36,9 @@ class Ability
   def define_authenticated_abilities(user)
     can :read, UserJob, user_id: user.id
     can %i[read accept], TeacherInvitation do |invitation|
-      user.email.present? && invitation.email_address.casecmp?(user.email)
+      user.email.present? &&
+        invitation.email_address.present? &&
+        invitation.email_address.casecmp?(user.email)
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
 
     return unless user
 
+    define_authenticated_abilities(user)
     define_authenticated_non_student_abilities(user)
     user.schools.active.each do |school|
       define_school_student_abilities(user:, school:) if user.school_student?(school)
@@ -30,6 +31,13 @@ class Ability
 
     # Anyone can read publicly shared lessons.
     can :read, Lesson, visibility: 'public'
+  end
+
+  def define_authenticated_abilities(user)
+    can :read, UserJob, user_id: user.id
+    can %i[read accept], TeacherInvitation do |invitation|
+      user.email.present? && invitation.email_address.casecmp?(user.email)
+    end
   end
 
   def define_authenticated_non_student_abilities(user)

--- a/spec/features/user_job/showing_user_jobs_spec.rb
+++ b/spec/features/user_job/showing_user_jobs_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Showing user jobs', type: :request do
   let(:headers) { { Authorization: UserProfileMock::TOKEN } }
   let(:school) { create(:school) }
   let(:owner) { create(:owner, school:) }
+  let(:other_user) { create(:user) }
 
   let!(:batch) { GoodJob::BatchRecord.create!(description: school.id) }
   let!(:user_job) { create(:user_job, good_job_batch_id: batch.id, user_id: owner.id) }
@@ -38,5 +39,14 @@ RSpec.describe 'Showing user jobs', type: :request do
     data = JSON.parse(response.body, symbolize_names: true)
 
     expect(data[:job][:id]).to eq(job_id)
+  end
+
+  it 'responds 404 Not Found when the job belongs to another user' do
+    other_batch = GoodJob::BatchRecord.create!(description: 'other-user-job')
+    other_user_job = create(:user_job, good_job_batch_id: other_batch.id, user_id: other_user.id)
+
+    get("/api/user_jobs/#{other_user_job.good_job_batch_id}", headers:)
+
+    expect(response).to have_http_status(:not_found)
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe Ability do
   let(:project) { build(:project, user_id:) }
   let(:starter_project) { build(:project, user_id: nil) }
 
+  describe 'TeacherInvitation' do
+    let(:user) { build(:user, email: 'teacher@example.com') }
+
+    it { is_expected.to be_able_to(:read, build(:teacher_invitation, email_address: user.email)) }
+    it { is_expected.to be_able_to(:accept, build(:teacher_invitation, email_address: user.email)) }
+    it { is_expected.not_to be_able_to(:read, build(:teacher_invitation, email_address: nil)) }
+  end
+
   describe 'Project' do
     context 'with no user' do
       let(:user) { nil }

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ApiController do
       cattr_accessor :authorize_user_required
       cattr_accessor :error
 
+      skip_authorization_check only: :index
+
       def index
         authorize_user if self.class.authorize_user_required
         raise self.class.error if self.class.error.present?
@@ -16,14 +18,23 @@ RSpec.describe ApiController do
       end
     end
   end
+  let(:unguarded_test_controller) do
+    Class.new(ApiController) do
+      def index
+        render json: {}
+      end
+    end
+  end
 
   before do
     stub_const('TestController', test_controller)
+    stub_const('UnguardedTestController', unguarded_test_controller)
 
     Rails.application.routes.disable_clear_and_finalize = true
 
     Rails.application.routes.draw do
       get '/test', to: 'test#index'
+      get '/unguarded_test', to: 'unguarded_test#index'
     end
   end
 
@@ -159,6 +170,12 @@ RSpec.describe ApiController do
       expect(response.parsed_body).to include(
         'error' => 'RuntimeError: foo'
       )
+    end
+  end
+
+  context 'when an action completes without CanCan authorization' do
+    it 'fails closed with an authorization-not-performed error' do
+      expect { get '/unguarded_test' }.to raise_error(CanCan::AuthorizationNotPerformed)
     end
   end
 

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -173,6 +173,33 @@ RSpec.describe ApiController do
     end
   end
 
+  context 'when CanCan::AuthorizationNotPerformed is raised before rendering' do
+    let(:error) { CanCan::AuthorizationNotPerformed.new('foo') }
+
+    before do
+      test_controller.error = error
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it 'reports exception to Sentry' do
+      get '/test'
+
+      expect(Sentry).to have_received(:capture_exception).with(error)
+    end
+
+    it 'responds with 500 Internal server error status code' do
+      get '/test'
+
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
+    it 'responds with a generic error message' do
+      get '/test'
+
+      expect(response.parsed_body).to eq('error' => 'Internal server error')
+    end
+  end
+
   context 'when an action completes without CanCan authorization' do
     it 'fails closed with an authorization-not-performed error' do
       expect { get '/unguarded_test' }.to raise_error(CanCan::AuthorizationNotPerformed)

--- a/spec/requests/projects/remix_spec.rb
+++ b/spec/requests/projects/remix_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe 'Remix requests' do
 
         expect(response).to have_http_status(:not_found)
       end
+
+      context 'when the original project is a private project belonging to another user' do
+        let!(:original_project) { create(:project, user_id: create(:user).id) }
+
+        it 'returns forbidden' do
+          get("/api/projects/#{original_project.identifier}/remixes", headers:)
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'when the original project belongs to another user but is visible to the school owner' do
+        let(:teacher) { create(:teacher, school:) }
+        let(:lesson) { create(:lesson, school:, user_id: teacher.id, visibility: 'students') }
+        let!(:original_project) { create(:project, school:, lesson:, user_id: teacher.id) }
+
+        it 'returns success' do
+          get("/api/projects/#{original_project.identifier}/remixes", headers:)
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     describe '#show' do
@@ -169,7 +191,7 @@ RSpec.describe 'Remix requests' do
         expect(response).to have_http_status(:not_found)
       end
 
-      context 'when the original project belongs to another user' do
+      context 'when the original project is a private project belonging to another user' do
         let!(:original_project) { create(:project, user_id: create(:user).id) }
 
         it 'returns forbidden without creating a remix' do


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1487

## Points for consideration:

- Security
  - Enables CanCanCan `check_authorization` for API controllers so actions fail closed if they complete without an explicit CanCan authorization decision.
  - Public/non-resource endpoints are explicitly annotated with action-scoped `skip_authorization_check`.
  - This guard confirms that authorization happened, but endpoint-specific specs are still needed to prove the correct resource/action is authorized.

- Performance
  - Minimal expected impact.
  - Adds lightweight after-action authorization verification.
  - A few endpoints now perform explicit CanCan checks, using existing loaded resources or scoped objects.

## What's changed?

- Enabled CanCanCan `check_authorization` in `ApiController`.
- Added explicit `skip_authorization_check only:` annotations for intentionally public or non-resource API actions.
- Added missing CanCan authorization checks to audited API actions that read or mutate protected resources.
- Added authenticated ability rules for user jobs and teacher invitations.
- Added a regression spec proving an unaudited API action raises `CanCan::AuthorizationNotPerformed`.

