### PR TITLE
Log request origins

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -17,6 +17,13 @@ class ApiController < ActionController::API
 
   private
 
+  def append_info_to_payload(payload)
+    super
+
+    origin = request.origin
+    payload[:origin] = origin if origin.present?
+  end
+
   def bad_request(exception)
     render_error_as_json(exception, :bad_request)
   end

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -42,6 +42,34 @@ RSpec.describe ApiController do
     Rails.application.reload_routes!
   end
 
+  describe 'request logging' do
+    def completed_request_payload(headers: {})
+      payload = nil
+
+      callback = lambda do |event|
+        payload = event.payload
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, 'process_action.action_controller') do
+        get '/test', headers:
+      end
+
+      payload
+    end
+
+    it 'includes the request origin in the completed request payload' do
+      payload = completed_request_payload(headers: { 'Origin' => 'https://editor.raspberrypi.org' })
+
+      expect(payload).to include(origin: 'https://editor.raspberrypi.org')
+    end
+
+    it 'omits the origin when the request does not include one' do
+      payload = completed_request_payload
+
+      expect(payload).not_to have_key(:origin)
+    end
+  end
+
   context 'when ActionController::ParameterMissing is raised' do
     before do
       test_controller.error = ActionController::ParameterMissing.new('foo')


### PR DESCRIPTION


## Status

- Closes [#1588](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1588)

## What's changed?

- Adds the request `Origin` header to the structured completed-request payload.
- Applies the logging to requests through `ApiController`.
- Adds request specs covering requests with and without an `Origin` header.
- Makes the origin available for filtering and grouping request logs in Better Stack.

