### PR TITLE
Migrate old instructions column

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
+  self.ignored_columns += [:instructions]
+
   module Types
     PYTHON = 'python'
     HTML = 'html'
@@ -83,12 +85,11 @@ class Project < ApplicationRecord
   end
 
   def instructions
-    self[:instruction_steps].nil? ? self[:instructions] : self[:instruction_steps]
+    instruction_steps
   end
 
   def instructions=(value)
-    self[:instructions] = value unless value.is_a?(Array)
-    self[:instruction_steps] = value
+    self.instruction_steps = value
   end
 
   def last_edited_at

--- a/db/migrate/20260825144345_backfill_instruction_steps_from_instructions.rb
+++ b/db/migrate/20260825144345_backfill_instruction_steps_from_instructions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class BackfillInstructionStepsFromInstructions < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE projects
+      SET instruction_steps = to_jsonb(instructions)
+      WHERE instruction_steps IS NULL AND instructions IS NOT NULL
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_122510) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_144345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -437,31 +437,12 @@ RSpec.describe Project, :versioning do
   end
 
   describe '#instructions' do
-    let(:project) { create(:project, :with_instructions, school:, user_id: create(:teacher, school:).id) }
+    let(:project) { create(:project, school:, user_id: create(:teacher, school:).id) }
 
-    it 'falls back to the legacy text column for rows that predate instruction_steps' do
-      project.instruction_steps = nil
-      project.save!
-      expect(project.instructions).to eq(project[:instructions])
-    end
-
-    it 'returns instruction_steps once set, without touching the legacy column for arrays' do
-      legacy_value = project[:instructions]
+    it 'delegates to instruction_steps' do
       project.update!(instructions: [{ markdown_content: 'step 1' }])
       expect(project.instructions).to eq([{ 'markdown_content' => 'step 1' }])
-      expect(project[:instructions]).to eq(legacy_value)
-    end
-
-    it 'does not fall back to stale legacy text once instruction_steps is set to an empty array' do
-      project.update!(instructions: [])
-      expect(project.instructions).to eq([])
-    end
-
-    it 'also clears the legacy column when instructions are set to nil' do
-      project.update!(instructions: [{ markdown_content: 'step 1' }])
-      project.update!(instructions: nil)
-      expect(project.instructions).to be_nil
-      expect(project[:instructions]).to be_nil
+      expect(project.instruction_steps).to eq([{ 'markdown_content' => 'step 1' }])
     end
   end
 


### PR DESCRIPTION
## Status

- Related to #953 

## What's changed?

This is tidy up after introducing instruction Steps to migrate all data into a single column.

By adding `instructions` to ignored columns tests will fail if anything is accessing it and we can later drop the old column in another deploy.

Note that instruction steps is a JSONB column, that might contain an array of instruction objects, or a single string. Currently editor-ui handles these different formats. We could later do another migration to wrap the strings into an array which would allow us to simplify the frontend.

