### PR TITLE
Seed preview projects for local/preview work

### DIFF
--- a/lib/tasks/project_preview_seeds_helper.rb
+++ b/lib/tasks/project_preview_seeds_helper.rb
@@ -31,23 +31,27 @@ module ProjectPreviewSeedsHelper
       identifier: PROJECT_PREVIEW_IDENTIFIER,
       locale:
     )
+    raise "Refusing to overwrite non-public project '#{PROJECT_PREVIEW_IDENTIFIER}' (#{locale})" if project.persisted? && (project.user_id.present? || project.school_id.present?)
+
     Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}' (#{locale})..."
     project.name = name
     project.user_id = nil
-    project.school = nil
+    project.school_id = nil
     project.project_type = Project::Types::CODE_EDITOR_SCRATCH
     project.instructions = instructions
-    if project.scratch_component
-      project.scratch_component.content = public_scratch_preview_content
-    else
-      project.scratch_component = ScratchComponent.new(content: public_scratch_preview_content)
-    end
+    project.scratch_component ||= ScratchComponent.new
+    project.scratch_component.content = public_scratch_preview_content
     project.save!
     project
   end
 
   def destroy_public_scratch_preview_project
-    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER).destroy_all
+    Project.where(
+      identifier: PROJECT_PREVIEW_IDENTIFIER,
+      user_id: nil,
+      school_id: nil,
+      project_type: Project::Types::CODE_EDITOR_SCRATCH
+    ).destroy_all
   end
 
   def public_scratch_preview_content

--- a/lib/tasks/project_preview_seeds_helper.rb
+++ b/lib/tasks/project_preview_seeds_helper.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ProjectPreviewSeedsHelper
+  # Public Blocks template for Experience CS project preview (unowned, loadable without auth).
+  PROJECT_PREVIEW_IDENTIFIER = 'excs-preview-starter'
+  PROJECT_PREVIEW_LOCALE = 'en'
+  PROJECT_PREVIEW_LOCALE_FR = 'fr-FR'
+  PROJECT_PREVIEW_NAME = 'Experience CS Preview Starter'
+  PROJECT_PREVIEW_NAME_FR = 'Démo Aperçu Experience CS'
+  PROJECT_PREVIEW_CONTENT_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter.json')
+  PROJECT_PREVIEW_INSTRUCTIONS_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions.json')
+  PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions_fr.json')
+
+  def create_public_scratch_preview_project
+    [
+      {
+        locale: PROJECT_PREVIEW_LOCALE,
+        name: PROJECT_PREVIEW_NAME,
+        instructions: public_scratch_preview_instructions
+      },
+      {
+        locale: PROJECT_PREVIEW_LOCALE_FR,
+        name: PROJECT_PREVIEW_NAME_FR,
+        instructions: public_scratch_preview_instructions_fr
+      }
+    ].map { |attrs| upsert_public_scratch_preview_project(**attrs) }
+  end
+
+  def upsert_public_scratch_preview_project(locale:, name:, instructions:)
+    project = Project.find_or_initialize_by(
+      identifier: PROJECT_PREVIEW_IDENTIFIER,
+      locale:
+    )
+    Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}' (#{locale})..."
+    project.name = name
+    project.user_id = nil
+    project.school = nil
+    project.project_type = Project::Types::CODE_EDITOR_SCRATCH
+    project.instructions = instructions
+    if project.scratch_component
+      project.scratch_component.content = public_scratch_preview_content
+    else
+      project.scratch_component = ScratchComponent.new(content: public_scratch_preview_content)
+    end
+    project.save!
+    project
+  end
+
+  def destroy_public_scratch_preview_project
+    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER).destroy_all
+  end
+
+  def public_scratch_preview_content
+    JSON.parse(File.read(PROJECT_PREVIEW_CONTENT_PATH))
+  end
+
+  def public_scratch_preview_instructions
+    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+  end
+
+  def public_scratch_preview_instructions_fr
+    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH))
+  end
+end

--- a/lib/tasks/seed_data/excs_preview_starter.json
+++ b/lib/tasks/seed_data/excs_preview_starter.json
@@ -1,0 +1,100 @@
+{
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "`jEk@4|i[#Fk?(8x)AV.-my variable": ["my variable", 0]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "blocks": {},
+      "comments": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
+          "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "layerOrder": 0,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "blocks": {},
+      "comments": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "bcf454acf82e4504149f7ffe07081dbc",
+          "md5ext": "bcf454acf82e4504149f7ffe07081dbc.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "0fb9be3e8397c983338cb71dc84d0b25",
+          "md5ext": "0fb9be3e8397c983338cb71dc84d0b25.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "layerOrder": 1,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around"
+    }
+  ],
+  "monitors": [],
+  "extensions": [],
+  "meta": {
+    "semver": "3.0.0",
+    "vm": "12.7.0",
+    "agent": "default"
+  }
+}

--- a/lib/tasks/seed_data/excs_preview_starter_instructions.json
+++ b/lib/tasks/seed_data/excs_preview_starter_instructions.json
@@ -1,0 +1,11 @@
+[
+  {
+    "markdown_content": "## Welcome\n\nThis is a sample Experience CS Blocks project you can try without signing in."
+  },
+  {
+    "markdown_content": "## Try it out\n\n1. Click the green flag to run the project.\n2. Explore the sprites and backdrops.\n3. Change a block and run it again."
+  },
+  {
+    "markdown_content": "## What's next?\n\nWhen you use this project in a class, teachers can add their own steps here for learners."
+  }
+]

--- a/lib/tasks/seed_data/excs_preview_starter_instructions_fr.json
+++ b/lib/tasks/seed_data/excs_preview_starter_instructions_fr.json
@@ -1,0 +1,11 @@
+[
+  {
+    "markdown_content": "## Bienvenue\n\nVoici un projet Blocks Experience CS d'exemple que vous pouvez essayer sans vous connecter."
+  },
+  {
+    "markdown_content": "## Essayez\n\n1. Cliquez sur le drapeau vert pour lancer le projet.\n2. Explorez les lutins et les arrière-plans.\n3. Modifiez un bloc et relancez."
+  },
+  {
+    "markdown_content": "## Et ensuite ?\n\nLorsque vous utilisez ce projet en classe, les enseignants peuvent ajouter ici leurs propres étapes pour les élèves."
+  }
+]

--- a/lib/tasks/seeds_helper.rb
+++ b/lib/tasks/seeds_helper.rb
@@ -17,9 +17,12 @@ module SeedsHelper
   # Public Blocks template for Experience CS project preview (unowned, loadable without auth).
   PROJECT_PREVIEW_IDENTIFIER = 'excs-preview-starter'
   PROJECT_PREVIEW_LOCALE = 'en'
+  PROJECT_PREVIEW_LOCALE_FR = 'fr-FR'
   PROJECT_PREVIEW_NAME = 'Experience CS Preview Starter'
+  PROJECT_PREVIEW_NAME_FR = 'Démo Aperçu Experience CS'
   PROJECT_PREVIEW_CONTENT_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter.json')
   PROJECT_PREVIEW_INSTRUCTIONS_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions.json')
+  PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions_fr.json')
 
   def create_school(creator_id, school_id = nil)
     School.find_or_create_by!(creator_id:, id: school_id) do |school|
@@ -124,16 +127,31 @@ module SeedsHelper
   end
 
   def create_public_scratch_preview_project
+    [
+      {
+        locale: PROJECT_PREVIEW_LOCALE,
+        name: PROJECT_PREVIEW_NAME,
+        instructions: public_scratch_preview_instructions
+      },
+      {
+        locale: PROJECT_PREVIEW_LOCALE_FR,
+        name: PROJECT_PREVIEW_NAME_FR,
+        instructions: public_scratch_preview_instructions_fr
+      }
+    ].map { |attrs| upsert_public_scratch_preview_project(**attrs) }
+  end
+
+  def upsert_public_scratch_preview_project(locale:, name:, instructions:)
     project = Project.find_or_initialize_by(
       identifier: PROJECT_PREVIEW_IDENTIFIER,
-      locale: PROJECT_PREVIEW_LOCALE
+      locale:
     )
-    Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}'..."
-    project.name = PROJECT_PREVIEW_NAME
+    Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}' (#{locale})..."
+    project.name = name
     project.user_id = nil
     project.school = nil
     project.project_type = Project::Types::CODE_EDITOR_SCRATCH
-    project.instructions = public_scratch_preview_instructions
+    project.instructions = instructions
     if project.scratch_component
       project.scratch_component.content = public_scratch_preview_content
     else
@@ -144,7 +162,7 @@ module SeedsHelper
   end
 
   def destroy_public_scratch_preview_project
-    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER, locale: PROJECT_PREVIEW_LOCALE).destroy_all
+    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER).destroy_all
   end
 
   def public_scratch_preview_content
@@ -153,5 +171,9 @@ module SeedsHelper
 
   def public_scratch_preview_instructions
     JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+  end
+
+  def public_scratch_preview_instructions_fr
+    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH))
   end
 end

--- a/lib/tasks/seeds_helper.rb
+++ b/lib/tasks/seeds_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'project_preview_seeds_helper'
+
 module SeedsHelper
+  include ProjectPreviewSeedsHelper
+
   TEST_USERS = {
     jane_doe: '583ba872-b16e-46e1-9f7d-df89d267550d', # jane.doe@example.com
     john_doe: 'bbb9b8fd-f357-4238-983d-6f87b99bdbb2', # john.doe@example.com
@@ -13,16 +17,6 @@ module SeedsHelper
   # Match the school in profile...
   TEST_SCHOOL = 'e52de409-9210-4e94-b08c-dd11439e07d9' # e52de409-9210-4e94-b08c-dd11439e07d9
   SCHOOL_CODE = '12-34-56'
-
-  # Public Blocks template for Experience CS project preview (unowned, loadable without auth).
-  PROJECT_PREVIEW_IDENTIFIER = 'excs-preview-starter'
-  PROJECT_PREVIEW_LOCALE = 'en'
-  PROJECT_PREVIEW_LOCALE_FR = 'fr-FR'
-  PROJECT_PREVIEW_NAME = 'Experience CS Preview Starter'
-  PROJECT_PREVIEW_NAME_FR = 'Démo Aperçu Experience CS'
-  PROJECT_PREVIEW_CONTENT_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter.json')
-  PROJECT_PREVIEW_INSTRUCTIONS_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions.json')
-  PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions_fr.json')
 
   def create_school(creator_id, school_id = nil)
     School.find_or_create_by!(creator_id:, id: school_id) do |school|
@@ -124,56 +118,5 @@ module SeedsHelper
       project.components << Component.new({ extension: 'py', name: 'main',
                                             content: code })
     end
-  end
-
-  def create_public_scratch_preview_project
-    [
-      {
-        locale: PROJECT_PREVIEW_LOCALE,
-        name: PROJECT_PREVIEW_NAME,
-        instructions: public_scratch_preview_instructions
-      },
-      {
-        locale: PROJECT_PREVIEW_LOCALE_FR,
-        name: PROJECT_PREVIEW_NAME_FR,
-        instructions: public_scratch_preview_instructions_fr
-      }
-    ].map { |attrs| upsert_public_scratch_preview_project(**attrs) }
-  end
-
-  def upsert_public_scratch_preview_project(locale:, name:, instructions:)
-    project = Project.find_or_initialize_by(
-      identifier: PROJECT_PREVIEW_IDENTIFIER,
-      locale:
-    )
-    Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}' (#{locale})..."
-    project.name = name
-    project.user_id = nil
-    project.school = nil
-    project.project_type = Project::Types::CODE_EDITOR_SCRATCH
-    project.instructions = instructions
-    if project.scratch_component
-      project.scratch_component.content = public_scratch_preview_content
-    else
-      project.scratch_component = ScratchComponent.new(content: public_scratch_preview_content)
-    end
-    project.save!
-    project
-  end
-
-  def destroy_public_scratch_preview_project
-    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER).destroy_all
-  end
-
-  def public_scratch_preview_content
-    JSON.parse(File.read(PROJECT_PREVIEW_CONTENT_PATH))
-  end
-
-  def public_scratch_preview_instructions
-    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_PATH))
-  end
-
-  def public_scratch_preview_instructions_fr
-    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH))
   end
 end

--- a/lib/tasks/seeds_helper.rb
+++ b/lib/tasks/seeds_helper.rb
@@ -14,6 +14,13 @@ module SeedsHelper
   TEST_SCHOOL = 'e52de409-9210-4e94-b08c-dd11439e07d9' # e52de409-9210-4e94-b08c-dd11439e07d9
   SCHOOL_CODE = '12-34-56'
 
+  # Public Blocks template for Experience CS project preview (unowned, loadable without auth).
+  PROJECT_PREVIEW_IDENTIFIER = 'excs-preview-starter'
+  PROJECT_PREVIEW_LOCALE = 'en'
+  PROJECT_PREVIEW_NAME = 'Experience CS Preview Starter'
+  PROJECT_PREVIEW_CONTENT_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter.json')
+  PROJECT_PREVIEW_INSTRUCTIONS_PATH = Rails.root.join('lib/tasks/seed_data/excs_preview_starter_instructions.json')
+
   def create_school(creator_id, school_id = nil)
     School.find_or_create_by!(creator_id:, id: school_id) do |school|
       Rails.logger.info 'Seeding a school...'
@@ -114,5 +121,37 @@ module SeedsHelper
       project.components << Component.new({ extension: 'py', name: 'main',
                                             content: code })
     end
+  end
+
+  def create_public_scratch_preview_project
+    project = Project.find_or_initialize_by(
+      identifier: PROJECT_PREVIEW_IDENTIFIER,
+      locale: PROJECT_PREVIEW_LOCALE
+    )
+    Rails.logger.info "Seeding public Scratch preview project '#{PROJECT_PREVIEW_IDENTIFIER}'..."
+    project.name = PROJECT_PREVIEW_NAME
+    project.user_id = nil
+    project.school = nil
+    project.project_type = Project::Types::CODE_EDITOR_SCRATCH
+    project.instructions = public_scratch_preview_instructions
+    if project.scratch_component
+      project.scratch_component.content = public_scratch_preview_content
+    else
+      project.scratch_component = ScratchComponent.new(content: public_scratch_preview_content)
+    end
+    project.save!
+    project
+  end
+
+  def destroy_public_scratch_preview_project
+    Project.where(identifier: PROJECT_PREVIEW_IDENTIFIER, locale: PROJECT_PREVIEW_LOCALE).destroy_all
+  end
+
+  def public_scratch_preview_content
+    JSON.parse(File.read(PROJECT_PREVIEW_CONTENT_PATH))
+  end
+
+  def public_scratch_preview_instructions
+    JSON.parse(File.read(PROJECT_PREVIEW_INSTRUCTIONS_PATH))
   end
 end

--- a/lib/tasks/test_seeds.rake
+++ b/lib/tasks/test_seeds.rake
@@ -37,6 +37,8 @@ namespace :test_seeds do
       school_ids = [school_id, teacher_signup_school_id].compact
       School.where(id: school_ids).destroy_all
 
+      destroy_public_scratch_preview_project
+
       # Clear any feature flags that may have been set
       Flipper.features.each(&:remove)
 
@@ -46,6 +48,8 @@ namespace :test_seeds do
 
   desc 'Create a school with lessons and students'
   task create: :environment do
+    create_public_scratch_preview_project
+
     if School.exists?(id: TEST_SCHOOL)
       puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over)."
     else

--- a/lib/tasks/test_seeds.rake
+++ b/lib/tasks/test_seeds.rake
@@ -48,13 +48,14 @@ namespace :test_seeds do
 
   desc 'Create a school with lessons and students'
   task create: :environment do
-    create_public_scratch_preview_project
-
     if School.exists?(id: TEST_SCHOOL)
-      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over)."
+      create_public_scratch_preview_project
+      puts "Test school (#{TEST_SCHOOL}) already exists, run the destroy_seed_data task to start over."
     else
       ActiveRecord::Base.transaction do
         Rails.logger.info 'Attempting to seed data...'
+        create_public_scratch_preview_project
+
         creator_id = ENV.fetch('SEEDING_CREATOR_ID', TEST_USERS[:jane_doe])
         teacher_id = ENV.fetch('SEEDING_TEACHER_ID', TEST_USERS[:john_doe])
 

--- a/spec/lib/test_seeds_spec.rb
+++ b/spec/lib/test_seeds_spec.rb
@@ -62,6 +62,19 @@ RSpec.describe 'test_seeds', type: :task do
       ).not_to exist
     end
 
+    it 'does not destroy owned projects that share the preview identifier' do
+      owned = create(
+        :scratch_project,
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE,
+        user_id: SecureRandom.uuid
+      )
+
+      task.invoke
+
+      expect(Project.find_by(id: owned.id)).to be_present
+    end
+
     it 'removes all feature flags' do
       Flipper.enable(:some_feature)
       task.invoke
@@ -132,6 +145,22 @@ RSpec.describe 'test_seeds', type: :task do
 
       expect(project.reload.instructions).to eq(
         JSON.parse(File.read(SeedsHelper::PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+      )
+    end
+
+    it 'refuses to overwrite a non-public project with the preview identifier' do
+      Project.where(identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER).destroy_all
+      create(
+        :scratch_project,
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE,
+        user_id: SecureRandom.uuid
+      )
+
+      task.reenable
+      expect { task.invoke }.to raise_error(
+        RuntimeError,
+        /Refusing to overwrite non-public project/
       )
     end
 

--- a/spec/lib/test_seeds_spec.rb
+++ b/spec/lib/test_seeds_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe 'test_seeds', type: :task do
       expect(ScratchAsset.where(project_id: scratch_project_id)).not_to exist
     end
 
+    it 'destroys the public Scratch preview project' do
+      create(
+        :scratch_project,
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE,
+        user_id: nil,
+        name: SeedsHelper::PROJECT_PREVIEW_NAME
+      )
+
+      task.invoke
+
+      expect(
+        Project.where(
+          identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+          locale: SeedsHelper::PROJECT_PREVIEW_LOCALE
+        )
+      ).not_to exist
+    end
+
     it 'removes all feature flags' do
       Flipper.enable(:some_feature)
       task.invoke
@@ -58,6 +77,40 @@ RSpec.describe 'test_seeds', type: :task do
 
     it 'creates a verified school' do
       expect(School.find_by(creator_id:).verified_at).to be_truthy
+    end
+
+    it 'creates a public Scratch preview project' do
+      project = Project.find_by!(
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE
+      )
+
+      expect(project).to have_attributes(
+        name: SeedsHelper::PROJECT_PREVIEW_NAME,
+        user_id: nil,
+        school_id: nil,
+        project_type: Project::Types::CODE_EDITOR_SCRATCH
+      )
+      expect(project.scratch_component).to be_present
+      expect(project.scratch_component.content.to_h).to include('targets')
+      expect(project.instructions).to eq(
+        JSON.parse(File.read(SeedsHelper::PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+      )
+    end
+
+    it 'updates instructions on an existing public Scratch preview project' do
+      project = Project.find_by!(
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE
+      )
+      project.update!(instructions: [{ markdown_content: 'stale step' }])
+
+      task.reenable
+      task.invoke
+
+      expect(project.reload.instructions).to eq(
+        JSON.parse(File.read(SeedsHelper::PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+      )
     end
 
     it 'creates lessons with projects' do

--- a/spec/lib/test_seeds_spec.rb
+++ b/spec/lib/test_seeds_spec.rb
@@ -47,14 +47,18 @@ RSpec.describe 'test_seeds', type: :task do
         user_id: nil,
         name: SeedsHelper::PROJECT_PREVIEW_NAME
       )
+      create(
+        :scratch_project,
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE_FR,
+        user_id: nil,
+        name: SeedsHelper::PROJECT_PREVIEW_NAME_FR
+      )
 
       task.invoke
 
       expect(
-        Project.where(
-          identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
-          locale: SeedsHelper::PROJECT_PREVIEW_LOCALE
-        )
+        Project.where(identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER)
       ).not_to exist
     end
 
@@ -95,6 +99,24 @@ RSpec.describe 'test_seeds', type: :task do
       expect(project.scratch_component.content.to_h).to include('targets')
       expect(project.instructions).to eq(
         JSON.parse(File.read(SeedsHelper::PROJECT_PREVIEW_INSTRUCTIONS_PATH))
+      )
+    end
+
+    it 'creates a French locale public Scratch preview project' do
+      project = Project.find_by!(
+        identifier: SeedsHelper::PROJECT_PREVIEW_IDENTIFIER,
+        locale: SeedsHelper::PROJECT_PREVIEW_LOCALE_FR
+      )
+
+      expect(project).to have_attributes(
+        name: SeedsHelper::PROJECT_PREVIEW_NAME_FR,
+        user_id: nil,
+        school_id: nil,
+        project_type: Project::Types::CODE_EDITOR_SCRATCH
+      )
+      expect(project.scratch_component).to be_present
+      expect(project.instructions).to eq(
+        JSON.parse(File.read(SeedsHelper::PROJECT_PREVIEW_INSTRUCTIONS_FR_PATH))
       )
     end
 


### PR DESCRIPTION
Arises from issue: [1653](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1653)

## Summary
Adds unowned Blocks (`code_editor_scratch`) templates to test seeds so Experience CS project previews can be loaded from editor-api without auth (and without waiting on ExCS content sync).
Pairs with the classroom preview route work in editor-standalone - [see this editor-standalone PR](https://github.com/RaspberryPiFoundation/editor-standalone/pull/1058).

- Seed **`excs-preview-starter`** as a public Scratch template (`user_id` / `school_id` nil) with real Scratch JSON and instruction steps
- Also seed the same identifier in **`fr-FR`** with a French name and instructions, so locale-aware `ProjectLoader` requests return translated project content instead of falling back to English
- Wire create/destroy into `test_seeds:create` / `test_seeds:destroy` (and thus `/test/reseed`)
- Cover create, destroy, idempotent instruction updates, and the French locale row in `spec/lib/test_seeds_spec.rb`

## Why
#1653 needs a stable public Blocks project that classroom can open at a preview URL while logged out. Production templates will come from ExCS sync later; this seed unblocks local and PR testing.

## How to try it
```sh
docker compose exec api bundle exec rake test_seeds:create
# or
curl -X POST http://localhost:3009/test/reseed -H "X-RESEED-API-KEY: $RESEED_API_KEY"
```

```sh
curl -s 'http://localhost:3009/api/projects/excs-preview-starter?locale=en' | head
curl -s 'http://localhost:3009/api/projects/excs-preview-starter?locale=fr-FR' | head
curl -s 'http://localhost:3009/api/scratch/projects/excs-preview-starter' | head
```
English and French project metadata should differ; Scratch content is shared.

**Note:** if the API process has been up a long time, restart it (or run `rake test_seeds:create` in a fresh `docker compose exec`) so reseed picks up the new rake task code.
