### PR TITLE
Allow Experience CS to sync public Scratch projects

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -104,18 +104,25 @@ module Api
         :user_id,
         :identifier,
         :name,
-        :project_type,
         :locale,
         {
           components: %i[id name extension content index default]
         },
-        scratch_component: {},
         parent: {},
         image_list: []
       ]
-      return attributes if current_user&.student?
+      attributes.push(:instructions, { instructions: [:markdown_content] }) if can_set_instructions?
+      attributes.push(:project_type, { scratch_component: { content: {} } }) if can_set_project_type_and_scratch_data?
 
-      attributes + [:instructions, { instructions: [:markdown_content] }]
+      attributes
+    end
+
+    def can_set_instructions?
+      !current_user&.student?
+    end
+
+    def can_set_project_type_and_scratch_data?
+      action_name == 'create' || current_user&.experience_cs_admin?
     end
 
     def school_owner?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -161,9 +161,14 @@ class Project < ApplicationRecord
   end
 
   def project_with_instructions_must_belong_to_school
+    return if public_code_editor_scratch_project?
     return unless instructions && !school_id
 
     errors.add(:instructions, 'Projects with instructions must belong to a school')
+  end
+
+  def public_code_editor_scratch_project?
+    user_id.nil? && locale.present? && project_type == Types::CODE_EDITOR_SCRATCH
   end
 
   def project_with_school_id_has_school_project

--- a/lib/concepts/project/operations/update.rb
+++ b/lib/concepts/project/operations/update.rb
@@ -9,6 +9,7 @@ class Project
         setup_deletions(response, update_hash)
         update_project_attributes(response, update_hash)
         update_component_attributes(response, update_hash)
+        update_scratch_component_attributes(response, update_hash)
         persist_changes(response)
         response
       rescue StandardError => e
@@ -45,7 +46,7 @@ class Project
       def update_project_attributes(response, update_hash)
         return if response.failure?
 
-        response[:project].assign_attributes(update_hash.slice(:name, :instructions))
+        response[:project].assign_attributes(update_hash.slice(:name, :instructions, :project_type))
       end
 
       def update_component_attributes(response, update_hash)
@@ -65,11 +66,20 @@ class Project
         component.assign_attributes(component_params)
       end
 
+      def update_scratch_component_attributes(response, update_hash)
+        return if response.failure? || update_hash[:scratch_component].nil?
+
+        scratch_component = response[:project].scratch_component || response[:project].build_scratch_component
+        scratch_component.assign_attributes(update_hash[:scratch_component].slice(:content))
+        response[:scratch_component] = scratch_component
+      end
+
       def persist_changes(response)
         return if response.failure?
 
         ActiveRecord::Base.transaction do
           response[:project].save!
+          response[:scratch_component]&.save!
           response[:project].components.where(id: response[:component_ids_to_delete]).destroy_all
         end
       end

--- a/spec/concepts/project/update_spec.rb
+++ b/spec/concepts/project/update_spec.rb
@@ -80,6 +80,29 @@ RSpec.describe Project::Update, type: :unit do
       end
     end
 
+    context 'when Scratch component attributes are provided' do
+      subject(:update_scratch_component) do
+        described_class.call(
+          project:,
+          update_hash: { scratch_component: { content: new_content, project_id: other_project.id } }
+        )
+      end
+
+      let!(:scratch_component) { create(:scratch_component, project:) }
+      let(:other_project) { create(:project) }
+      let(:new_content) { { targets: [{ isStage: true }], monitors: [], extensions: [], meta: {} } }
+
+      it 'updates the content' do
+        expect { update_scratch_component }
+          .to change { scratch_component.reload.content.to_h }
+          .to(new_content.deep_stringify_keys)
+      end
+
+      it 'ignores other attributes' do
+        expect { update_scratch_component }.not_to change { scratch_component.reload.project_id }
+      end
+    end
+
     context 'when updating the instructions if project does not belong to a school' do
       let(:instructions) { 'new instructions' }
 

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -227,15 +227,25 @@ RSpec.describe 'Creating a project', type: :request do
     end
   end
 
-  context 'when an Experience CS admin creates a starter Scratch project' do
+  context 'when an Experience CS admin creates a Code Classroom Blocks project' do
     let(:experience_cs_admin) { create(:experience_cs_admin_user) }
+    let(:scratch_data) do
+      {
+        targets: [{ isStage: true, name: 'Stage' }],
+        monitors: [],
+        extensions: [],
+        meta: { semver: '3.0.0' }
+      }
+    end
     let(:params) do
       {
         project: {
           identifier: 'test-project',
+          instructions: '<p>Project instructions</p>',
           name: 'Test Project',
           locale: 'fr',
-          project_type: Project::Types::SCRATCH,
+          project_type: Project::Types::CODE_EDITOR_SCRATCH,
+          scratch_component: { content: scratch_data },
           user_id: nil,
           components: []
         }
@@ -247,43 +257,56 @@ RSpec.describe 'Creating a project', type: :request do
     end
 
     it 'responds 201 Created' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       expect(response).to have_http_status(:created)
     end
 
     it 'sets the project identifier to the specified (not the generated) value' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       data = JSON.parse(response.body, symbolize_names: true)
 
       expect(data[:identifier]).to eq('test-project')
     end
 
     it 'sets the project name to the specified value' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       data = JSON.parse(response.body, symbolize_names: true)
 
       expect(data[:name]).to eq('Test Project')
     end
 
     it 'sets the project locale to the specified value' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       data = JSON.parse(response.body, symbolize_names: true)
 
       expect(data[:locale]).to eq('fr')
     end
 
     it 'sets the project type to the specified value' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       data = JSON.parse(response.body, symbolize_names: true)
 
-      expect(data[:project_type]).to eq(Project::Types::SCRATCH)
+      expect(data[:project_type]).to eq(Project::Types::CODE_EDITOR_SCRATCH)
     end
 
     it 'sets the project user_id to the specified value (i.e. nil to represent a public project)' do
-      post('/api/projects', headers:, params:)
+      post('/api/projects', headers:, params:, as: :json)
       data = JSON.parse(response.body, symbolize_names: true)
 
       expect(data[:user_id]).to be_nil
+    end
+
+    it 'stores the project instructions' do
+      post('/api/projects', headers:, params:, as: :json)
+
+      expect(Project.find_by!(identifier: 'test-project', locale: 'fr').instructions).to eq('<p>Project instructions</p>')
+    end
+
+    it 'stores the Scratch data in a Scratch component' do
+      post('/api/projects', headers:, params:, as: :json)
+
+      project = Project.find_by!(identifier: 'test-project', locale: 'fr')
+      expect(project.scratch_component.content.to_h).to eq(scratch_data.deep_stringify_keys)
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -53,6 +53,30 @@ RSpec.describe Project, :versioning do
       expect(valid_project).to be_valid
     end
 
+    it 'allows a public Code Classroom Blocks project to have instructions' do
+      project = build(
+        :project,
+        instructions: '<p>Project instructions</p>',
+        locale: 'en',
+        project_type: Project::Types::CODE_EDITOR_SCRATCH,
+        user_id: nil
+      )
+
+      expect(project).to be_valid
+    end
+
+    it 'does not allow another type of public project to have instructions' do
+      project = build(
+        :project,
+        instructions: '<p>Project instructions</p>',
+        locale: 'en',
+        project_type: Project::Types::SCRATCH,
+        user_id: nil
+      )
+
+      expect(project).not_to be_valid
+    end
+
     it 'is invalid if school_id but no school project' do
       invalid_project = build(:project, school_id: SecureRandom.uuid)
       expect(invalid_project).not_to be_valid

--- a/spec/requests/projects/update_spec.rb
+++ b/spec/requests/projects/update_spec.rb
@@ -79,6 +79,28 @@ RSpec.describe 'Project update requests' do
       end
     end
 
+    context 'when project type and Scratch data are specified' do
+      let(:params) do
+        {
+          project: {
+            project_type: Project::Types::CODE_EDITOR_SCRATCH,
+            scratch_component: { content: { targets: [] } }
+          }
+        }
+      end
+
+      it 'does not update the project type' do
+        expect { put("/api/projects/#{project.identifier}", params:, headers:) }
+          .not_to(change { project.reload.project_type })
+      end
+
+      it 'does not create a Scratch component' do
+        put("/api/projects/#{project.identifier}", params:, headers:)
+
+        expect(project.reload.scratch_component).to be_nil
+      end
+    end
+
     context 'when updated (non-school) project has instructions' do
       let(:params) { { project: { instructions: 'updated instructions' } } }
 
@@ -102,6 +124,61 @@ RSpec.describe 'Project update requests' do
     it 'returns forbidden response' do
       put("/api/projects/#{project.identifier}", params:, headers:)
       expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context 'when an Experience CS admin updates a Code Classroom Blocks project' do
+    let(:experience_cs_admin) { create(:experience_cs_admin_user) }
+    let!(:project) do
+      create(
+        :project,
+        identifier: 'experience-cs-project',
+        locale: 'fr',
+        project_type: Project::Types::SCRATCH,
+        user_id: nil
+      )
+    end
+    let(:scratch_data) do
+      {
+        targets: [{ isStage: true, name: 'Scène' }],
+        monitors: [],
+        extensions: [],
+        meta: { semver: '3.0.0' }
+      }
+    end
+    let(:params) do
+      {
+        project: {
+          name: 'Projet traduit',
+          instructions: '<p>Instructions traduites</p>',
+          project_type: Project::Types::CODE_EDITOR_SCRATCH,
+          scratch_component: { content: scratch_data }
+        }
+      }
+    end
+
+    before do
+      authenticated_in_hydra_as(experience_cs_admin)
+    end
+
+    it 'updates the locale-specific project and stores its Scratch data' do
+      put('/api/projects/experience-cs-project?locale=fr', params:, headers:, as: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(project.reload).to have_attributes(
+        name: 'Projet traduit',
+        instructions: '<p>Instructions traduites</p>',
+        project_type: Project::Types::CODE_EDITOR_SCRATCH
+      )
+      expect(project.scratch_component.content.to_h).to eq(scratch_data.deep_stringify_keys)
+    end
+
+    it 'updates an existing Scratch component without creating another one' do
+      create(:scratch_component, project:)
+
+      expect { put('/api/projects/experience-cs-project?locale=fr', params:, headers:, as: :json) }
+        .not_to change(ScratchComponent, :count)
+      expect(project.scratch_component.reload.content.to_h).to eq(scratch_data.deep_stringify_keys)
     end
   end
 


### PR DESCRIPTION
## Status

- Partially closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1657
- Related to https://github.com/RaspberryPiFoundation/experience-cs/pull/2330

  ## Points for consideration:

- Security: Only users with the `experience-cs-admin` role can change the project type and Scratch data for public projects.
- Security: Projects are not yet marked as coming from Experience CS. Until origin tracking is added, only known Experience CS project identifiers should be enabled for synchronization.

## What's changed?

- Allow public, localized `code_editor_scratch` projects to contain instructions. This is a narrow exception to [Restrict instructions to school projects (#479)](https://github.com/RaspberryPiFoundation/editor-api/pull/479) for public Experience CS templates. This may be worth discussing.
- Allow Experience CS admins to change a public project to `code_editor_scratch`.
- Allow Experience CS admins to create or update Scratch data through the project update endpoint.

Some concerns of mine were to understand the cases:

- Existing ExCS stub with no ScratchComponent -> Create ScratchComponent -> Store the ExCS code -> Change type from scratch to code_editor_scratch

- Existing ExCS project with a ScratchComponent -> Replace its content with the latest ExCS code  -> This is intentional because ExCS is the source of truth

- User-owned project  -> Cannot be updated by an experience-cs-admin  -> Authorization prevents the overwrite

- Unrelated public project with the same identifier  -> Could currently be overwritten  -> This is the known provenance/origin risk mentioned in the ticket