### PR TITLE
Defensive serving Scratch projects

### DIFF
--- a/app/controllers/api/scratch/projects_controller.rb
+++ b/app/controllers/api/scratch/projects_controller.rb
@@ -105,7 +105,10 @@ module Api
       end
 
       def load_project
-        @project = Project.find_by!(identifier: params.expect(:id), project_type: Project::Types::CODE_EDITOR_SCRATCH)
+        @project = Project.joins(:scratch_component).find_by!(
+          identifier: params.expect(:id),
+          project_type: Project::Types::CODE_EDITOR_SCRATCH
+        )
       end
     end
   end

--- a/spec/features/scratch/showing_a_scratch_project_spec.rb
+++ b/spec/features/scratch/showing_a_scratch_project_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe 'Showing a Scratch project', type: :request do
     expect(response).to have_http_status(:not_found)
   end
 
+  it 'returns a 404 if project does not have a scratch component' do
+    authenticated_in_hydra_as(teacher)
+    project = create(
+      :project,
+      project_type: Project::Types::CODE_EDITOR_SCRATCH,
+      locale: 'en',
+      school: school,
+      user_id: teacher.id,
+      lesson: lesson
+    )
+
+    get "/api/scratch/projects/#{project.identifier}", headers: headers
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   it 'returns a 200 ok if not logged in for an anonymous scratch project' do
     project = create(:scratch_project, locale: 'en', user_id: nil)
     get "/api/scratch/projects/#{project.identifier}"


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1457

## Points for consideration

- **Security:** No change to authentication or authorization behaviour.
- **Performance:** The project lookup now includes an inner join against `scratch_components`. This uses the existing indexed `project_id` and should have small to none impact.
- Existing or historical Scratch projects without a Scratch component will now be treated as not found rather than causing an internal server error.

## What’s changed?

- Approached to fix Sentry issue.
- Requires a Scratch project to have an associated Scratch component when loading it through the Scratch projects endpoint.
- Returns the existing `404 Not Found` response for projects in this invalid state instead of raising:

  ```text
  NoMethodError: undefined method `content_with_stage_first` for nil
  ```

- Adds a request spec covering a Scratch project without a Scratch component.
- Valid Scratch projects are unaffected.

## Steps to perform after deploying to production

None. This change does not require a migration, data cleanup, or Rake task. Existing malformed records will be handled safely by the endpoint.