### PR TITLE
Allow school owners to save projects outside their classes

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -24,7 +24,7 @@ module Api
         @user = project_with_user[1]
       end
 
-      @project.user_id = current_user.id if class_teacher?(@project) || school_owner?
+      @project.user_id = current_user.id if class_teacher?(@project) || school_owner_can_update?(@project)
       render :show, formats: [:json]
     end
 
@@ -114,6 +114,10 @@ module Api
 
     def school_owner?
       school && current_user.school_owner?(school)
+    end
+
+    def school_owner_can_update?(project)
+      school_owner? && can?(:update, project)
     end
 
     def class_teacher?(project)

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -24,7 +24,7 @@ module Api
         @user = project_with_user[1]
       end
 
-      @project.user_id = current_user.id if class_teacher?(@project)
+      @project.user_id = current_user.id if class_teacher?(@project) || school_owner?
       render :show, formats: [:json]
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -73,7 +73,7 @@ class Ability
     can(%i[read update destroy], School, id: school.id)
     can(%i[read], :school_member)
     can(%i[read create import update destroy regenerate_join_code], SchoolClass, school: { id: school.id })
-    can(%i[read show_context], Project, school_id: school.id, lesson: { visibility: %w[teachers students] })
+    can(%i[read update show_context], Project, school_id: school.id, lesson: { visibility: %w[teachers students] })
     can(%i[read create create_batch destroy], ClassStudent, school_class: { school: { id: school.id } })
     can(%i[read create destroy], :school_owner)
     can(%i[read create destroy], :school_teacher)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -136,7 +136,7 @@ class Project < ApplicationRecord
 
     return if no_lesson || no_school_class || user_is_school_owner? || user_is_class_student? || user_is_class_teacher?
 
-    errors.add(:user, "'#{user_id}' is not a class member or school owner for lesson '#{lesson_id}'")
+    errors.add(:user, "'#{user_id}' is not a class member and is not a school owner for school '#{school_id}' (lesson '#{lesson_id}')")
   end
 
   def user_is_class_student?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   validate :identifier_cannot_be_taken_by_another_user
   validates :locale, presence: true, unless: :user_id
   validate :user_has_a_role_within_the_school
-  validate :user_is_class_teacher_or_student
+  validate :user_can_own_class_project
   validate :project_with_instructions_must_belong_to_school
   validate :project_with_school_id_has_school_project
   validate :school_project_school_matches_project_school
@@ -129,18 +129,22 @@ class Project < ApplicationRecord
     errors.add(:user, msg)
   end
 
-  def user_is_class_teacher_or_student
+  def user_can_own_class_project
     # TODO: Revisit the case where the lesson is not associated to a class i.e. when we build a lesson library
     no_lesson = !lesson
     no_school_class = lesson && !lesson.school_class
 
-    return if no_lesson || no_school_class || user_is_class_student? || user_is_class_teacher?
+    return if no_lesson || no_school_class || user_is_school_owner? || user_is_class_student? || user_is_class_teacher?
 
-    errors.add(:user, "'#{user_id}' is not a class member or the owner of the lesson '#{lesson_id}'")
+    errors.add(:user, "'#{user_id}' is not a class member or school owner for lesson '#{lesson_id}'")
   end
 
   def user_is_class_student?
     lesson&.school_class&.students&.exists?(student_id: user_id)
+  end
+
+  def user_is_school_owner?
+    school && User.new(id: user_id).school_owner?(school)
   end
 
   def user_is_class_teacher?

--- a/spec/features/scratch/updating_a_scratch_project_spec.rb
+++ b/spec/features/scratch/updating_a_scratch_project_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe 'Updating a Scratch project', type: :request do
     )
   end
 
+  it "allows a school owner to update another teacher's project outside their class" do
+    owner = create(:owner, school:)
+    authenticated_in_hydra_as(owner)
+    project = create(
+      :project,
+      project_type: Project::Types::CODE_EDITOR_SCRATCH,
+      locale: 'en',
+      school:,
+      lesson:,
+      user_id: teacher.id
+    )
+    create(:scratch_component, project:)
+
+    put "/api/scratch/projects/#{project.identifier}", params: { targets: ['owner update'] }, headers: auth_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(project.reload.scratch_component.content.to_h['targets']).to eq(['owner update'])
+  end
+
   it 'returns 403 Forbidden when trying to update a project user does not have access to' do
     authenticated_in_hydra_as(teacher)
     project = create(

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Ability do
         it { is_expected.to be_able_to(:read, project) }
         it { is_expected.to be_able_to(:show_context, project) }
         it { is_expected.not_to be_able_to(:create, project) }
-        it { is_expected.not_to be_able_to(:update, project) }
+        it { is_expected.to be_able_to(:update, project) }
         it { is_expected.not_to be_able_to(:set_finished, project.school_project) }
         it { is_expected.not_to be_able_to(:destroy, project) }
       end
@@ -251,7 +251,7 @@ RSpec.describe Ability do
         it { is_expected.to be_able_to(:read, project) }
         it { is_expected.to be_able_to(:show_context, project) }
         it { is_expected.not_to be_able_to(:create, project) }
-        it { is_expected.not_to be_able_to(:update, project) }
+        it { is_expected.to be_able_to(:update, project) }
         it { is_expected.not_to be_able_to(:set_finished, project.school_project) }
         it { is_expected.not_to be_able_to(:destroy, project) }
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -135,6 +135,14 @@ RSpec.describe Project, :versioning do
         expect(project).to be_valid
       end
 
+      it 'is valid if the user is a school owner outside the class' do
+        owner = create(:owner, school:)
+        project.user_id = owner.id
+        project.identifier = 'unique-owner-identifier'
+
+        expect(project).to be_valid
+      end
+
       it 'is invalid if the user is neither the owner nor a class member' do
         project.user_id = SecureRandom.uuid
         expect(project).not_to be_valid

--- a/spec/requests/projects/school_owner_editing_spec.rb
+++ b/spec/requests/projects/school_owner_editing_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'School owner class project editing' do
+  let(:headers) { { Authorization: UserProfileMock::TOKEN } }
+  let(:school) { create(:school) }
+  let(:owner) { create(:owner, school:) }
+  let(:teacher) { create(:teacher, school:) }
+  let(:teacher_ids) { [teacher.id, (owner.id if owner_in_class)].compact }
+  let(:school_class) { create(:school_class, school:, teacher_ids:) }
+  let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'teachers') }
+  let(:project_user) { project_created_by_owner ? owner : teacher }
+  let(:project) { create(:project, school:, lesson:, user_id: project_user.id, project_type:, locale: nil) }
+
+  before do
+    authenticated_in_hydra_as(owner)
+    create(:scratch_component, project:) if project.scratch_project?
+  end
+
+  project_types = [
+    ['Python', Project::Types::PYTHON],
+    ['Scratch', Project::Types::CODE_EDITOR_SCRATCH]
+  ]
+  ownership_cases = [
+    ['created by the owner in their class', true, true],
+    ['created by the owner outside their class', true, false],
+    ['created by another teacher in the owner\'s class', false, true],
+    ['created by another teacher outside the owner\'s class', false, false]
+  ]
+
+  project_types.product(ownership_cases).each do |(type_name, type), (case_name, created_by_owner, in_class)|
+    context "with a #{type_name} project #{case_name}" do
+      let(:project_type) { type }
+      let(:project_created_by_owner) { created_by_owner }
+      let(:owner_in_class) { in_class }
+
+      it 'loads as editable and updates the original project' do
+        get("/api/projects/#{project.identifier}", headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['user_id']).to eq(owner.id)
+
+        project_count = Project.count
+        if project.scratch_project?
+          put("/api/scratch/projects/#{project.identifier}", params: { targets: ['owner update'] }, headers:)
+          expect(project.reload.scratch_component.content.to_h['targets']).to eq(['owner update'])
+        else
+          put("/api/projects/#{project.identifier}", params: { project: { name: 'owner update' } }, headers:)
+          expect(project.reload.name).to eq('owner update')
+        end
+
+        expect(response).to have_http_status(:ok)
+        expect(Project.count).to eq(project_count)
+        expect(project.reload.user_id).to eq(project_user.id)
+      end
+    end
+  end
+end

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -5,13 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Project show requests' do
   let(:headers) { {} }
   let(:teacher) { create(:teacher, school:) }
+  let(:authenticated_user) { teacher }
   let(:school) { create(:school) }
 
   context 'when user is logged in' do
     let(:headers) { { Authorization: UserProfileMock::TOKEN } }
 
     before do
-      authenticated_in_hydra_as(teacher)
+      authenticated_in_hydra_as(authenticated_user)
       stub_profile_api_list_school_students(school:, student_attributes: [{ name: 'Joe Bloggs' }])
       stub_profile_api_create_safeguarding_flag
     end
@@ -150,35 +151,36 @@ RSpec.describe 'Project show requests' do
     end
 
     context "when a school owner loads another teacher's project outside their class" do
-      let(:teacher) { create(:owner, school:) }
-      let(:project_teacher) { create(:teacher, school:) }
-      let(:school_class) { create(:school_class, school:, teacher_ids: [project_teacher.id]) }
-      let(:lesson) { create(:lesson, school:, school_class:, user_id: project_teacher.id, visibility: 'teachers') }
-      let(:project) { create(:project, school:, lesson:, user_id: project_teacher.id, locale: nil) }
+      let(:authenticated_user) { owner }
+      let(:owner) { create(:owner, school:) }
+      let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }
+      let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'teachers') }
+      let(:project) { create(:project, school:, lesson:, user_id: teacher.id, locale: nil) }
 
       it 'returns the owner as the effective project owner without changing the stored owner' do
         get("/api/projects/#{project.identifier}", headers:)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['user_id']).to eq(teacher.id)
-        expect(project.reload.user_id).to eq(project_teacher.id)
+        expect(response.parsed_body['user_id']).to eq(owner.id)
+        expect(project.reload.user_id).to eq(teacher.id)
       end
     end
 
     context "when a school owner loads a student's project from a class they teach" do
-      let(:teacher) { create(:owner, school:) }
+      let(:authenticated_user) { owner }
+      let(:owner) { create(:owner, school:) }
       let(:student) { create(:student, school:) }
-      let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }
+      let(:school_class) { create(:school_class, school:, teacher_ids: [owner.id]) }
       let(:class_student) { create(:class_student, school_class:, student_id: student.id) }
-      let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'students') }
-      let(:lesson_project) { create(:project, school:, lesson:, user_id: teacher.id, locale: nil) }
+      let(:lesson) { create(:lesson, school:, school_class:, user_id: owner.id, visibility: 'students') }
+      let(:lesson_project) { create(:project, school:, lesson:, user_id: owner.id, locale: nil) }
       let(:student_project) do
         class_student
         create(:project, school:, user_id: student.id, remixed_from_id: lesson_project.id, locale: nil)
       end
 
       before do
-        create(:teacher_role, school:, user_id: teacher.id)
+        create(:teacher_role, school:, user_id: owner.id)
       end
 
       it 'returns the student as the project owner because the school owner cannot update it' do
@@ -186,7 +188,7 @@ RSpec.describe 'Project show requests' do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['user_id']).to eq(student.id)
-        expect(Ability.new(teacher).can?(:update, student_project)).to be(false)
+        expect(Ability.new(owner).can?(:update, student_project)).to be(false)
       end
     end
 

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -149,6 +149,22 @@ RSpec.describe 'Project show requests' do
       end
     end
 
+    context "when a school owner loads another teacher's project outside their class" do
+      let(:teacher) { create(:owner, school:) }
+      let(:project_teacher) { create(:teacher, school:) }
+      let(:school_class) { create(:school_class, school:, teacher_ids: [project_teacher.id]) }
+      let(:lesson) { create(:lesson, school:, school_class:, user_id: project_teacher.id, visibility: 'teachers') }
+      let(:project) { create(:project, school:, lesson:, user_id: project_teacher.id, locale: nil) }
+
+      it 'returns the owner as the effective project owner without changing the stored owner' do
+        get("/api/projects/#{project.identifier}", headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['user_id']).to eq(teacher.id)
+        expect(project.reload.user_id).to eq(project_teacher.id)
+      end
+    end
+
     context 'when loading another user\'s project' do
       let!(:another_project) { create(:project, user_id: SecureRandom.uuid, locale: nil) }
       let(:another_project_json) do

--- a/spec/requests/projects/show_spec.rb
+++ b/spec/requests/projects/show_spec.rb
@@ -165,6 +165,31 @@ RSpec.describe 'Project show requests' do
       end
     end
 
+    context "when a school owner loads a student's project from a class they teach" do
+      let(:teacher) { create(:owner, school:) }
+      let(:student) { create(:student, school:) }
+      let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }
+      let(:class_student) { create(:class_student, school_class:, student_id: student.id) }
+      let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'students') }
+      let(:lesson_project) { create(:project, school:, lesson:, user_id: teacher.id, locale: nil) }
+      let(:student_project) do
+        class_student
+        create(:project, school:, user_id: student.id, remixed_from_id: lesson_project.id, locale: nil)
+      end
+
+      before do
+        create(:teacher_role, school:, user_id: teacher.id)
+      end
+
+      it 'returns the student as the project owner because the school owner cannot update it' do
+        get("/api/projects/#{student_project.identifier}", headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['user_id']).to eq(student.id)
+        expect(Ability.new(teacher).can?(:update, student_project)).to be(false)
+      end
+    end
+
     context 'when loading another user\'s project' do
       let!(:another_project) { create(:project, user_id: SecureRandom.uuid, locale: nil) }
       let(:another_project_json) do

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -156,6 +156,27 @@ RSpec.describe 'Project update requests' do
     end
   end
 
+  context "when a school owner updates another teacher's class project" do
+    let(:school) { create(:school) }
+    let(:owner) { create(:owner, school:) }
+    let(:teacher) { create(:teacher, school:) }
+    let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }
+    let(:lesson) { create(:lesson, school:, school_class:, user_id: teacher.id, visibility: 'teachers') }
+    let(:project) { create(:project, school:, lesson:, locale: nil, user_id: teacher.id) }
+    let(:params) { { project: { name: 'updated by school owner' } } }
+
+    before do
+      authenticated_in_hydra_as(owner)
+    end
+
+    it 'updates the original project' do
+      put("/api/projects/#{project.identifier}", params:, headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(project.reload.name).to eq('updated by school owner')
+    end
+  end
+
   context 'when authed user is a student and the project is remixed from a lesson project' do
     let(:teacher) { create(:teacher, school:) }
     let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id]) }


### PR DESCRIPTION
## Status

- Partially closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/636

## Points for consideration:

- Security
- Performance

## What's changed?

Allows school owners to save any project in their school, even when they are not members of the project’s class.
This prevents the editor from creating a remix when the owner should be editing the original project.
Tests cover Scratch and Python projects across all combinations of project ownership and class membership.

