### PR TITLE
Expose deployed commit sha at /info/release

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InfoController < ActionController::API
+  def release
+    render plain: ENV.fetch('HEROKU_SLUG_COMMIT', 'unknown')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     root to: 'projects#index'
   end
 
+  get '/info/release', to: 'info#release'
+
   post '/test/reseed', to: 'test_utilities#reseed'
   post '/test/enable_feature', to: 'test_utilities#enable_feature'
   post '/test/disable_feature', to: 'test_utilities#disable_feature'

--- a/spec/requests/info_controller_spec.rb
+++ b/spec/requests/info_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InfoController do
+  describe 'GET /info/release' do
+    subject(:request) { get '/info/release' }
+
+    it 'returns the deployed commit sha as text' do
+      ClimateControl.modify(HEROKU_SLUG_COMMIT: 'abc123') do
+        request
+        expect(response.body).to eq('abc123')
+      end
+    end
+
+    it 'returns unknown when the sha is unavailable' do
+      ClimateControl.modify(HEROKU_SLUG_COMMIT: nil) do
+        request
+        expect(response.body).to eq('unknown')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What's changed?

This adds an info/release route that shows the current git sha for the release.

I intend to use this from the editor dashboard to show what apps need deploying.

## After deploy:

- [ ] exclude '/info/release' from cloudflare access in staging/test