### PR TITLE
Allow students to view the preview projects

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    define_common_non_student_abilities(user)
+    define_common_abilities
 
     return unless user
 
@@ -22,14 +22,7 @@ class Ability
 
   private
 
-  def define_common_non_student_abilities(user)
-    if user&.student?
-      # Allow students to view the Experience CS preview starter template.
-      can :show, Project, user_id: nil, school_id: nil, project_type: Project::Types::CODE_EDITOR_SCRATCH
-      can :show, Component, project: { user_id: nil, school_id: nil, project_type: Project::Types::CODE_EDITOR_SCRATCH }
-      return
-    end
-
+  def define_common_abilities
     # Anyone can view projects not owned by a user or a school.
     can :show, Project, user_id: nil, school_id: nil
     can :show, Component, project: { user_id: nil, school_id: nil }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,12 @@ class Ability
   private
 
   def define_common_non_student_abilities(user)
-    return if user&.student?
+    if user&.student?
+      # Allow students to view the Experience CS preview starter template.
+      can :show, Project, user_id: nil, school_id: nil, project_type: Project::Types::CODE_EDITOR_SCRATCH
+      can :show, Component, project: { user_id: nil, school_id: nil, project_type: Project::Types::CODE_EDITOR_SCRATCH }
+      return
+    end
 
     # Anyone can view projects not owned by a user or a school.
     can :show, Project, user_id: nil, school_id: nil

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -161,34 +161,6 @@ RSpec.describe Ability do
       end
     end
 
-    context 'with a persisted school student' do
-      let(:school) { create(:school) }
-      let(:user) { create(:user, id: user_id) }
-      let(:public_scratch_starter) do
-        build(:project,
-              user_id: nil,
-              school_id: nil,
-              project_type: Project::Types::CODE_EDITOR_SCRATCH)
-      end
-      let(:public_python_starter) do
-        build(:project,
-              user_id: nil,
-              school_id: nil,
-              project_type: Project::Types::PYTHON)
-      end
-      let(:public_scratch_component) { build(:component, project: public_scratch_starter) }
-      let(:public_python_component) { build(:component, project: public_python_starter) }
-
-      before do
-        create(:student_role, user_id: user.id, school:)
-      end
-
-      it { is_expected.to be_able_to(:show, public_scratch_starter) }
-      it { is_expected.not_to be_able_to(:show, public_python_starter) }
-      it { is_expected.to be_able_to(:show, public_scratch_component) }
-      it { is_expected.not_to be_able_to(:show, public_python_component) }
-    end
-
     context 'with an experience-cs admin' do
       let(:user) { build(:experience_cs_admin_user, id: user_id) }
       let(:another_project) { build(:project) }
@@ -572,7 +544,7 @@ RSpec.describe Ability do
 
       context 'with a starter project' do
         it { is_expected.not_to be_able_to(:index, starter_project) }
-        it { is_expected.not_to be_able_to(:show, starter_project) }
+        it { is_expected.to be_able_to(:show, starter_project) }
         it { is_expected.not_to be_able_to(:create, starter_project) }
         it { is_expected.not_to be_able_to(:update, starter_project) }
         it { is_expected.not_to be_able_to(:destroy, starter_project) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -161,6 +161,34 @@ RSpec.describe Ability do
       end
     end
 
+    context 'with a persisted school student' do
+      let(:school) { create(:school) }
+      let(:user) { create(:user, id: user_id) }
+      let(:public_scratch_starter) do
+        build(:project,
+              user_id: nil,
+              school_id: nil,
+              project_type: Project::Types::CODE_EDITOR_SCRATCH)
+      end
+      let(:public_python_starter) do
+        build(:project,
+              user_id: nil,
+              school_id: nil,
+              project_type: Project::Types::PYTHON)
+      end
+      let(:public_scratch_component) { build(:component, project: public_scratch_starter) }
+      let(:public_python_component) { build(:component, project: public_python_starter) }
+
+      before do
+        create(:student_role, user_id: user.id, school:)
+      end
+
+      it { is_expected.to be_able_to(:show, public_scratch_starter) }
+      it { is_expected.not_to be_able_to(:show, public_python_starter) }
+      it { is_expected.to be_able_to(:show, public_scratch_component) }
+      it { is_expected.not_to be_able_to(:show, public_python_component) }
+    end
+
     context 'with an experience-cs admin' do
       let(:user) { build(:experience_cs_admin_user, id: user_id) }
       let(:another_project) { build(:project) }


### PR DESCRIPTION
Needs to allow student view checks on issue: [1659](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1659)

Comes out of this work on editor-standalone - https://github.com/RaspberryPiFoundation/editor-standalone/pull/1064

## Summary

Updated `editor-api` CanCan permissions so that **school students** can `:show` the Experience CS preview starter project used by the classroom preview route.

With this changes students are now allowed to view **unowned** (`user_id: nil`, `school_id: nil`) **Scratch** template projects.

This prevents the preview route in editor-standalone from failing project loading (which previously triggered a redirect to `/${locale}/error`).

