### PR TITLE
Load scratch projects in correct locale

### DIFF
--- a/app/controllers/api/scratch/projects_controller.rb
+++ b/app/controllers/api/scratch/projects_controller.rb
@@ -105,7 +105,12 @@ module Api
       end
 
       def load_project
-        @project = Project.find_by!(identifier: params.expect(:id), project_type: Project::Types::CODE_EDITOR_SCRATCH)
+        @project = ProjectLoader.new(params[:id], project_locale).load
+        raise ActiveRecord::RecordNotFound unless @project&.scratch_project?
+      end
+
+      def project_locale
+        request.headers['X-Project-Locale']
       end
     end
   end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-Bullet.add_safelist type: :unused_eager_loading, class_name: 'Project', association: :images_attachments if Rails.env.development? || Rails.env.test?
+if Rails.env.development? || Rails.env.test?
+  Bullet.add_safelist type: :unused_eager_loading, class_name: 'Project', association: :images_attachments
+  Bullet.add_safelist type: :n_plus_one_query, class_name: 'Project', association: :scratch_component
+end

--- a/spec/features/scratch/showing_a_scratch_project_spec.rb
+++ b/spec/features/scratch/showing_a_scratch_project_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe 'Showing a Scratch project', type: :request do
     expect(response.parsed_body.fetch('targets').pluck('name')).to eq(%w[Stage Sprite1 Sprite2])
   end
 
+  it 'prefers the project matching the project locale header' do
+    identifier = 'locale-specific-project'
+    english_project = create(:project, project_type: Project::Types::CODE_EDITOR_SCRATCH, identifier:, locale: 'en', user_id: nil)
+    create(:scratch_component, project: english_project, content: { targets: [{ name: 'English Stage', isStage: true }] })
+    french_project = create(:project, project_type: Project::Types::CODE_EDITOR_SCRATCH, identifier:, locale: 'fr-FR', user_id: nil)
+    create(:scratch_component, project: french_project, content: { targets: [{ name: 'French Stage', isStage: true }] })
+
+    get "/api/scratch/projects/#{identifier}", headers: { 'X-Project-Locale' => 'fr-FR' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.fetch('targets').pluck('name')).to eq(['French Stage'])
+  end
+
   it 'returns a 404 if project does not exist' do
     authenticated_in_hydra_as(teacher)
     get '/api/scratch/projects/non_existent_project', headers: headers


### PR DESCRIPTION
## Status

- Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1800
- Corresponding UI PR https://github.com/RaspberryPiFoundation/editor-ui/pull/1633

## Points for consideration:

In most places in editor we only have one locale per project. One place this isn't true is the new Preview page for Experience CS scratch projects- there are multiple projects that share one identifier with translated content.

Use the existing ProjectLoader to load the project in the correct locale. See commits for more
