### PR TITLE
Stop reporting expected student validation errors to Sentry

### DIFF
--- a/lib/concepts/school_student/create.rb
+++ b/lib/concepts/school_student/create.rb
@@ -7,6 +7,9 @@ module SchoolStudent
         response = OperationResponse.new
         response[:student_id] = create_student(school, school_student_params, token)
         response
+      rescue ProfileApiClient::Student422Error => e
+        response[:error] = e.to_s
+        response
       rescue StandardError => e
         Sentry.capture_exception(e)
         response[:error] = e.to_s

--- a/lib/concepts/school_student/create.rb
+++ b/lib/concepts/school_student/create.rb
@@ -4,16 +4,13 @@ module SchoolStudent
   class Create
     class << self
       def call(school:, school_student_params:, token:)
-        response = OperationResponse.new
-        response[:student_id] = create_student(school, school_student_params, token)
-        response
+        student_id = create_student(school, school_student_params, token)
+        OperationResponse[student_id:]
       rescue ProfileApiClient::Student422Error => e
-        response[:error] = e.to_s
-        response
+        OperationResponse[error: e.to_s]
       rescue StandardError => e
         Sentry.capture_exception(e)
-        response[:error] = e.to_s
-        response
+        OperationResponse[error: e.to_s]
       end
 
       private

--- a/spec/concepts/school_student/create_spec.rb
+++ b/spec/concepts/school_student/create_spec.rb
@@ -77,17 +77,28 @@ RSpec.describe SchoolStudent::Create, type: :unit do
     end
   end
 
-  context 'when the student cannot be created in profile api because of a 422 response' do
-    let(:error) { { 'message' => "something's up with the username" } }
+  context 'when Profile API rejects the student details' do
+    let(:error) do
+      {
+        'errorCode' => 'isComplex',
+        'message' => 'Password is too simple'
+      }
+    end
     let(:exception) { ProfileApiClient::Student422Error.new(error) }
 
     before do
       allow(ProfileApiClient).to receive(:create_school_student).and_raise(exception)
+      allow(Sentry).to receive(:capture_exception)
     end
 
-    it 'adds a useful error message' do
+    it 'returns the translatable error code' do
       response = described_class.call(school:, school_student_params:, token:)
-      expect(response[:error]).to eq("something's up with the username")
+      expect(response[:error]).to eq('isComplex')
+    end
+
+    it 'does not send the expected validation error to Sentry' do
+      described_class.call(school:, school_student_params:, token:)
+      expect(Sentry).not_to have_received(:capture_exception)
     end
   end
 


### PR DESCRIPTION
Related to Sentry issue https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1583

## Points for consideration:

- No security impact.
- No performance impact.

## What's changed?

- When someone tries to create a student with:
  - Username already taken
  - Password matches the username
  - Password too short
  - Missing or invalid student details

Profile API returns an isComplex validation error.
- This is an expected error that is shown to the user, but we were also sending it to Sentry.
- This change handles student validation errors separately, so they are no longer sent to Sentry (since i don't think they add value and cause noise)..

## Steps to perform after deploying to production

No additional steps are required. There are no migrations, configuration changes, or data backfills.