### PR TITLE
Identify Experience CS projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,10 @@ class Project < ApplicationRecord
     CODE_EDITOR_SCRATCH = 'code_editor_scratch'
   end
 
+  module Origins
+    EXPERIENCE_CS = 'experience_cs'
+  end
+
   belongs_to :school, optional: true
   belongs_to :lesson, optional: true
   belongs_to :parent, optional: true, class_name: :Project, foreign_key: :remixed_from_id, inverse_of: :remixes
@@ -35,6 +39,8 @@ class Project < ApplicationRecord
   validate :project_with_instructions_must_belong_to_school
   validate :project_with_school_id_has_school_project
   validate :school_project_school_matches_project_school
+  validates :origin, inclusion: { in: [Origins::EXPERIENCE_CS], allow_nil: true }
+  validate :origin_cannot_change, on: :update
 
   scope :internal_projects, -> { where(user_id: nil) }
 
@@ -181,5 +187,13 @@ class Project < ApplicationRecord
     return unless school_id && school_project && school_id != school_project.school_id
 
     errors.add(:school_project, 'School project school_id must match project school_id')
+  end
+
+  def origin_cannot_change
+    return unless origin_changed?
+    # allow filling in origin when it's nil
+    return if origin_was.nil?
+
+    errors.add(:origin, 'cannot be changed once set')
   end
 end

--- a/db/migrate/20260820122510_add_origin_to_projects.rb
+++ b/db/migrate/20260820122510_add_origin_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOriginToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :origin, :string
+    add_index :projects, :origin, where: 'origin IS NOT NULL'
+  end
+end

--- a/db/migrate/20260820122510_add_origin_to_projects.rb
+++ b/db/migrate/20260820122510_add_origin_to_projects.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class AddOriginToProjects < ActiveRecord::Migration[8.1]
-  disable_ddl_transaction!
-
   def change
-    add_column :projects, :origin, :string, if_not_exists: true
-    add_index :projects, :origin, where: 'origin IS NOT NULL',
-                                  algorithm: :concurrently,
-                                  if_not_exists: true
+    add_column :projects, :origin, :string
   end
 end

--- a/db/migrate/20260820122510_add_origin_to_projects.rb
+++ b/db/migrate/20260820122510_add_origin_to_projects.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class AddOriginToProjects < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
   def change
-    add_column :projects, :origin, :string
-    add_index :projects, :origin, where: 'origin IS NOT NULL'
+    add_column :projects, :origin, :string, if_not_exists: true
+    add_index :projects, :origin, where: 'origin IS NOT NULL',
+                                  algorithm: :concurrently,
+                                  if_not_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,7 +250,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_122510) do
     t.index ["identifier", "locale"], name: "index_projects_on_identifier_and_locale", unique: true
     t.index ["identifier"], name: "index_projects_on_identifier"
     t.index ["lesson_id"], name: "index_projects_on_lesson_id"
-    t.index ["origin"], name: "index_projects_on_origin", where: "(origin IS NOT NULL)"
     t.index ["remixed_from_id"], name: "index_projects_on_remixed_from_id"
     t.index ["school_id"], name: "index_projects_on_school_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_122510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -240,6 +240,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_120000) do
     t.uuid "lesson_id"
     t.string "locale"
     t.string "name"
+    t.string "origin"
     t.string "project_type", default: "python", null: false
     t.string "remix_origin"
     t.uuid "remixed_from_id"
@@ -249,6 +250,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_120000) do
     t.index ["identifier", "locale"], name: "index_projects_on_identifier_and_locale", unique: true
     t.index ["identifier"], name: "index_projects_on_identifier"
     t.index ["lesson_id"], name: "index_projects_on_lesson_id"
+    t.index ["origin"], name: "index_projects_on_origin", where: "(origin IS NOT NULL)"
     t.index ["remixed_from_id"], name: "index_projects_on_remixed_from_id"
     t.index ["school_id"], name: "index_projects_on_school_id"
   end

--- a/lib/concepts/project/operations/create.rb
+++ b/lib/concepts/project/operations/create.rb
@@ -17,7 +17,12 @@ class Project
       private
 
       def build_project(project_hash, current_user)
-        project_hash[:identifier] = PhraseIdentifier.generate unless current_user&.experience_cs_admin?
+        if current_user&.experience_cs_admin?
+          project_hash[:origin] = Project::Origins::EXPERIENCE_CS
+        else
+          project_hash[:identifier] = PhraseIdentifier.generate
+        end
+
         new_project = Project.new(project_hash.except(:components, :scratch_component))
         new_project.components.build(project_hash[:components])
         new_project.build_scratch_component(project_hash[:scratch_component]) if project_hash[:scratch_component].present?

--- a/spec/concepts/project/create_remix_spec.rb
+++ b/spec/concepts/project/create_remix_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe Project::CreateRemix, type: :unit do
       expect(remixed_project.remix_origin).to eq(remix_origin)
     end
 
+    it 'does not set an origin when the original project has none' do
+      remixed_project = create_remix[:project]
+      expect(remixed_project.origin).to be_nil
+    end
+
+    context 'when the original project has an origin' do
+      let!(:original_project) { create(:project, :with_components, origin: Project::Origins::EXPERIENCE_CS) }
+
+      it 'copies the origin to the remix' do
+        remixed_project = create_remix[:project]
+        expect(remixed_project.origin).to eq(Project::Origins::EXPERIENCE_CS)
+      end
+    end
+
     it 'links remix to attached images' do
       remixed_project = create_remix[:project]
       expect(remixed_project.images.length).to eq(original_project.images.length)

--- a/spec/concepts/project/create_spec.rb
+++ b/spec/concepts/project/create_spec.rb
@@ -40,6 +40,36 @@ RSpec.describe Project::Create, type: :unit do
         new_project = create_project_with_content[:project]
         expect(new_project.components.first.content).to eq('print("hello world")')
       end
+
+      it 'does not set the project origin' do
+        expect(create_project_with_content[:project].origin).to be_nil
+      end
+    end
+
+    context 'when the current user is an Experience CS admin' do
+      subject(:create_project_as_admin) { described_class.call(project_hash:, current_user:) }
+
+      let(:current_user) { create(:experience_cs_admin_user) }
+      let(:project_hash) do
+        {
+          project_type: Project::Types::PYTHON,
+          components: [{
+            name: 'main',
+            extension: 'py',
+            content: 'print("hello world")',
+            default: true
+          }],
+          user_id:
+        }
+      end
+
+      it 'returns success' do
+        expect(create_project_as_admin.success?).to be(true)
+      end
+
+      it 'sets the project origin to experience_cs' do
+        expect(create_project_as_admin[:project].origin).to eq(Project::Origins::EXPERIENCE_CS)
+      end
     end
 
     context 'when creation fails' do

--- a/spec/features/project/creating_a_project_spec.rb
+++ b/spec/features/project/creating_a_project_spec.rb
@@ -308,5 +308,11 @@ RSpec.describe 'Creating a project', type: :request do
       project = Project.find_by!(identifier: 'test-project', locale: 'fr')
       expect(project.scratch_component.content.to_h).to eq(scratch_data.deep_stringify_keys)
     end
+
+    it 'sets the project origin to experience_cs' do
+      post('/api/projects', headers:, params:, as: :json)
+
+      expect(Project.find_by!(identifier: 'test-project', locale: 'fr').origin).to eq(Project::Origins::EXPERIENCE_CS)
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe Project, :versioning do
       expect(valid_project).to be_valid
     end
 
+    it 'is valid without an origin' do
+      valid_project = build(:project, origin: nil)
+      expect(valid_project).to be_valid
+    end
+
+    it 'is valid with a known origin' do
+      valid_project = build(:project, origin: Project::Origins::EXPERIENCE_CS)
+      expect(valid_project).to be_valid
+    end
+
+    it 'is invalid with an unrecognised origin' do
+      invalid_project = build(:project, origin: 'invalid_origin')
+      expect(invalid_project).not_to be_valid
+    end
+
     it 'allows a public Code Classroom Blocks project to have instructions' do
       project = build(
         :project,
@@ -194,6 +209,24 @@ RSpec.describe Project, :versioning do
     it 'generates an identifier if nil' do
       unsaved_project = build(:project, identifier: nil)
       expect { unsaved_project.valid? }.to change { unsaved_project.identifier.nil? }.from(true).to(false)
+    end
+  end
+
+  describe 'origin_cannot_change' do
+    it 'allows an origin to be set on create' do
+      expect { create(:project, origin: Project::Origins::EXPERIENCE_CS) }.not_to raise_error
+    end
+
+    it 'allows an origin to be set on a project that does not have one' do
+      project = create(:project, origin: nil)
+      expect { project.update!(origin: Project::Origins::EXPERIENCE_CS) }.not_to raise_error
+    end
+
+    it 'does not allow an origin to be updated once set' do
+      project = create(:project, origin: Project::Origins::EXPERIENCE_CS)
+
+      expect(project.update(origin: nil)).to be(false)
+      expect(project.errors[:origin]).to include(/cannot be changed once set/)
     end
   end
 


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1717

## Points for consideration:

- Security
- Performance

## What's changed?
- Add `origin` column to Project
- Validations: 
  - `inclusion` in known origins (only `Project::Origins::EXPERIENCE_CS` for now) 
  - allows nil value so that we can backfill, blocks any change once set
- build_project now sets origin for ECS admins
- Remix projects inherit `origin` from original project. 
- With #973 in, service-authenticated create also gets the origin assignment. 
