### PR TITLE
Reduce likelyhood of generated number conflicts

### DIFF
--- a/lib/for_education_code_generator.rb
+++ b/lib/for_education_code_generator.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 class ForEducationCodeGenerator
   MAX_CODE = 1_000_000
 
-  cattr_accessor :random
-
-  self.random ||= Random.new
-
   def self.generate
-    number = random.rand(MAX_CODE)
+    number = SecureRandom.random_number(MAX_CODE)
     code = format('%06d', number)
 
     code.match(/(\d\d)(\d\d)(\d\d)/) do |m|

--- a/spec/lib/for_education_code_generator_spec.rb
+++ b/spec/lib/for_education_code_generator_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ForEducationCodeGenerator do
   describe '.generate' do
-    it 'uses Random#rand to generate a random number up to the maximum' do
-      allow(described_class.random).to receive(:rand).with(ForEducationCodeGenerator::MAX_CODE).and_return(123)
+    it 'uses SecureRandom to generate a random number up to the maximum' do
+      allow(SecureRandom).to receive(:random_number).with(ForEducationCodeGenerator::MAX_CODE).and_return(123)
 
       expect(described_class.generate).to eq('00-01-23')
     end

--- a/spec/lib/for_education_code_generator_spec.rb
+++ b/spec/lib/for_education_code_generator_spec.rb
@@ -13,9 +13,5 @@ RSpec.describe ForEducationCodeGenerator do
     it 'generates a string containing 3 pairs of digits' do
       expect(described_class.generate).to match(/\d\d-\d\d-\d\d/)
     end
-
-    it 'generates a different code each time' do
-      expect(described_class.generate).not_to eq(described_class.generate)
-    end
   end
 end

--- a/spec/support/for_education_code_generator.rb
+++ b/spec/support/for_education_code_generator.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |config|
-  config.before(:suite) do
-    Rails.logger.debug { "ForEducationCodeGenerator randomized with seed #{config.seed}" }
-    ForEducationCodeGenerator.random = Random.new(config.seed)
-  end
-end


### PR DESCRIPTION


## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1582

## What's changed?

Switch to using the SecureRandom generator. This is an approach similar to taken for Join Codes in https://github.com/RaspberryPiFoundation/editor-api/pull/952

See commit for more.