### PR TITLE
Address potential weaknesses source of join-code generation

### DIFF
--- a/lib/join_code_generator.rb
+++ b/lib/join_code_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 class JoinCodeGenerator
   # Omit K, X, Z — commonly confused or offensive in short codes.
   CONSONANTS = %w[B C D F G H J L M N P Q R S T V W Y].freeze
@@ -7,13 +9,10 @@ class JoinCodeGenerator
   # Format: CDDD-CDDD (e.g., B123-C456). C = consonant from CONSONANTS, D = digit.
   FORMAT_REGEX = Regexp.new("\\A(?:#{CONSONANTS.join('|')})\\d{3}-(?:#{CONSONANTS.join('|')})\\d{3}\\z").freeze
 
-  cattr_accessor :random
-
-  self.random ||= Random.new
-
   def self.generate
     seg = lambda do
-      "#{CONSONANTS.sample(random: random)}#{format('%03d', random.rand(1000))}"
+      consonant = CONSONANTS[SecureRandom.random_number(CONSONANTS.length)]
+      "#{consonant}#{format('%03d', SecureRandom.random_number(1000))}"
     end
 
     "#{seg.call}-#{seg.call}"

--- a/spec/lib/join_code_generator_spec.rb
+++ b/spec/lib/join_code_generator_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe JoinCodeGenerator do
     it 'matches CDDD-CDDD' do
       expect(described_class.generate).to match(described_class::FORMAT_REGEX)
     end
+
+    it 'uses SecureRandom for each code component' do
+      allow(SecureRandom).to receive(:random_number).with(described_class::CONSONANTS.length).and_return(0, 1)
+      allow(SecureRandom).to receive(:random_number).with(1000).and_return(123, 456)
+
+      expect(described_class.generate).to eq('B123-C456')
+      expect(SecureRandom).to have_received(:random_number).with(described_class::CONSONANTS.length).twice
+      expect(SecureRandom).to have_received(:random_number).with(1000).twice
+    end
   end
 
   describe '.normalize' do


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1582

## What's changed?

My guess for the Sentry error is that, JoinCodeGenerator created one Random.new instance when the application loaded. 

Maybe Puma preloads the application and then forks its workers, so each worker inherited the same random-generator state. Those workers could therefore generate the same sequence of join codes, or there is a hash collision because of not being random although this is less likely.

The PR replaces that shared Random instance with SecureRandom, which obtains fork-safe randomness from the operating system. Each worker therefore generates an independent sequence.