### PR TITLE
Return the project locale on lesson JSON

### DIFF
--- a/app/views/api/lessons/_lesson.json.jbuilder
+++ b/app/views/api/lessons/_lesson.json.jbuilder
@@ -19,7 +19,8 @@ if lesson.project
   json.project(
     lesson.project,
     :identifier,
-    :project_type
+    :project_type,
+    :locale
   )
 end
 

--- a/spec/features/lesson/creating_a_batch_of_lessons_spec.rb
+++ b/spec/features/lesson/creating_a_batch_of_lessons_spec.rb
@@ -75,6 +75,33 @@ RSpec.describe 'Creating a batch of lessons', type: :request do
     end
   end
 
+  context 'when a locale is supplied for each project' do
+    let(:lesson_project_params) do
+      [
+        {
+          name: 'Lesson 1',
+          school_id: school.id,
+          project_attributes: { name: 'Project 1', project_type: Project::Types::CODE_EDITOR_SCRATCH, locale: 'fr-FR' }
+        },
+        {
+          name: 'Lesson 2',
+          school_id: school.id,
+          project_attributes: { name: 'Project 2', project_type: Project::Types::CODE_EDITOR_SCRATCH, locale: 'fr-FR' }
+        }
+      ]
+    end
+
+    it 'persists the locale on each created project' do
+      expect(Project.where(locale: 'fr-FR').count).to eq(2)
+    end
+
+    it 'returns the locale on each project so callers can confirm it' do
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data.map { |entry| entry.dig(:project, :locale) }).to all(eq('fr-FR'))
+    end
+  end
+
   context 'when some entries are invalid' do
     let(:lesson_projects) do
       lesson_project_params + [{

--- a/spec/features/lesson/listing_lessons_spec.rb
+++ b/spec/features/lesson/listing_lessons_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Listing lessons', type: :request do
   it 'responds with the project JSON' do
     get('/api/lessons', headers:)
     data = JSON.parse(response.body, symbolize_names: true)
-    expected_project = JSON.parse(lesson.project.to_json(only: %i[identifier project_type]), symbolize_names: true)
+    expected_project = JSON.parse(lesson.project.to_json(only: %i[identifier project_type locale]), symbolize_names: true)
 
     expect(data.first[:project]).to eq(expected_project)
   end


### PR DESCRIPTION
## Status

- Work towards - https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1722

Return the project locale on lesson JSON

Adds :locale to the nested project object in _lesson.json.jbuilder, so it appears on GET /api/lessons, GET /api/lessons/:id and POST /api/lessons/batch.

Experience CS now sends project_attributes.locale when adding projects to a class, so teachers get lesson content in the language they were browsing in. Editor API already accepted and stored that value, but never returned it — so there's no way to confirm through the API which locale a lesson's project was created in.

This follows the existing pattern on this endpoint: create_batch already echoes origin_identifier back so callers can verify their request landed correctly. It also brings the nested project in line with projects#show, which already returns locale.

Response-only — no change to what gets persisted, and no behaviour change for existing consumers (additive field). No caller reads it today; this is for consistency and observability rather than to unblock the Experience CS work, which ships without it.