### PR TITLE
Allow Scratch projects to be created by ExCS clients

### DIFF
--- a/app/controllers/api/lessons/batch_controller.rb
+++ b/app/controllers/api/lessons/batch_controller.rb
@@ -8,7 +8,6 @@ module Api
 
       before_action :authorize_user
       before_action :verify_school_class_belongs_to_school
-      before_action :verify_can_create_scratch_projects
       before_action :authorize_lesson_projects!
       before_action :authorize_source_projects!
 
@@ -31,15 +30,6 @@ module Api
         return unless lesson_projects?
 
         params[:lesson_projects].each { |lesson_params| verify_lesson_school_class!(lesson_params) }
-      end
-
-      def verify_can_create_scratch_projects
-        return unless lesson_projects?
-
-        batch_lessons_params.each_index do |index|
-          verify_lesson_scratch!(batch_lessons_params[index], source_project: source_project_for(index))
-          break if performed?
-        end
       end
 
       def batch_lessons_params

--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -7,7 +7,6 @@ module Api
 
     before_action :authorize_user, except: %i[index show]
     before_action :verify_school_class_belongs_to_school, only: :create
-    before_action :verify_can_create_scratch_projects, only: %i[create create_copy]
     load_and_authorize_resource :lesson
 
     def index
@@ -84,10 +83,6 @@ module Api
 
     def verify_school_class_belongs_to_school
       verify_lesson_school_class!(create_params)
-    end
-
-    def verify_can_create_scratch_projects
-      verify_lesson_scratch!(create_params, source_project:)
     end
 
     def user_remixes(lessons)

--- a/app/controllers/concerns/lesson_creation.rb
+++ b/app/controllers/concerns/lesson_creation.rb
@@ -32,19 +32,6 @@ module LessonCreation
     raise ParameterError, 'school_class_id does not correspond to school_id'
   end
 
-  def verify_lesson_scratch!(lesson_params, source_project: nil)
-    return unless scratch_project?(lesson_params) || source_project&.scratch_project?
-
-    school = School.find_by(id: lesson_params[:school_id])
-    return if school&.scratch_enabled?
-
-    render json: { error: 'Forbidden' }, status: :forbidden
-  end
-
-  def scratch_project?(lesson_params)
-    lesson_params.dig(:project_attributes, :project_type) == Project::Types::CODE_EDITOR_SCRATCH
-  end
-
   def find_source_project!(identifier, locale)
     return nil if identifier.blank?
 

--- a/spec/features/lesson/creating_a_batch_of_lessons_spec.rb
+++ b/spec/features/lesson/creating_a_batch_of_lessons_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe 'Creating a batch of lessons', type: :request do
   end
 
   let(:teacher) { create(:teacher, school:) }
-  let(:school) { create(:school, scratch_enabled:) }
-  let(:scratch_enabled) { true }
+  let(:school) { create(:school) }
   let(:batch_path) { '/api/lessons/batch' }
   let(:lesson_projects) { lesson_project_params }
 
@@ -176,7 +175,7 @@ RSpec.describe 'Creating a batch of lessons', type: :request do
   end
 
   context 'when the user does not belong to the school' do
-    let(:other_school) { create(:school, scratch_enabled: true) }
+    let(:other_school) { create(:school) }
     let(:lesson_project_params) do
       [
         {
@@ -193,18 +192,6 @@ RSpec.describe 'Creating a batch of lessons', type: :request do
     end
 
     it 'responds 403 Forbidden' do
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it 'does not create any lessons' do
-      expect(Lesson.count).to eq(0)
-    end
-  end
-
-  context 'when the school does not have Scratch enabled' do
-    let(:scratch_enabled) { false }
-
-    it 'returns forbidden' do
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -311,18 +298,6 @@ RSpec.describe 'Creating a batch of lessons', type: :request do
 
       it 'responds 422 Unprocessable' do
         expect(response).to have_http_status(:unprocessable_content)
-      end
-
-      it 'does not create any lessons' do
-        expect(Lesson.count).to eq(0)
-      end
-    end
-
-    context 'when a source_project_identifier points at a scratch project and the school does not have Scratch enabled' do
-      let(:scratch_enabled) { false }
-
-      it 'responds 403 Forbidden' do
-        expect(response).to have_http_status(:forbidden)
       end
 
       it 'does not create any lessons' do

--- a/spec/features/lesson/creating_a_lesson_spec.rb
+++ b/spec/features/lesson/creating_a_lesson_spec.rb
@@ -226,8 +226,7 @@ RSpec.describe 'Creating a lesson', type: :request do
       }
     end
 
-    it 'creates a lesson with a scratch component when school has Scratch enabled' do
-      school.update!(scratch_enabled: true)
+    it 'creates a lesson with a scratch component' do
       post('/api/lessons', headers:, params:)
       expect(response).to have_http_status(:created)
 
@@ -238,12 +237,6 @@ RSpec.describe 'Creating a lesson', type: :request do
       project = Lesson.find(lesson_id).project
       expect(project.project_type).to eq(Project::Types::CODE_EDITOR_SCRATCH)
       expect(project.scratch_component.content).to eq({ 'example_data' => 'true' })
-    end
-
-    it 'returns forbidden when school does not have Scratch enabled' do
-      school.update!(scratch_enabled: false)
-      post('/api/lessons', headers:, params:)
-      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -278,7 +271,6 @@ RSpec.describe 'Creating a lesson', type: :request do
 
     context 'when the source project is a shared Experience CS project' do
       before do
-        school.update!(scratch_enabled: true)
         post('/api/lessons', headers:, params:)
       end
 
@@ -310,33 +302,6 @@ RSpec.describe 'Creating a lesson', type: :request do
 
       it 'inherits origin from the source project' do
         expect(lesson_project.origin).to eq(source_project.origin)
-      end
-    end
-
-    context 'when the school does not have Scratch enabled' do
-      # The request carries no project_attributes[:project_type], so the scratch gate has to
-      # look at the source project to see that a Scratch project is about to be created.
-      let(:params) do
-        {
-          lesson: {
-            name: 'Test Lesson',
-            school_id: school.id,
-            source_project_identifier: source_project.identifier,
-            project_attributes: {
-              name: 'My digital canvas',
-              locale: 'en'
-            }
-          }
-        }
-      end
-
-      before do
-        school.update!(scratch_enabled: false)
-      end
-
-      it 'responds 403 Forbidden when only source_project_identifier points at a scratch project' do
-        post('/api/lessons', headers:, params:)
-        expect(response).to have_http_status(:forbidden)
       end
     end
   end


### PR DESCRIPTION

## Status

- Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1795

## What's changed?

Currently if a school doesn't have the blocks editor enabled they are unable to add migrated ExCS projects.
This cuahge allows any client to create scratch projects, even if the School does not have Scratch enabled. 


- Schools without this enabled still won't see the button to add Scratch projects. 
- Even if we did restrict it to ExCS projects in some way, clients could add those projects and then edit them however they want making the restriction useless.
- Since we plan on removing the beta flag soon anyway I think it's simpler to loosen the restriction.


