### PR TITLE
Update sf mapping to include code editor ExCS projects

### DIFF
--- a/app/jobs/salesforce/lesson_sync_job.rb
+++ b/app/jobs/salesforce/lesson_sync_job.rb
@@ -29,7 +29,7 @@ module Salesforce
     def sf_lesson_attributes(lesson:)
       mapped_attributes(lesson:).merge(
         teacherprojecttitle__c: lesson.project&.name,
-        teacherprojecttype__c: lesson.project&.project_type,
+        teacherprojecttype__c: project_type_attribute(lesson),
         numberofassignedprojects__c: assigned_projects_count(lesson),
         # Sum of the two completion paths: state-machine `:submitted` (Code Editor flow)
         # and `school_projects.finished` (Experience CS flow). They are mutually exclusive
@@ -47,6 +47,12 @@ module Salesforce
       FIELD_MAPPINGS.transform_values do |lesson_field|
         lesson.send(lesson_field)
       end
+    end
+
+    def project_type_attribute(lesson)
+      return Project::Types::SCRATCH if lesson.project&.origin == Project::Origins::EXPERIENCE_CS
+
+      lesson.project&.project_type
     end
 
     # A lesson is "assigned" to every student in its class iff it's visible to them

--- a/spec/jobs/salesforce/lesson_sync_job_spec.rb
+++ b/spec/jobs/salesforce/lesson_sync_job_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Salesforce::LessonSyncJob, :requires_salesforce_db do
     end
   end
 
+  context 'when the lesson project originates from Experience CS' do
+    Project::EXPERIENCE_CS_PROJECT_TYPES.each do |project_type|
+      it "syncs teacherprojecttype__c as scratch when the underlying project_type is #{project_type}" do
+        lesson.project.update!(origin: Project::Origins::EXPERIENCE_CS, project_type:)
+        perform_job
+        sf_lesson = Salesforce::Lesson.find_by(lesson_uuid__c: lesson.id)
+        expect(sf_lesson.teacherprojecttype__c).to eq(Project::Types::SCRATCH)
+      end
+    end
+  end
+
   describe 'numberofassignedprojects__c' do
     let(:students) { Array.new(3) { create(:student, school:) } }
 


### PR DESCRIPTION
## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1702

## What's changed?

- Added the new `project_type_attribute` logic in lesson_sync_job.rb
  - Syncing `teacherprojecttype__c` as `scratch` when an ExCS project has project_type of either scratch (default behaviour) or code_editor_scratch (i.e., `Project::EXPERIENCE_CS_PROJECT_TYPES`)
