### PR TITLE
Show teacher names and emails on admin school classes

### DIFF
--- a/app/controllers/admin/school_classes_controller.rb
+++ b/app/controllers/admin/school_classes_controller.rb
@@ -7,7 +7,7 @@ module Admin
     private
 
     def class_teacher_users_by_id
-      @class_teacher_users_by_id ||= User.from_userinfo(ids: requested_resource.teacher_ids).index_by(&:id)
+      @class_teacher_users_by_id ||= User.from_userinfo(ids: requested_resource.teachers.map(&:user_id).uniq).index_by(&:id)
     end
   end
 end

--- a/app/controllers/admin/school_classes_controller.rb
+++ b/app/controllers/admin/school_classes_controller.rb
@@ -2,5 +2,12 @@
 
 module Admin
   class SchoolClassesController < Admin::ApplicationController
+    helper_method :class_teacher_users_by_id
+
+    private
+
+    def class_teacher_users_by_id
+      @class_teacher_users_by_id ||= User.from_userinfo(ids: requested_resource.teacher_ids).index_by(&:id)
+    end
   end
 end

--- a/app/dashboards/school_class_dashboard.rb
+++ b/app/dashboards/school_class_dashboard.rb
@@ -11,7 +11,7 @@ class SchoolClassDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     school: Field::BelongsTo,
-    teachers: Field::HasMany,
+    teachers: ClassTeachersField,
     students: Field::HasMany,
     lessons: Field::HasMany,
     id: Field::String,

--- a/app/fields/class_teachers_field.rb
+++ b/app/fields/class_teachers_field.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'administrate/field/base'
+
+class ClassTeachersField < Administrate::Field::Base
+  def teachers
+    @teachers ||= data.sort_by(&:created_at)
+  end
+
+  def user_display(teacher, users_by_id)
+    user = users_by_id[teacher.teacher_id]
+    user.present? ? user_dashboard.display_resource(user) : teacher.teacher_id
+  end
+
+  private
+
+  def user_dashboard
+    @user_dashboard ||= UserDashboard.new
+  end
+end

--- a/app/fields/class_teachers_field.rb
+++ b/app/fields/class_teachers_field.rb
@@ -7,9 +7,9 @@ class ClassTeachersField < Administrate::Field::Base
     @teachers ||= data.sort_by(&:created_at)
   end
 
-  def user_display(teacher, users_by_id)
-    user = users_by_id[teacher.teacher_id]
-    user.present? ? user_dashboard.display_resource(user) : teacher.teacher_id
+  def user_display(teacher, users_by_id = {})
+    user = users_by_id[teacher.user_id]
+    user.present? ? user_dashboard.display_resource(user) : teacher.user_id
   end
 
   private

--- a/app/views/fields/class_teachers_field/_show.html.erb
+++ b/app/views/fields/class_teachers_field/_show.html.erb
@@ -3,8 +3,7 @@
     <thead>
       <tr>
         <th>Teacher</th>
-        <th>Created</th>
-        <th>Updated</th>
+        <th>Added to class</th>
       </tr>
     </thead>
     <tbody>
@@ -12,7 +11,6 @@
         <tr>
           <td><%= field.user_display(teacher, class_teacher_users_by_id) %></td>
           <td><%= l(teacher.created_at) %></td>
-          <td><%= l(teacher.updated_at) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/fields/class_teachers_field/_show.html.erb
+++ b/app/views/fields/class_teachers_field/_show.html.erb
@@ -1,0 +1,22 @@
+<% if field.teachers.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>Teacher</th>
+        <th>Created</th>
+        <th>Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% field.teachers.each do |teacher| %>
+        <tr>
+          <td><%= field.user_display(teacher, class_teacher_users_by_id) %></td>
+          <td><%= l(teacher.created_at) %></td>
+          <td><%= l(teacher.updated_at) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <%= t('administrate.fields.has_many.none', default: '–') %>
+<% end %>

--- a/spec/features/admin/school_classes_spec.rb
+++ b/spec/features/admin/school_classes_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin school classes', type: :request do
+  let(:admin_user) { create(:admin_user) }
+  let(:school) { create(:school) }
+  let(:teacher) { create(:user, name: 'Tariq Teacher', email: 'teacher@example.com') }
+  let(:other_teacher) { create(:user, name: 'Olivia Teacher', email: 'olivia@example.com') }
+  let(:school_class) { create(:school_class, school:, teacher_ids: [teacher.id, other_teacher.id]) }
+
+  before do
+    allow(User).to receive(:from_omniauth).and_return(admin_user)
+    get '/auth/callback'
+    allow(User).to receive(:from_userinfo).with(ids: contain_exactly(teacher.id, other_teacher.id)).and_return([other_teacher, teacher])
+  end
+
+  it 'displays each teacher name and email using a single batch lookup' do
+    get admin_school_class_path(school_class)
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('Tariq Teacher (teacher@example.com)', 'Olivia Teacher (olivia@example.com)')
+    expect(response.body).not_to include(teacher.id, other_teacher.id)
+    expect(User).to have_received(:from_userinfo).with(ids: contain_exactly(teacher.id, other_teacher.id)).once
+  end
+
+  it 'falls back to the UUID when a teacher is missing from user info' do
+    allow(User).to receive(:from_userinfo).and_return([teacher])
+
+    get admin_school_class_path(school_class)
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('Tariq Teacher (teacher@example.com)', other_teacher.id)
+  end
+
+  it 'renders an empty teacher list without looking up users' do
+    school_class.teachers.destroy_all
+
+    get admin_school_class_path(school_class)
+
+    expect(response).to have_http_status(:success)
+    expect(User).not_to have_received(:from_userinfo)
+  end
+end

--- a/spec/features/admin/school_classes_spec.rb
+++ b/spec/features/admin/school_classes_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'Admin school classes', type: :request do
 
     expect(response).to have_http_status(:success)
     expect(response.body).to include('Tariq Teacher (teacher@example.com)', 'Olivia Teacher (olivia@example.com)')
+    expect(response.body).to include('<th>Added to class</th>')
+    expect(response.body).not_to include('<th>Updated</th>')
     expect(response.body).not_to include(teacher.id, other_teacher.id)
     expect(User).to have_received(:from_userinfo).with(ids: contain_exactly(teacher.id, other_teacher.id)).once
   end


### PR DESCRIPTION
> [!NOTE]
> Co-authored with ChatGPT GPT-6 Astro Light.  Reviewed by Copilot Lite, /code-review-by-matt GPT-5.6 

Show teacher names and email addresses on `/admin/school_classes/:id`, using the same `Name (email)` format as school roles. Fetch user details in one batch and retain the teacher UUID when a user is missing.

Validated with 24 passing admin request specs covering schools and school classes, including multiple teachers, missing users, and empty lists. RuboCop passes for all changed Ruby files. Browser demo uses the existing seeded Nursing 524 class and the built-in development auth/user-info mock.

### Local demo screenshots

Existing seeded class and school, using the built-in development auth/user-info mock.

**School class — teacher name and email**

![School class showing teacher name and email](https://github.com/user-attachments/assets/30137cc1-134f-4fd7-b11a-f64a3db0a31b)

**School page — matching existing display**

![School page showing the matching teacher display](https://github.com/user-attachments/assets/e08a7039-5fd6-46c8-9acb-30dacfe862ad)
